### PR TITLE
fix(contract-standards): allow ft_transfer_call deposits

### DIFF
--- a/near-contract-standards/src/fungible_token/core_impl.rs
+++ b/near-contract-standards/src/fungible_token/core_impl.rs
@@ -4,8 +4,8 @@ use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::collections::LookupMap;
 use near_sdk::json_types::{ValidAccountId, U128};
 use near_sdk::{
-    assert_one_yocto, env, ext_contract, log, AccountId, Balance, Gas, PromiseOrValue,
-    PromiseResult, StorageUsage,
+    assert_at_least_one_yocto, assert_one_yocto, env, ext_contract, log, AccountId, Balance, Gas,
+    PromiseOrValue, PromiseResult, StorageUsage,
 };
 
 const GAS_FOR_RESOLVE_TRANSFER: Gas = 5_000_000_000_000;
@@ -158,7 +158,7 @@ impl FungibleTokenCore for FungibleToken {
         memo: Option<String>,
         msg: String,
     ) -> PromiseOrValue<U128> {
-        assert_one_yocto();
+        assert_at_least_one_yocto();
         let sender_id = env::predecessor_account_id();
         let amount: Balance = amount.into();
         self.internal_transfer(&sender_id, receiver_id.as_ref(), amount, memo);
@@ -168,7 +168,7 @@ impl FungibleTokenCore for FungibleToken {
             amount.into(),
             msg,
             receiver_id.as_ref(),
-            NO_DEPOSIT,
+            env::attached_deposit(),
             env::prepaid_gas() - GAS_FOR_FT_TRANSFER_CALL,
         )
         .then(ext_self::ft_resolve_transfer(

--- a/near-sdk/src/utils/mod.rs
+++ b/near-sdk/src/utils/mod.rs
@@ -20,6 +20,11 @@ pub fn assert_one_yocto() {
     assert_eq!(env::attached_deposit(), 1, "Requires attached deposit of exactly 1 yoctoNEAR")
 }
 
+/// Assert that at least 1 yoctoNEAR was attached.
+pub fn assert_at_least_one_yocto() {
+    assert!(env::attached_deposit() >= 1, "Requires attached deposit of at least 1 yoctoNEAR")
+}
+
 /// Returns true if promise was successful.
 /// Fails if called outside a callback that received 1 promise result.
 pub fn is_promise_success() -> bool {


### PR DESCRIPTION
Related to discussion at https://gov.near.org/t/discuss-improving-contract-development-chain-improvements/940/6

If a receiver contract wants to, say, register a user for a different FT (in the case of AMM swaps), it will need some attached deposit.

## TODO

- [ ] Update [spec](https://nomicon.io/Standards/Tokens/FungibleTokenCore.html) to match