### PR TITLE
feat: add contract caching in simulation testing

### DIFF
--- a/examples/fungible-token/Cargo.toml
+++ b/examples/fungible-token/Cargo.toml
@@ -27,3 +27,7 @@ members = [
   "ft",
   "test-contract-defi",
 ]
+
+[[example]]
+name = "heavy"
+

--- a/examples/fungible-token/examples/heavy.rs
+++ b/examples/fungible-token/examples/heavy.rs
@@ -1,0 +1,131 @@
+use near_sdk::{env, AccountId};
+use near_sdk_sim::{call, deploy, init_simulator, to_yocto, ContractAccount, UserAccount};
+
+use defi::*;
+/// Import the generated proxy contract
+use fungible_token::ContractContract as FtContract;
+
+use std::convert::TryInto;
+
+near_sdk_sim::lazy_static_include::lazy_static_include_bytes! {
+  TOKEN_WASM_BYTES => "res/fungible_token.wasm",
+  DEFI_WASM_BYTES => "res/defi.wasm",
+}
+
+const _REFERENCE: &str = "https://github.com/near/near-sdk-rs/tree/master/examples/fungible-token";
+
+const FT_ID: &str = "ft";
+const DEFI_ID: &str = "defi";
+
+fn init(
+    initial_balance: u128,
+) -> (
+    UserAccount,
+    ContractAccount<FtContract>,
+    ContractAccount<DeFiContract>,
+    UserAccount,
+) {
+    let root = init_simulator(None);
+    // uses default values for deposit and gas
+    let ft = deploy!(
+        // Contract Proxy
+        contract: FtContract,
+        // Contract account id
+        contract_id: FT_ID,
+        // Bytes of contract
+        bytes: &TOKEN_WASM_BYTES,
+        // User deploying the contract,
+        signer_account: root,
+        // init method
+        init_method: 
+          new_default_meta(
+            root.account_id().try_into().unwrap(),
+            initial_balance.into()
+        )
+    );
+    let alice = root.create_user("alice".to_string(), to_yocto("100"));
+    register_user(&ft, &alice);
+
+    let defi = deploy!(
+        contract: DeFiContract,
+        contract_id: DEFI_ID,
+        bytes: &DEFI_WASM_BYTES,
+        signer_account: root,
+        init_method: new(
+            FT_ID.try_into().unwrap()
+        )
+    );
+
+    (root, ft, defi, alice)
+}
+
+// For given `contract` which uses the Account Storage standard,
+// register the given `user`
+fn register_user(contract: &ContractAccount<FtContract>, user: &UserAccount) {
+    call!(
+        user,
+        contract.storage_deposit(Some(user.account_id().try_into().unwrap()), None),
+        deposit = env::storage_byte_cost() * 125
+    )
+    .assert_success();
+}
+
+const TRANSFER_DEPOSIT: u128 = 1u128;
+
+fn transfer(
+    from: &UserAccount,
+    to: AccountId,
+    amount: u128,
+    contract: &ContractAccount<FtContract>,
+) {
+    call!(
+        from,
+        contract.ft_transfer(to.try_into().unwrap(), amount.into(), None),
+        deposit = TRANSFER_DEPOSIT
+    )
+    .assert_success()
+}
+
+fn main() {
+    let iterations: u64 = if std::env::args().len() >= 2 {
+        (&std::env::args().collect::<Vec<String>>()[1])
+            .parse()
+            .unwrap()
+    } else {
+        10
+    };
+    let transfer_amount = to_yocto("1");
+    let initial_balance = to_yocto("10000000000");
+    let (master_account, contract, _defi, alice) = init(initial_balance);
+    transfer(
+        &master_account,
+        alice.account_id(),
+        transfer_amount,
+        &contract,
+    );
+    let now = std::time::Instant::now();
+    for i in 0..iterations {
+        if i % 2 == 0 {
+            transfer(
+                &master_account,
+                alice.account_id(),
+                transfer_amount,
+                &contract,
+            );
+        } else {
+            transfer(
+                &alice,
+                master_account.account_id(),
+                transfer_amount,
+                &contract,
+            );
+        }
+    }
+    let elapsed = now.elapsed().as_millis();
+    println!(
+        "{} calls to transfer in {} ms, {} calls / second",
+        iterations,
+        elapsed,
+        (iterations * 1000) as u128 / elapsed
+    );
+}

--- a/near-sdk-sim/Cargo.toml
+++ b/near-sdk-sim/Cargo.toml
@@ -16,6 +16,8 @@ lazy-static-include = "3"
 near-pool = { git = "https://github.com/near/nearcore.git", rev = "1e88c6c699e3a2c49c6cbd09d284f69885982e80" }
 near-store = { git = "https://github.com/near/nearcore.git", rev = "1e88c6c699e3a2c49c6cbd09d284f69885982e80" }
 node-runtime = { git = "https://github.com/near/nearcore.git", rev = "1e88c6c699e3a2c49c6cbd09d284f69885982e80", features=["costs_counting"] }
+
+# Temporary workaround see https://github.com/bitvecto-rs/bitvec/issues/105
 funty = "=1.1.0"
 
 [dev-dependencies]
@@ -27,3 +29,4 @@ fungible-token = { path="../examples/fungible-token/ft" }
 default = []
 no_cache = ["near-store/no_cache", "node-runtime/no_cache"]
 no_sim = []
+no_contract_cache = []

--- a/near-sdk-sim/src/cache.rs
+++ b/near-sdk-sim/src/cache.rs
@@ -1,0 +1,108 @@
+use crate::types::CompiledContractCache;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+use std::sync::Arc;
+
+/// This provides a disc cache for compiled contracts.
+/// The cached contracts are located `CARGO_MANIFEST_DIR/target/contract_cache`.
+#[derive(Clone)]
+pub struct ContractCache {
+    data: Rc<RefCell<HashMap<Vec<u8>, Vec<u8>>>>,
+}
+
+pub(crate) fn key_to_b58(key: &[u8]) -> String {
+    near_sdk::bs58::encode(key).into_string()
+}
+
+impl ContractCache {
+    #[allow(dead_code)]
+    pub fn new() -> Self {
+        Self {
+            data: Rc::new(RefCell::new(HashMap::new())),
+        }
+    }
+
+    fn path() -> PathBuf {
+        let s = std::env::var("CARGO_MANIFEST_DIR").unwrap().to_string();
+        Path::new(&s).join("target").join("contract_cache")
+    }
+
+    fn open_file(&self, key: &[u8]) -> std::io::Result<File> {
+        let path = self.get_path(key);
+        // Ensure that the parent path exists
+        let prefix = path.parent().unwrap();
+        std::fs::create_dir_all(prefix).unwrap();
+        // Ensure we can read, write, and create file if it doesn't exist
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(path)
+    }
+
+    fn get_path(&self, key: &[u8]) -> PathBuf {
+        ContractCache::path().join(key_to_b58(key))
+    }
+
+    fn file_exists(&self, key: &[u8]) -> bool {
+        self.get_path(key).exists()
+    }
+
+    pub fn insert(&self, key: &[u8], value: &[u8]) -> Option<Vec<u8>> {
+        (*self.data)
+            .borrow_mut()
+            .insert((*key).to_owned(), (*value).to_owned())
+    }
+
+    pub fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+        match (*self.data).borrow_mut().get(key) {
+            Some(v) => Some(v.clone()),
+            _ => None,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn to_arc(&self) -> Arc<ContractCache> {
+        Arc::new(self.clone())
+    }
+}
+
+impl CompiledContractCache for ContractCache {
+    fn put(&self, key: &[u8], value: &[u8]) -> Result<(), std::io::Error> {
+        self.insert(key, value);
+        let mut file = self.open_file(key).expect("File failed to open");
+        let metadata = file.metadata()?;
+        if metadata.len() != value.len() as u64 {
+            file.write_all(value)?;
+        }
+        Ok(())
+    }
+
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, std::io::Error> {
+        if (*self.data).borrow().contains_key(key) {
+            return Ok(self.get(key));
+        } else if self.file_exists(key) {
+            let mut file = self.open_file(key)?;
+            let mut contents = vec![];
+            file.read_to_end(&mut contents)?;
+            self.insert(key, &contents);
+            return Ok(Some(contents));
+        }
+        Ok(None)
+    }
+}
+
+pub fn create_cache() -> ContractCache {
+    ContractCache::new()
+}
+
+pub fn cache_to_arc(cache: &ContractCache) -> Arc<ContractCache> {
+    cache.to_arc()
+}
+
+unsafe impl Send for ContractCache {}
+unsafe impl Sync for ContractCache {}

--- a/near-sdk-sim/src/lib.rs
+++ b/near-sdk-sim/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod outcome;
 #[doc(inline)]
 pub use outcome::*;
+mod cache;
 pub mod runtime;
 pub mod units;
 pub mod user;

--- a/near-sdk-sim/src/user.rs
+++ b/near-sdk-sim/src/user.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use near_crypto::{InMemorySigner, KeyType, PublicKey, Signer};
 
-use near_sdk::utils::PendingContractTx;
+use near_sdk::PendingContractTx;
 
 use crate::runtime::init_runtime;
 pub use crate::to_yocto;


### PR DESCRIPTION
After Contracts compile they are cached at `target/contract_cache/<Hash>`.

Adds an example for a sample program that does a transfer back and forth in order to test the performance.