### PR TITLE
chore: bump contract standards version for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1494,7 +1494,7 @@ checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 
 [[package]]
 name = "near-contract-standards"
-version = "3.1.1"
+version = "3.2.0"
 dependencies = [
  "near-sdk",
 ]

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-contract-standards"
-version = "3.1.1"
+version = "3.2.0"
 authors = ["Near Inc <hello@near.org>"]
 edition = "2018"
 license = "GPL-3.0"


### PR DESCRIPTION
Dry run went successful, will publish when confirmed and update anything here if necessary.

(release only contains NFT standard)