### PR TITLE
feat(json_types): impl FromStr for public key json types and cleanup

### DIFF
--- a/near-sdk/src/json_types/public_key.rs
+++ b/near-sdk/src/json_types/public_key.rs
@@ -34,7 +34,7 @@ impl std::str::FromStr for CurveType {
 
 /// Public key in a binary format with base58 string serialization with human-readable curve.
 /// The key types currently supported are `secp256k1` and `ed25519`.
-/// 
+///
 /// Ed25519 public keys accepted are 32 bytes and secp256k1 keys are the uncompressed 64 format.
 ///
 /// # Example

--- a/near-sdk/src/json_types/public_key.rs
+++ b/near-sdk/src/json_types/public_key.rs
@@ -98,7 +98,7 @@ impl<'de> serde::Deserialize<'de> for Base58PublicKey {
         D: serde::Deserializer<'de>,
     {
         let s: Cow<'de, str> = Deserialize::deserialize(deserializer)?;
-        s.parse::<Base58PublicKey>().map_err(|err| serde::de::Error::custom(err))
+        s.parse::<Base58PublicKey>().map_err(serde::de::Error::custom)
     }
 }
 

--- a/near-sdk/src/json_types/public_key.rs
+++ b/near-sdk/src/json_types/public_key.rs
@@ -34,6 +34,8 @@ impl std::str::FromStr for CurveType {
 
 /// Public key in a binary format with base58 string serialization with human-readable curve.
 /// The key types currently supported are `secp256k1` and `ed25519`.
+/// 
+/// Ed25519 public keys accepted are 32 bytes and secp256k1 keys are the uncompressed 64 format.
 ///
 /// # Example
 /// ```


### PR DESCRIPTION
- Implements FromStr for `CurveType` and `Base58PublicKey`
- Switches deserialization intermediate type to `Cow`
- Document type (was unclear to me what exactly was supported)