### PR TITLE
docs: recommend a decimal-handling library

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ The general workflow is the following:
     }
     ```
 
+## Tips
+When working with NEAR smart contracts you will need to handle many large numbers (the minimum allowed amount of NEAR is 1/10<super>24</super> of one NEAR token – put another way, one NEAR token is 1,000,000,000,000,000,000,000,000 yoctoNEAR). To simplify handling such large numbers, we recommend [decimate](https://docs.rs/decimate/).
+
 ## Building Rust Contract
 We can build the contract using rustc:
 ```bash

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ The general workflow is the following:
     ```
 
 ## Tips
-When working with NEAR smart contracts you will need to handle many large numbers (the minimum allowed amount of NEAR is 1/10<super>24</super> of one NEAR token – put another way, one NEAR token is 1,000,000,000,000,000,000,000,000 yoctoNEAR). To simplify handling such large numbers, we recommend [decimate](https://docs.rs/decimate/).
+When working with NEAR smart contracts you will need to handle very large numbers or numbers with many decimal places (the minimum allowed amount of NEAR is 1/10<super>24</super> of one NEAR token – put another way, one NEAR token is 1,000,000,000,000,000,000,000,000 yoctoNEAR). You should not use floats for such decimal places! To simplify handling both such large numbers and many decimal places, we recommend [decimate](https://docs.rs/decimate/).
 
 ## Building Rust Contract
 We can build the contract using rustc:


### PR DESCRIPTION
[On StackOverflow], @robert-zaremba asked if the NEAR team recommends a specific library for handling decimals. This question was closed because it does not meet StackOverflow's guidelines, given the imprecise nature of recommendations. I thought this might make a good addition to `near_sdk` docs. Robert prefers `decimate`, so that's what I've recommended here.

* Is there a better place for this information to live in the `near_sdk` docs?
* Do more accomplished NEAR Rustaceans recommend a different way to handle large numbers?

  [On StackOverflow]: https://stackoverflow.com/questions/62990352/whats-the-recommended-library-for-handling-decimals-in-near-smart-contracts