### PR TITLE
refactor(examples/ft): no need for `extern crate`

### DIFF
--- a/examples/fungible-token/tests/general.rs
+++ b/examples/fungible-token/tests/general.rs
@@ -1,6 +1,3 @@
-/// Bring contract crate into namespace
-extern crate fungible_token;
-
 use std::convert::TryInto;
 
 use defi::*;


### PR DESCRIPTION
The project structure makes this superfluous