### PR TITLE
fix: crate references in contract-standards macros

### DIFF
--- a/near-contract-standards/src/fungible_token/macros.rs
+++ b/near-contract-standards/src/fungible_token/macros.rs
@@ -3,8 +3,8 @@
 #[macro_export]
 macro_rules! impl_fungible_token_core {
     ($contract: ident, $token: ident $(, $on_tokens_burned_fn:ident)?) => {
-        use near_contract_standards::fungible_token::core::FungibleTokenCore;
-        use near_contract_standards::fungible_token::resolver::FungibleTokenResolver;
+        use $crate::fungible_token::core::FungibleTokenCore;
+        use $crate::fungible_token::resolver::FungibleTokenResolver;
 
         #[near_bindgen]
         impl FungibleTokenCore for $contract {
@@ -67,7 +67,7 @@ macro_rules! impl_fungible_token_core {
 #[macro_export]
 macro_rules! impl_fungible_token_storage {
     ($contract: ident, $token: ident $(, $on_account_closed_fn:ident)?) => {
-        use near_contract_standards::storage_management::{
+        use $crate::storage_management::{
             StorageManagement, StorageBalance, StorageBalanceBounds
         };
 

--- a/near-contract-standards/src/non_fungible_token/macros.rs
+++ b/near-contract-standards/src/non_fungible_token/macros.rs
@@ -3,9 +3,9 @@
 #[macro_export]
 macro_rules! impl_non_fungible_token_core {
     ($contract: ident, $token: ident) => {
+        use std::collections::HashMap;
         use $crate::non_fungible_token::core::NonFungibleTokenCore;
         use $crate::non_fungible_token::core::NonFungibleTokenResolver;
-        use std::collections::HashMap;
 
         #[near_bindgen]
         impl NonFungibleTokenCore for $contract {
@@ -113,8 +113,8 @@ macro_rules! impl_non_fungible_token_approval {
 #[macro_export]
 macro_rules! impl_non_fungible_token_enumeration {
     ($contract: ident, $token: ident) => {
-        use $crate::non_fungible_token::enumeration::NonFungibleTokenEnumeration;
         use near_sdk::json_types::U128;
+        use $crate::non_fungible_token::enumeration::NonFungibleTokenEnumeration;
 
         #[near_bindgen]
         impl NonFungibleTokenEnumeration for $contract {

--- a/near-contract-standards/src/non_fungible_token/macros.rs
+++ b/near-contract-standards/src/non_fungible_token/macros.rs
@@ -3,8 +3,8 @@
 #[macro_export]
 macro_rules! impl_non_fungible_token_core {
     ($contract: ident, $token: ident) => {
-        use near_contract_standards::non_fungible_token::core::NonFungibleTokenCore;
-        use near_contract_standards::non_fungible_token::core::NonFungibleTokenResolver;
+        use $crate::non_fungible_token::core::NonFungibleTokenCore;
+        use $crate::non_fungible_token::core::NonFungibleTokenResolver;
         use std::collections::HashMap;
 
         #[near_bindgen]
@@ -72,7 +72,7 @@ macro_rules! impl_non_fungible_token_core {
 #[macro_export]
 macro_rules! impl_non_fungible_token_approval {
     ($contract: ident, $token: ident) => {
-        use near_contract_standards::non_fungible_token::approval::NonFungibleTokenApproval;
+        use $crate::non_fungible_token::approval::NonFungibleTokenApproval;
 
         #[near_bindgen]
         impl NonFungibleTokenApproval for $contract {
@@ -113,7 +113,7 @@ macro_rules! impl_non_fungible_token_approval {
 #[macro_export]
 macro_rules! impl_non_fungible_token_enumeration {
     ($contract: ident, $token: ident) => {
-        use near_contract_standards::non_fungible_token::enumeration::NonFungibleTokenEnumeration;
+        use $crate::non_fungible_token::enumeration::NonFungibleTokenEnumeration;
         use near_sdk::json_types::U128;
 
         #[near_bindgen]


### PR DESCRIPTION
Possibly this should also be included before #436 comes in and released. Noticed when scanning over changes 