### PR TITLE
Add deprecated ValidAccountId type mentioned in #464

### DIFF
--- a/near-sdk/src/json_types/mod.rs
+++ b/near-sdk/src/json_types/mod.rs
@@ -5,6 +5,14 @@ mod integers;
 mod public_key;
 mod vector;
 
+use crate::types::AccountId;
+
+#[deprecated(
+    since = "4.0.0",
+    note = "ValidAccountId is no longer maintained, and AccountId should be used instead"
+)]
+pub type ValidAccountId = AccountId;
+
 pub use hash::Base58CryptoHash;
 pub use integers::{I128, I64, U128, U64};
 pub use public_key::{Base58PublicKey, CurveType};


### PR DESCRIPTION
Just to stay consistent with #464, added the deprecated attribute to `ValidAccountId`