### PR TITLE
feat: Print logs when in debug and not wasm32 architecture

### DIFF
--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -692,6 +692,9 @@ pub fn panic(message: &[u8]) -> ! {
 }
 /// Log the UTF-8 encodable message.
 pub fn log(message: &[u8]) {
+    #[cfg(all(debug_assertions, not(target_arch = "wasm32")))]
+    println!("{}", String::from_utf8_lossy(message));
+
     unsafe {
         BLOCKCHAIN_INTERFACE.with(|b| {
             b.borrow()


### PR DESCRIPTION
cc @mikedotexe as you mentioned this would be useful for testing, and I would generally agree given it doesn't have negative side effects I'm not aware of.

I've kept the config as restrictive as possible so this never gets compiled in release mode or if in wasm32 arch, but can remove the release check if that's wanted.