### PR TITLE
fix env::block_timestamp documentation

### DIFF
--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -182,7 +182,7 @@ pub fn block_index() -> BlockHeight {
     }
 }
 
-/// Current block timestamp, i.e, number of non-leap-nanoseconds since January 1, 1970 0:00:00 UTC.
+/// Current block timestamp, i.e, number of non-leap-seconds since January 1, 1970 0:00:00 UTC.
 pub fn block_timestamp() -> u64 {
     unsafe {
         BLOCKCHAIN_INTERFACE.with(|b| {


### PR DESCRIPTION
The current `env::block_timestamp` documentation says that the return value is denominated in nanoseconds. This is wrong. The value is denominated in seconds (did empirical tests).