### PR TITLE
fix: update panic signature to indicate no return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Updates `Gas` type to be a newtype, which makes the API harder to misuse.
   * This also changes the JSON serialization of this type to a string, to avoid precision loss when deserializing in JavaScript
 * `PublicKey` now utilizes `Base58PublicKey` instead of `Vec<u8>` directly [PR 453](https://github.com/near/near-sdk-rs/pull/453). Usage of `Base58PublicKey` is deprecated
+* Update `panic` and `panic_utf8` syscall signatures to indicate they do not return.
 
 ## `3.1.0` [04-06-2021]
 

--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -484,7 +484,6 @@ pub fn value_return(value: &[u8]) {
 /// Terminates the execution of the program with the UTF-8 encoded message.
 pub fn panic(message: &[u8]) -> ! {
     unsafe { sys::panic_utf8(message.len() as _, message.as_ptr() as _) }
-    unreachable!()
 }
 /// Logs the string message message. This message is stored on chain.
 pub fn log_str(message: &str) {

--- a/near-sdk/src/environment/sys.rs
+++ b/near-sdk/src/environment/sys.rs
@@ -36,8 +36,8 @@ extern "C" {
     // #####################
     pub fn value_return(value_len: u64, value_ptr: u64);
     #[allow(dead_code)]
-    pub fn panic();
-    pub fn panic_utf8(len: u64, ptr: u64);
+    pub fn panic() -> !;
+    pub fn panic_utf8(len: u64, ptr: u64) -> !;
     pub fn log_utf8(len: u64, ptr: u64);
     #[allow(dead_code)]
     pub fn log_utf16(len: u64, ptr: u64);


### PR DESCRIPTION
A better interface when interacting with syscalls directly avoids using `unreachable` in `env`

Also, side note, I've never understood why we don't expose a public `env::panic` to avoid having to log a message if a developer doesn't want to? Is it just to discourage this or push people toward using `unreachable` or a similar panic?