### PR TITLE
chore: deprecate block_index and replace with block_height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   * This type will have `ValidAccountId`'s JSON (de)serialization and the borsh serialization will be equivalent to what it was previously
 * Initializes default for `BLOCKCHAIN_INTERFACE` to avoid requiring to initialize testing environment for tests that don't require custom blockchain interface configuration
   * This default only affects outside of `wasm32` environments and is optional/backwards compatible
+* Deprecates `env::block_index` and replaces it with `env::block_height` for more consistent naming
 
 ## `3.1.0` [04-06-2021]
 

--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -176,8 +176,14 @@ pub fn input() -> Option<Vec<u8>> {
 }
 
 /// Current block index.
+#[deprecated(since = "4.0.0", note = "Use block_height instead")]
 pub fn block_index() -> BlockHeight {
-    unsafe { sys::block_index() }
+    block_height()
+}
+
+/// Returns the height of the block the transaction is being executed in.
+pub fn block_height() -> BlockHeight {
+    unsafe { sys::block_height() }
 }
 
 /// Current block timestamp, i.e, number of non-leap-nanoseconds since January 1, 1970 0:00:00 UTC.

--- a/near-sdk/src/environment/sys.rs
+++ b/near-sdk/src/environment/sys.rs
@@ -141,3 +141,8 @@ extern "C" {
     pub fn validator_stake(account_id_len: u64, account_id_ptr: u64, stake_ptr: u64);
     pub fn validator_total_stake(stake_ptr: u64);
 }
+
+#[inline]
+pub unsafe fn block_height() -> u64 {
+    block_index()
+}


### PR DESCRIPTION
- Deprecates `env::block_index`
- Adds `env::block_height` and `sys::block_height`

closes #460 