### PR TITLE
feat: implement FromStr for Base58CryptoHash and cleanup

### DIFF
--- a/near-sdk/src/json_types/hash.rs
+++ b/near-sdk/src/json_types/hash.rs
@@ -1,8 +1,9 @@
 use crate::CryptoHash;
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{de, Deserialize};
+use std::borrow::Cow;
+use std::convert::TryFrom;
 use std::str::FromStr;
-use std::{borrow::Cow, convert::TryFrom};
 
 #[derive(
     Debug, Copy, Clone, PartialEq, PartialOrd, Ord, Eq, BorshDeserialize, BorshSerialize, Default,


### PR DESCRIPTION
a similar change to #391 and also cleanup for readability and deserialize type for potential performance increase (`Cow` can avoid an allocation depending on the underlying deserialize buffer).