### PR TITLE
chore: remove release notes from README and add unreleased changes to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 
-## `3.1.0`
+## [unreleased]
+
+* Move type aliases and core types to near-sdk to avoid coupling. [PR 415](https://github.com/near/near-sdk-rs/pull/415).
+* Implements new `Lazy` type under the new `unstable` feature which is a lazily loaded storage value. [PR 409](https://github.com/near/near-sdk-rs/pull/409).
+* fix(promise): `PromiseOrValue` now correctly sets `should_return` flag correctly on serialization. [PR 407](https://github.com/near/near-sdk-rs/pull/407).
+* fix(tree_map): Correctly panic when range indices are exluded and `start > end`. [PR 392](https://github.com/near/near-sdk-rs/pull/392).
+* Implement `FromStr` for json types to allow calling `.parse()` to convert them.
+  * `ValidAccountId` [PR 391](https://github.com/near/near-sdk-rs/pull/391).
+  * `Base58CryptoHash` [PR 398](https://github.com/near/near-sdk-rs/pull/398).
+  * `Base58PublicKey` [PR 400](https://github.com/near/near-sdk-rs/pull/400).
+* expose `cur_block` and `genesis_config` from `RuntimeStandalone` to configure simulation tests. [PR 390](https://github.com/near/near-sdk-rs/pull/390).
+* fix(simulator): failing with long chains. [PR 385](https://github.com/near/near-sdk-rs/pull/385).
+* Make block time configurable to sim contract tests. [PR 378](https://github.com/near/near-sdk-rs/pull/378).
+
+## `3.1.0` [04-06-2021]
 
 * Updated dependencies for `near-sdk`
 * Introduce trait `IntoStorageKey` and updating all persistent collections to take it instead of `Vec<u8>`.
@@ -34,7 +48,7 @@ impl StatusMessage {
 }
 ```
 
-## `3.0.1`
+## `3.0.1` [03-25-2021]
 
 * Introduced `#[private]` method decorator, that verifies `predecessor_account_id() == current_account_id()`.
   NOTE: Usually, when a contract has to have a callback for a remote cross-contract call, this callback method should
@@ -58,11 +72,11 @@ impl StatusMessage {
 * **BREAKING** `#[init]` now checks that the state is not initialized. This is expected behavior. To ignore state check you can call `#[init(ignore_state)]`
 * NOTE: `3.0.0` is not published, due to tag conflicts on the `near-sdk-rs` repo.
 
-## `2.0.1`
+## `2.0.1` [01-13-2021]
 
 * Pinned version of `syn` crate to `=1.0.57`, since `1.0.58` introduced a breaking API change.
 
-## `2.0.0`
+## `2.0.0` [08-25-2020]
 
 ### Contract changes
 
@@ -79,7 +93,7 @@ impl StatusMessage {
   Previous `TreeMap` implementation was renamed to `LegacyTreeMap` and was deprecated.
   It should only be used if the contract was already deployed and state has to be compatible with the previous implementation.
 
-## `1.0.1`
+## `1.0.1` [08-22-2020]
 
 ### Other changes
 
@@ -89,7 +103,7 @@ impl StatusMessage {
 
 * Bumped dependency version of `near-vm-logic` and `near-runtime-fees` to `2.0.0` that changed `VMLogic` interface.
 
-## `1.0.0`
+## `1.0.0` [07-13-2020]
 
 ### Other changes
 
@@ -104,7 +118,7 @@ impl StatusMessage {
 
 * Use re-exported crate dependencies through `near_sdk` crate.
 
-## `0.11.0`
+## `0.11.0` [06-08-2020]
 
 ### API breaking changes
 

--- a/README.md
+++ b/README.md
@@ -33,41 +33,7 @@
 
 ## Release notes
 
-### `3.1.0`
-
-* Updated dependencies for `near-sdk`
-* Introduce trait `IntoStorageKey` and updating all persistent collections to take it instead of `Vec<u8>`.
-  It's a non-breaking change.
-* Introduce a macro derive `BorshStorageKey` that implements `IntoStorageKey` using borsh serialization. Example:
-```rust
-use near_sdk::BorshStorageKey;
-
-#[derive(BorshSerialize, BorshStorageKey)]
-enum StorageKey {
-    Records,
-    UniqueValues,
-}
-
-#[near_bindgen]
-#[derive(BorshDeserialize, BorshSerialize, PanicOnDefault)]
-pub struct StatusMessage {
-    pub records: LookupMap<String, String>,
-    pub unique_values: LookupSet<String>,
-}
-
-#[near_bindgen]
-impl StatusMessage {
-    #[init]
-    pub fn new() -> Self {
-        Self {
-            records: LookupMap::new(StorageKey::Records),
-            unique_values: LookupSet::new(StorageKey::UniqueValues),
-        }
-    }
-}
-```
-
-**Previous version [CHANGELOG](CHANGELOG.md)**
+**Release notes and unreleased changes can be found in the [CHANGELOG](CHANGELOG.md)**
 
 ## Example
 


### PR DESCRIPTION
- Removes release notes from README to remove clutter
- Adds unreleased changes to changelog
  - This only includes changes that would be relevant to SDK users, but I am open to updating any format or including all changes
- Adds date to releases.
  - this can be useful for users to easily check what has changed since they last used it or know how mature a release is

Please share any options on how this should be structured, as it would be best if this has a format we're all happy with to keep this up to date. I considered having crate level `CHANGELOG`s but decided against it because there wasn't a need for that granular of changes it seems.