### PR TITLE
fix(collections): range panic on lo/hi excluded and flipped

### DIFF
--- a/near-sdk/src/collections/legacy_tree_map.rs
+++ b/near-sdk/src/collections/legacy_tree_map.rs
@@ -175,7 +175,7 @@ where
             (Bound::Included(a), Bound::Included(b)) if a > b => panic!("Invalid range."),
             (Bound::Excluded(a), Bound::Included(b)) if a > b => panic!("Invalid range."),
             (Bound::Included(a), Bound::Excluded(b)) if a > b => panic!("Invalid range."),
-            (Bound::Excluded(a), Bound::Excluded(b)) if a == b => panic!("Invalid range."),
+            (Bound::Excluded(a), Bound::Excluded(b)) if a >= b => panic!("Invalid range."),
             (lo, hi) => (lo, hi),
         };
 

--- a/near-sdk/src/collections/legacy_tree_map.rs
+++ b/near-sdk/src/collections/legacy_tree_map.rs
@@ -1579,6 +1579,14 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "Invalid range.")]
+    fn test_range_panics_non_overlap_excl_excl() {
+        test_env::setup();
+        let map: LegacyTreeMap<u32, u32> = LegacyTreeMap::new(next_trie_id());
+        let _ = map.range((Bound::Excluded(2), Bound::Excluded(1)));
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid range.")]
     fn test_range_panics_non_overlap_incl_incl() {
         test_env::setup();
         let map: LegacyTreeMap<u32, u32> = LegacyTreeMap::new(next_trie_id());

--- a/near-sdk/src/collections/tree_map.rs
+++ b/near-sdk/src/collections/tree_map.rs
@@ -174,7 +174,7 @@ where
             (Bound::Included(a), Bound::Included(b)) if a > b => panic!("Invalid range."),
             (Bound::Excluded(a), Bound::Included(b)) if a > b => panic!("Invalid range."),
             (Bound::Included(a), Bound::Excluded(b)) if a > b => panic!("Invalid range."),
-            (Bound::Excluded(a), Bound::Excluded(b)) if a == b => panic!("Invalid range."),
+            (Bound::Excluded(a), Bound::Excluded(b)) if a >= b => panic!("Invalid range."),
             (lo, hi) => (lo, hi),
         };
 

--- a/near-sdk/src/collections/tree_map.rs
+++ b/near-sdk/src/collections/tree_map.rs
@@ -1581,6 +1581,14 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "Invalid range.")]
+    fn test_range_panics_non_overlap_excl_excl() {
+        test_env::setup();
+        let map: TreeMap<u32, u32> = TreeMap::new(next_trie_id());
+        let _ = map.range((Bound::Excluded(2), Bound::Excluded(1)));
+    }
+
+    #[test]
     fn test_iter_rev_from_empty() {
         test_env::setup();
         let map: TreeMap<u32, u32> = TreeMap::new(next_trie_id());


### PR DESCRIPTION
In the case of lo > hi and both are excluded, this does not panic as the function comment suggests.

If this is intended, let me know and I can update the docs or add docs on the `Cursor` to indicate it will panic in this case (if it does).