### PR TITLE
Fix `syn` crate pin using `=1.0.57` instead of `<=1.0.57`

### DIFF
--- a/near-sdk-core/Cargo.toml
+++ b/near-sdk-core/Cargo.toml
@@ -13,6 +13,6 @@ Core part of the library for writing NEAR smart contracts.
 
 [dependencies]
 proc-macro2 = "1.0"
-syn = {version = "<=1.0.57", features = ["full", "fold", "extra-traits", "visit"] }
+syn = {version = "=1.0.57", features = ["full", "fold", "extra-traits", "visit"] }
 quote = "1.0"
 Inflector = { version = "0.11.4", default-features = false, features = [] }

--- a/near-sdk-macros/Cargo.toml
+++ b/near-sdk-macros/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro = true
 [dependencies]
 near-sdk-core = { path = "../near-sdk-core", version = "2.0.1"}
 proc-macro2 = "1.0"
-syn = {version = "<=1.0.57", features = ["full", "fold", "visit"] }
+syn = {version = "=1.0.57", features = ["full", "fold", "visit"] }
 quote = "1.0"
 
 


### PR DESCRIPTION
Seems like `<=` doesn't actually restrict `borsh` from depending on the `syn = "1.0.60"`
Switching to `=1.0.57`

Verified that is fixes the issue.