### PR TITLE
examples/ft: small readme improvement

### DIFF
--- a/examples/fungible-token/README.md
+++ b/examples/fungible-token/README.md
@@ -1,6 +1,11 @@
-# Fungible token
+Fungible Token (FT)
+===================
 
-Example implementation of a Fungible Token Standard ([NEP-141](https://github.com/near/NEPs/issues/141)).
+Example implementation of a [Fungible Token] contract which uses [near-contract-standards] and [simulation] tests.
+
+  [Fungible Token]: https://nomicon.io/Standards/Tokens/FungibleTokenCore.html
+  [near-contract-standards]: https://github.com/near/near-sdk-rs/tree/master/near-contract-standards
+  [simulation]: https://github.com/near/near-sdk-rs/tree/master/near-sdk-sim
 
 NOTES:
  - The maximum balance value is limited by U128 (2**128 - 1).


### PR DESCRIPTION
I made this change in https://github.com/near-examples/FT and figured I'd backport it here since it's useful for both.