### PR TITLE
refactor(collections): remove unnecessary explicit lifetimes from unordered types

### DIFF
--- a/near-sdk/src/collections/unordered_map.rs
+++ b/near-sdk/src/collections/unordered_map.rs
@@ -207,17 +207,17 @@ where
     }
 
     /// An iterator visiting all keys. The iterator element type is `K`.
-    pub fn keys<'a>(&'a self) -> impl Iterator<Item = K> + 'a {
+    pub fn keys(&self) -> impl Iterator<Item = K> + '_ {
         self.keys.iter()
     }
 
     /// An iterator visiting all values. The iterator element type is `V`.
-    pub fn values<'a>(&'a self) -> impl Iterator<Item = V> + 'a {
+    pub fn values(&self) -> impl Iterator<Item = V> + '_ {
         self.values.iter()
     }
 
     /// Iterate over deserialized keys and values.
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = (K, V)> + 'a {
+    pub fn iter(&self) -> impl Iterator<Item = (K, V)> + '_ {
         self.keys.iter().zip(self.values.iter())
     }
 

--- a/near-sdk/src/collections/unordered_set.rs
+++ b/near-sdk/src/collections/unordered_set.rs
@@ -153,7 +153,7 @@ where
     }
 
     /// Iterate over deserialized elements.
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = T> + 'a {
+    pub fn iter(&self) -> impl Iterator<Item = T> + '_ {
         self.elements.iter()
     }
 


### PR DESCRIPTION
This just makes this code more readable