### PR TITLE
feat(json_types): implement FromStr for ValidAccountId

### DIFF
--- a/near-sdk/src/json_types/account.rs
+++ b/near-sdk/src/json_types/account.rs
@@ -6,9 +6,6 @@ use std::fmt;
 use crate::env::is_valid_account_id;
 use crate::AccountId;
 
-// TODO: this should probably be a specific error type instead of a string.
-const INVALID_ACCOUNT_ID_MSG: &str = "The account ID is invalid";
-
 /// Helper class to validate account ID during serialization and deserializiation.
 /// This type wraps an [`AccountId`].
 ///
@@ -61,11 +58,11 @@ impl TryFrom<&str> for ValidAccountId {
     }
 }
 
-fn validate_account_id(id: &str) -> Result<(), Box<dyn std::error::Error>> {
+fn validate_account_id(id: &str) -> Result<(), ParseAccountIdError> {
     if is_valid_account_id(id.as_bytes()) {
         Ok(())
     } else {
-        Err(INVALID_ACCOUNT_ID_MSG.into())
+        Err(ParseAccountIdError::InvalidAccountId)
     }
 }
 
@@ -92,6 +89,22 @@ impl From<ValidAccountId> for AccountId {
         value.0
     }
 }
+
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum ParseAccountIdError {
+    InvalidAccountId,
+}
+
+impl std::fmt::Display for ParseAccountIdError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidAccountId => write!(f, "The account ID is invalid"),
+        }
+    }
+}
+
+impl std::error::Error for ParseAccountIdError {}
 
 #[cfg(test)]
 mod tests {

--- a/near-sdk/src/json_types/account.rs
+++ b/near-sdk/src/json_types/account.rs
@@ -2,7 +2,6 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{de, Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::fmt;
-use std::str::FromStr;
 
 use crate::env::is_valid_account_id;
 use crate::AccountId;
@@ -58,7 +57,7 @@ impl TryFrom<&str> for ValidAccountId {
     type Error = Box<dyn std::error::Error>;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        Self::from_str(value)
+        value.parse()
     }
 }
 
@@ -79,7 +78,7 @@ impl TryFrom<String> for ValidAccountId {
     }
 }
 
-impl FromStr for ValidAccountId {
+impl std::str::FromStr for ValidAccountId {
     type Err = Box<dyn std::error::Error>;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {

--- a/near-sdk/src/json_types/account.rs
+++ b/near-sdk/src/json_types/account.rs
@@ -1,7 +1,8 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{de, Deserialize, Serialize};
+use std::convert::TryFrom;
 use std::fmt;
-use std::{convert::TryFrom, str::FromStr};
+use std::str::FromStr;
 
 use crate::env::is_valid_account_id;
 use crate::AccountId;
@@ -73,7 +74,7 @@ impl TryFrom<String> for ValidAccountId {
     type Error = Box<dyn std::error::Error>;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        validate_account_id(value.as_ref())?;
+        validate_account_id(value.as_str())?;
         Ok(Self(value))
     }
 }

--- a/near-sdk/src/json_types/account.rs
+++ b/near-sdk/src/json_types/account.rs
@@ -1,5 +1,5 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::Serialize;
+use serde::{de, Deserialize, Serialize};
 use std::{borrow::Cow, fmt};
 use std::{convert::TryFrom, str::FromStr};
 
@@ -43,15 +43,13 @@ impl AsRef<AccountId> for ValidAccountId {
     }
 }
 
-impl<'de> serde::Deserialize<'de> for ValidAccountId {
-    fn deserialize<D>(deserializer: D) -> Result<Self, <D as serde::Deserializer<'de>>::Error>
+impl<'de> Deserialize<'de> for ValidAccountId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, <D as de::Deserializer<'de>>::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
-        let s: Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        s.as_ref()
-            .parse()
-            .map_err(|err: Box<dyn std::error::Error>| serde::de::Error::custom(err.to_string()))
+        let s: Cow<'de, str> = Deserialize::deserialize(deserializer)?;
+        Self::from_str(s.as_ref()).map_err(|err| de::Error::custom(err.to_string()))
     }
 }
 

--- a/near-sdk/src/json_types/account.rs
+++ b/near-sdk/src/json_types/account.rs
@@ -88,7 +88,6 @@ impl From<ValidAccountId> for AccountId {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::convert::TryInto;
 
     #[test]
     fn test_deser() {
@@ -101,7 +100,7 @@ mod tests {
 
     #[test]
     fn test_ser() {
-        let key: ValidAccountId = "alice.near".try_into().unwrap();
+        let key: ValidAccountId = "alice.near".parse().unwrap();
         let actual: String = serde_json::to_string(&key).unwrap();
         assert_eq!(actual, "\"alice.near\"");
     }


### PR DESCRIPTION
Just saw https://stackoverflow.com/questions/67332443/how-to-convert-accountid-into-validaccountid-in-near-protocol-contracts

and this makes it easier to convert as it doesn't require importing the `TryFrom` or `TryInto` trait

Also changes the logic a bit to avoid allocating a `String` from `&str` before it's checked as valid.