### PR TITLE
feat: Initialize blockchain interface by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 * Make block time configurable to sim contract tests. [PR 378](https://github.com/near/near-sdk-rs/pull/378).
 * Update syscall interface to no longer go through `BLOCKCHAIN_INTERFACE`. Instead uses `near_sdk::sys` which is under the `unstable` feature flag if needed. [PR 417](https://github.com/near/near-sdk-rs/pull/417).
 * Update `TreeMap` iterator implementation to avoid unnecessary storage reads. [PR 428](https://github.com/near/near-sdk-rs/pull/428).
+* Initializes default for `BLOCKCHAIN_INTERFACE` to avoid requiring to initialize testing environment for tests that don't require custom blockchain interface configuration
+  * This default only affects outside of `wasm32` environments and is optional/backwards compatible
 
 ## `3.1.0` [04-06-2021]
 

--- a/examples/mission-control/src/mission_control.rs
+++ b/examples/mission-control/src/mission_control.rs
@@ -87,35 +87,11 @@ fn rates_default() -> HashMap<Exchange, Rate> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use near_sdk::MockedBlockchain;
-    use near_sdk::{testing_env, VMContext};
-
-    fn get_context(input: Vec<u8>, is_view: bool) -> VMContext {
-        VMContext {
-            current_account_id: "alice_near".to_string(),
-            signer_account_id: "bob_near".to_string(),
-            signer_account_pk: vec![0, 1, 2],
-            predecessor_account_id: "carol_near".to_string(),
-            input,
-            block_index: 0,
-            block_timestamp: 0,
-            account_balance: 0,
-            account_locked_balance: 0,
-            storage_usage: 0,
-            attached_deposit: 0,
-            prepaid_gas: 10u64.pow(18),
-            random_seed: vec![0, 1, 2],
-            is_view,
-            output_data_receivers: vec![],
-            epoch_height: 0,
-        }
-    }
+    use near_sdk::env;
 
     #[test]
     fn add_agent() {
-        let context = get_context(vec![], false);
-        let account_id = context.signer_account_id.clone();
-        testing_env!(context);
+        let account_id = env::signer_account_id();
 
         let mut contract = MissionControl::default();
         contract.add_agent();

--- a/examples/test-contract/src/lib.rs
+++ b/examples/test-contract/src/lib.rs
@@ -41,35 +41,10 @@ impl TestContract {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use near_sdk::MockedBlockchain;
-    use near_sdk::{testing_env, VMContext};
-
-    fn get_context(input: Vec<u8>, is_view: bool) -> VMContext {
-        VMContext {
-            current_account_id: "alice_near".to_string(),
-            signer_account_id: "bob_near".to_string(),
-            signer_account_pk: vec![0, 1, 2],
-            predecessor_account_id: "carol_near".to_string(),
-            input,
-            block_index: 0,
-            block_timestamp: 0,
-            account_balance: 0,
-            account_locked_balance: 0,
-            storage_usage: 0,
-            attached_deposit: 0,
-            prepaid_gas: 10u64.pow(18),
-            random_seed: vec![0, 1, 2],
-            is_view,
-            output_data_receivers: vec![],
-            epoch_height: 0,
-        }
-    }
 
     #[test]
     #[should_panic(expected = "PANIC!")]
     fn test_panic() {
-        let context = get_context(vec![], false);
-        testing_env!(context);
         let mut contract = TestContract::new();
         contract.test_panic_macro();
     }

--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -22,7 +22,7 @@ thread_local! {
 /// Low-level blockchain interface wrapped by the environment. Prefer using `env::*` and `testing_env`
 /// for interacting with the real and fake blockchains.
     pub static BLOCKCHAIN_INTERFACE: RefCell<Option<Box<dyn BlockchainInterface>>>
-         = RefCell::new(None);
+         = RefCell::new(Some(Box::new(crate::MockedBlockchain::default())));
 }
 
 const REGISTER_EXPECTED_ERR: &str =

--- a/near-sdk/src/environment/mocked_blockchain.rs
+++ b/near-sdk/src/environment/mocked_blockchain.rs
@@ -1,5 +1,6 @@
 use crate::environment::blockchain_interface::BlockchainInterface;
 use crate::types::{AccountId, Balance, PromiseResult};
+use crate::test_utils::VMContextBuilder;
 use crate::RuntimeFeesConfig;
 use near_vm_logic::mocks::mock_external::{MockedExternal, Receipt};
 use near_vm_logic::mocks::mock_memory::MockedMemory;
@@ -18,6 +19,20 @@ pub struct MockedBlockchain {
     // We keep ownership over logic fixture so that references in `VMLogic` are valid.
     #[allow(dead_code)]
     logic_fixture: LogicFixture,
+}
+
+impl Default for MockedBlockchain {
+    fn default() -> Self {
+        MockedBlockchain::new(
+            VMContextBuilder::new().build(),
+            Default::default(),
+            Default::default(),
+            vec![],
+            Default::default(),
+            Default::default(),
+            None,
+        )
+    }
 }
 
 struct LogicFixture {

--- a/near-sdk/src/environment/mocked_blockchain.rs
+++ b/near-sdk/src/environment/mocked_blockchain.rs
@@ -1,6 +1,6 @@
 use crate::environment::blockchain_interface::BlockchainInterface;
-use crate::types::{AccountId, Balance, PromiseResult};
 use crate::test_utils::VMContextBuilder;
+use crate::types::{AccountId, Balance, PromiseResult};
 use crate::RuntimeFeesConfig;
 use near_vm_logic::mocks::mock_external::{MockedExternal, Receipt};
 use near_vm_logic::mocks::mock_memory::MockedMemory;


### PR DESCRIPTION
Made changes based on #417 because it removes `BLOCKCHAIN_INTERFACE` from non-wasm32 environments, and this default only makes sense outside anyway.

One part of #440, going to split up changes because other ideas I have are more opinionated/breaking.

This change is completely backwards compatible from #417 and I changed only some of the examples to show this.

Ideally, in the future, it would be possible to modify the context of the mocked blockchain in place instead of still rigidly constructing a new context and replacing the current one, which will come with more QOL improvements.