### PR TITLE
feat: add compiled code size tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,5 +24,7 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - name: Test Format
         run: cargo fmt -- --check
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
       - name: Test
         run: cargo test --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,12 @@ members = [
 exclude = [
     "examples/cross-contract-high-level",
     "examples/fungible-token",
+    "examples/lockable-fungible-token",
     "examples/cross-contract-low-level",
     "examples/mission-control",
     "examples/status-message",
     "examples/status-message-collections",
+    "examples/test-contract",
 ]
 
 # Special triple # comment for ci.

--- a/near-sdk/tests/code_size.rs
+++ b/near-sdk/tests/code_size.rs
@@ -1,0 +1,37 @@
+/// Compiles contract to wasm with release configuration and returns the code size.
+fn check_example_size(example: &str) -> usize {
+    let status = std::process::Command::new("cargo")
+        .env("RUSTFLAGS", "-C link-arg=-s")
+        .args(&["build", "--release", "--target", "wasm32-unknown-unknown", "--manifest-path"])
+        .arg(format!("../examples/{}/Cargo.toml", example))
+        .status()
+        .unwrap();
+    if !status.success() {
+        panic!("building wasm example returned non-zero code {}", status);
+    }
+
+    let wasm = std::fs::read(format!(
+        "../examples/{}/target/wasm32-unknown-unknown/release/{}.wasm",
+        example,
+        example.replace("-", "_")
+    ))
+    .unwrap();
+
+    wasm.len()
+}
+
+#[test]
+fn lock_fungible_code_size_check() {
+    let size = check_example_size("lockable-fungible-token");
+
+    // Current contract size at the time of writing this test is 164_433, giving about ~10% buffer.
+    assert!(size < 180_000);
+}
+
+#[test]
+fn status_message_code_size_check() {
+    let size = check_example_size("status-message");
+
+    // Currently 140823.
+    assert!(size < 155_000);
+}


### PR DESCRIPTION
cc @matklad as he suggested adding these before making other changes/refactoring.

The tests compile to wasm using release and any other usual flags and check the output wasm binary size.

The test checks to make sure it's no larger than 10% of what it currently is, to accommodate for external/platform discrepancies. Still feels a bit janky to me to test like this personally, but seems like it might be a reasonable check to have.