### PR TITLE
Modify ci-test script so it can be run on OS X

### DIFF
--- a/ci-test.sh
+++ b/ci-test.sh
@@ -11,7 +11,7 @@ else
     cp Cargo.toml{,.bak}
     cp Cargo.lock{,.bak}
 
-    sed -i "s|###||g" Cargo.toml
+    sed -i "" "s|###||g" Cargo.toml
     
     set +e
     cargo test --all


### PR DESCRIPTION
When attempting to run the `ci-test.sh` script, the use of `sed` has an issue on OS X.
After reading this article:
https://ed.gs/2016/01/26/macos-sed-invalid-command-code
found that this small modification will allow it to run locally. It looks like this change is only additive and linux systems (used for CI) shouldn't have an issue with it.