### PR TITLE
Update contract builder run to use HOST_DIR

### DIFF
--- a/contact-builder/run.sh
+++ b/contact-builder/run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 docker run \
-     --mount type=bind,source=`pwd`/..,target=/host \
+     --mount type=bind,source=$HOST_DIR,target=/host \
      --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
      -i -t contract-builder \
      /bin/bash


### PR DESCRIPTION
Use $HOST_DIR to be able to use it for other projects. E.g. core-contracts