### PR TITLE
chore: remove public visibility of b58 error variant

### DIFF
--- a/near-sdk/src/json_types/account.rs
+++ b/near-sdk/src/json_types/account.rs
@@ -103,7 +103,7 @@ enum ParseAccountIdErrorKind {
 impl std::fmt::Display for ParseAccountIdError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.kind {
-            ParseAccountIdErrorKind::InvalidAccountId => write!(f, "The account ID is invalid"),
+            ParseAccountIdErrorKind::InvalidAccountId => write!(f, "the account ID is invalid"),
         }
     }
 }

--- a/near-sdk/src/json_types/hash.rs
+++ b/near-sdk/src/json_types/hash.rs
@@ -93,9 +93,9 @@ impl std::fmt::Display for ParseCryptoHashError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.kind {
             ParseCryptoHashErrorKind::InvalidLength(l) => {
-                write!(f, "Invalid length of the crypto hash, expected 32 got {}", l)
+                write!(f, "invalid length of the crypto hash, expected 32 got {}", l)
             }
-            ParseCryptoHashErrorKind::Base58(e) => write!(f, "Base58 decoding error: {}", e),
+            ParseCryptoHashErrorKind::Base58(e) => write!(f, "base58 decoding error: {}", e),
         }
     }
 }

--- a/near-sdk/src/json_types/public_key.rs
+++ b/near-sdk/src/json_types/public_key.rs
@@ -170,10 +170,10 @@ impl std::fmt::Display for ParsePublicKeyError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.kind {
             ParsePublicKeyErrorKind::InvalidLength(l) => {
-                write!(f, "Invalid length of the public key, expected 32 got {}", l)
+                write!(f, "invalid length of the public key, expected 32 got {}", l)
             }
-            ParsePublicKeyErrorKind::Base58(e) => write!(f, "Base58 decoding error: {}", e),
-            ParsePublicKeyErrorKind::UnknownCurve => write!(f, "Unknown curve kind"),
+            ParsePublicKeyErrorKind::Base58(e) => write!(f, "base58 decoding error: {}", e),
+            ParsePublicKeyErrorKind::UnknownCurve => write!(f, "unknown curve kind"),
         }
     }
 }


### PR DESCRIPTION
As pointed out by @matklad [here](https://github.com/near/near-sdk-rs/pull/398#discussion_r630385963) it's probably best if we don't expose the error variants, to make it easier to make changes without being stuck to specific impls (in this case the base 58 error).

Probably best if this comes in before the next release, sorry for overlooking exposing this!