### PR TITLE
contract standards: add ext_fungible_token

### DIFF
--- a/near-contract-standards/src/fungible_token/core_impl.rs
+++ b/near-contract-standards/src/fungible_token/core_impl.rs
@@ -33,6 +33,25 @@ pub trait FungibleTokenReceiver {
     ) -> PromiseOrValue<U128>;
 }
 
+#[ext_contract(ext_fungible_token)]
+pub trait FungibleTokenContract {
+    fn ft_transfer(&mut self, receiver_id: AccountId, amount: U128, memo: Option<String>);
+
+    fn ft_transfer_call(
+        &mut self,
+        receiver_id: ValidAccountId,
+        amount: U128,
+        memo: Option<String>,
+        msg: String,
+    ) -> PromiseOrValue<U128>;
+
+    /// Returns the total supply of the token in a decimal string representation.
+    fn ft_total_supply(&self) -> U128;
+
+    /// Returns the balance of the account. If the account doesn't exist must returns `"0"`.
+    fn ft_balance_of(&self, account_id: ValidAccountId) -> U128;
+}
+
 /// Implementation of a FungibleToken standard.
 /// Allows to include NEP-141 compatible token to any contract.
 /// There are next traits that any contract may implement:

--- a/near-contract-standards/src/fungible_token/core_impl.rs
+++ b/near-contract-standards/src/fungible_token/core_impl.rs
@@ -39,7 +39,7 @@ pub trait FungibleTokenContract {
 
     fn ft_transfer_call(
         &mut self,
-        receiver_id: ValidAccountId,
+        receiver_id: AccountId,
         amount: U128,
         memo: Option<String>,
         msg: String,
@@ -49,7 +49,7 @@ pub trait FungibleTokenContract {
     fn ft_total_supply(&self) -> U128;
 
     /// Returns the balance of the account. If the account doesn't exist must returns `"0"`.
-    fn ft_balance_of(&self, account_id: ValidAccountId) -> U128;
+    fn ft_balance_of(&self, account_id: AccountId) -> U128;
 }
 
 /// Implementation of a FungibleToken standard.


### PR DESCRIPTION
When implementing contracts which operate with fungible tokens, it's useful to use `#[ext_contract(ext_fungible_token)]` macro.

This PR adds a canonical implementation of that wrapper to near-contract-standards.