### PR TITLE
TreeMap Bug with custom Ord

### DIFF
--- a/near-sdk/src/collections/tree_map.rs
+++ b/near-sdk/src/collections/tree_map.rs
@@ -1354,16 +1354,9 @@ mod tests {
         pub views: u64,
     }
 
-    const MIN_VIEWS_FOR_RATIO: u64 = 3;
-
     impl Ord for Rating {
         fn cmp(&self, other: &Self) -> Ordering {
-            if self.views >= MIN_VIEWS_FOR_RATIO && other.views >= MIN_VIEWS_FOR_RATIO {
-                (self.wins as u128 * other.views as u128)
-                    .cmp(&(self.views as u128 * other.wins as u128))
-            } else {
-                self.wins.cmp(&other.wins)
-            }
+            self.wins.cmp(&other.wins)
         }
     }
 
@@ -1387,7 +1380,6 @@ mod tests {
         for &i in &ins {
             map.remove(&(Rating { wins: 0, views: 0 }, i));
             map.insert(&(Rating { wins: 1, views: 1 }, i), &());
-            println!("{}", map.len());
         }
         map.remove(&(Rating { wins: 1, views: 1 }, ins_ag));
         map.insert(&(Rating { wins: 1, views: 2 }, ins_ag), &());

--- a/near-sdk/src/collections/tree_map.rs
+++ b/near-sdk/src/collections/tree_map.rs
@@ -1349,18 +1349,18 @@ mod tests {
     }
 
     #[derive(Default, PartialEq, Eq, Copy, Clone, BorshSerialize, BorshDeserialize)]
-    pub struct Rating {
-        pub wins: u64,
-        pub views: u64,
+    pub struct Pair {
+        pub a: u64,
+        pub b: u64,
     }
 
-    impl Ord for Rating {
+    impl Ord for Pair {
         fn cmp(&self, other: &Self) -> Ordering {
-            self.wins.cmp(&other.wins)
+            self.a.cmp(&other.a)
         }
     }
 
-    impl PartialOrd for Rating {
+    impl PartialOrd for Pair {
         fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
             Some(self.cmp(other))
         }
@@ -1370,23 +1370,21 @@ mod tests {
     fn test_regression_1() {
         test_env::setup();
 
-        let ins: Vec<u32> = vec![
-            24518600, 22704334, 28465247, 29660010, 23675009, 30232905, 35515346, 29685074,
-            23928192, 27165407, 23915501,
-        ];
-        let ins_ag = 35515346u32;
+        // Pair compares only by `a`, ignores `b`.
+        let mut map: TreeMap<(Pair, u32), ()> = TreeMap::new(next_trie_id());
+        map.insert(&(Pair { a: 1, b: 1 }, 1), &());
+        map.insert(&(Pair { a: 1, b: 1 }, 2), &());
 
-        let mut map: TreeMap<(Rating, u32), ()> = TreeMap::new(next_trie_id());
-        for &i in &ins {
-            map.remove(&(Rating { wins: 0, views: 0 }, i));
-            map.insert(&(Rating { wins: 1, views: 1 }, i), &());
-        }
-        map.remove(&(Rating { wins: 1, views: 1 }, ins_ag));
-        map.insert(&(Rating { wins: 1, views: 2 }, ins_ag), &());
+        map.remove(&(Pair { a: 1, b: 1 }, 2));
+        map.insert(&(Pair { a: 1, b: 2 }, 2), &());
 
-        assert_eq!(map.len(), ins.len() as u64);
+        assert_eq!(map.len(), 2);
+        let a: Vec<_> = map.iter().collect();
+        // Fails here
+        assert_eq!(a.len(), 2, "Forward iter len is not 2");
         let a: Vec<_> = map.iter_rev().collect();
-        assert_eq!(a.len(), ins.len());
+        // Fails here as well
+        assert_eq!(a.len(), 2, "Reverse iter len is not 2");
 
         map.clear();
     }

--- a/near-sdk/src/collections/tree_map.rs
+++ b/near-sdk/src/collections/tree_map.rs
@@ -1348,10 +1348,16 @@ mod tests {
         }
     }
 
-    #[derive(Default, PartialEq, Eq, Copy, Clone, BorshSerialize, BorshDeserialize)]
+    #[derive(Default, Eq, Copy, Clone, BorshSerialize, BorshDeserialize)]
     pub struct Pair {
         pub a: u64,
         pub b: u64,
+    }
+
+    impl PartialEq for Pair {
+        fn eq(&self, other: &Self) -> bool {
+            self.cmp(other) == Ordering::Equal
+        }
     }
 
     impl Ord for Pair {
@@ -1367,7 +1373,7 @@ mod tests {
     }
 
     #[test]
-    fn test_regression_1() {
+    fn test_regression_1_custom_ord() {
         test_env::setup();
 
         // Pair compares only by `a`, ignores `b`.


### PR DESCRIPTION
Triggers #299 

It looks like the issue is with the custom `Ord` operator that panics on reinsert of an Equal element.

NOTE: Maybe it's an issue with my implementation, because PartialEq doesn't match Ord