### PR TITLE
chore: bump versions for 4.0.0-pre.1 release and cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [unreleased]
+
+## `4.0.0-pre.1` [07-23-2021]
 * Implements new `LazyOption` type under `unstable` feature. Similar to `Lazy` but is optional to set a value. [PR 444](https://github.com/near/near-sdk-rs/pull/444).
 * Move type aliases and core types to near-sdk to avoid coupling. [PR 415](https://github.com/near/near-sdk-rs/pull/415).
 * Implements new `Lazy` type under the new `unstable` feature which is a lazily loaded storage value. [PR 409](https://github.com/near/near-sdk-rs/pull/409).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1496,7 +1496,7 @@ checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 
 [[package]]
 name = "near-contract-standards"
-version = "3.3.0"
+version = "4.0.0-pre.1"
 dependencies = [
  "near-sdk",
 ]
@@ -1666,7 +1666,7 @@ dependencies = [
 
 [[package]]
 name = "near-sdk"
-version = "3.1.0"
+version = "4.0.0-pre.1"
 dependencies = [
  "base64",
  "borsh",
@@ -1687,7 +1687,7 @@ dependencies = [
 
 [[package]]
 name = "near-sdk-macros"
-version = "3.1.0"
+version = "4.0.0-pre.1"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "near-sdk-sim"
-version = "3.2.0"
+version = "4.0.0-pre.1"
 dependencies = [
  "fungible-token",
  "funty",
@@ -1894,9 +1894,9 @@ checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "once_cell"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "opaque-debug"

--- a/examples/cross-contract-high-level/Cargo.lock
+++ b/examples/cross-contract-high-level/Cargo.lock
@@ -1660,7 +1660,7 @@ dependencies = [
 
 [[package]]
 name = "near-sdk"
-version = "3.1.0"
+version = "4.0.0-pre.1"
 dependencies = [
  "base64",
  "borsh",
@@ -1674,8 +1674,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-sdk-core"
-version = "3.1.0"
+name = "near-sdk-macros"
+version = "4.0.0-pre.1"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -1684,18 +1684,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-sdk-macros"
-version = "3.1.0"
-dependencies = [
- "near-sdk-core",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "near-sdk-sim"
-version = "3.2.0"
+version = "4.0.0-pre.1"
 dependencies = [
  "funty",
  "lazy-static-include",

--- a/examples/cross-contract-low-level/Cargo.lock
+++ b/examples/cross-contract-low-level/Cargo.lock
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "near-sdk"
-version = "3.1.0"
+version = "4.0.0-pre.1"
 dependencies = [
  "base64",
  "borsh",
@@ -1693,8 +1693,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-sdk-core"
-version = "3.1.0"
+name = "near-sdk-macros"
+version = "4.0.0-pre.1"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -1703,18 +1703,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-sdk-macros"
-version = "3.1.0"
-dependencies = [
- "near-sdk-core",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "near-sdk-sim"
-version = "3.2.0"
+version = "4.0.0-pre.1"
 dependencies = [
  "funty",
  "lazy-static-include",

--- a/examples/fungible-token/Cargo.lock
+++ b/examples/fungible-token/Cargo.lock
@@ -1512,7 +1512,7 @@ checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 
 [[package]]
 name = "near-contract-standards"
-version = "3.2.0"
+version = "4.0.0-pre.1"
 dependencies = [
  "near-sdk",
 ]
@@ -1682,7 +1682,7 @@ dependencies = [
 
 [[package]]
 name = "near-sdk"
-version = "3.1.0"
+version = "4.0.0-pre.1"
 dependencies = [
  "base64",
  "borsh",
@@ -1696,8 +1696,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-sdk-core"
-version = "3.1.0"
+name = "near-sdk-macros"
+version = "4.0.0-pre.1"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -1706,18 +1706,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-sdk-macros"
-version = "3.1.0"
-dependencies = [
- "near-sdk-core",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "near-sdk-sim"
-version = "3.2.0"
+version = "4.0.0-pre.1"
 dependencies = [
  "funty",
  "lazy-static-include",

--- a/examples/gas-fee-tester/Cargo.lock
+++ b/examples/gas-fee-tester/Cargo.lock
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "near-sdk"
-version = "3.1.0"
+version = "4.0.0-pre.1"
 dependencies = [
  "base64",
  "borsh",
@@ -340,20 +340,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-sdk-core"
-version = "3.1.0"
+name = "near-sdk-macros"
+version = "4.0.0-pre.1"
 dependencies = [
  "Inflector",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "near-sdk-macros"
-version = "3.1.0"
-dependencies = [
- "near-sdk-core",
  "proc-macro2",
  "quote",
  "syn",

--- a/examples/lockable-fungible-token/Cargo.lock
+++ b/examples/lockable-fungible-token/Cargo.lock
@@ -328,7 +328,7 @@ dependencies = [
 
 [[package]]
 name = "near-sdk"
-version = "3.1.0"
+version = "4.0.0-pre.1"
 dependencies = [
  "base64",
  "borsh",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "near-sdk-macros"
-version = "3.1.0"
+version = "4.0.0-pre.1"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/examples/mission-control/Cargo.lock
+++ b/examples/mission-control/Cargo.lock
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "near-sdk"
-version = "3.1.0"
+version = "4.0.0-pre.1"
 dependencies = [
  "base64",
  "borsh",
@@ -340,20 +340,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-sdk-core"
-version = "3.1.0"
+name = "near-sdk-macros"
+version = "4.0.0-pre.1"
 dependencies = [
  "Inflector",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "near-sdk-macros"
-version = "3.1.0"
-dependencies = [
- "near-sdk-core",
  "proc-macro2",
  "quote",
  "syn",

--- a/examples/non-fungible-token/Cargo.lock
+++ b/examples/non-fungible-token/Cargo.lock
@@ -1494,7 +1494,7 @@ checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 
 [[package]]
 name = "near-contract-standards"
-version = "3.2.0"
+version = "4.0.0-pre.1"
 dependencies = [
  "near-sdk",
 ]
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "near-sdk"
-version = "3.1.0"
+version = "4.0.0-pre.1"
 dependencies = [
  "base64",
  "borsh",
@@ -1678,8 +1678,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-sdk-core"
-version = "3.1.0"
+name = "near-sdk-macros"
+version = "4.0.0-pre.1"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -1688,18 +1688,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-sdk-macros"
-version = "3.1.0"
-dependencies = [
- "near-sdk-core",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "near-sdk-sim"
-version = "3.2.0"
+version = "4.0.0-pre.1"
 dependencies = [
  "funty",
  "lazy-static-include",

--- a/examples/status-message-collections/Cargo.lock
+++ b/examples/status-message-collections/Cargo.lock
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "near-sdk"
-version = "3.1.0"
+version = "4.0.0-pre.1"
 dependencies = [
  "base64",
  "borsh",
@@ -333,20 +333,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-sdk-core"
-version = "3.1.0"
+name = "near-sdk-macros"
+version = "4.0.0-pre.1"
 dependencies = [
  "Inflector",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "near-sdk-macros"
-version = "3.1.0"
-dependencies = [
- "near-sdk-core",
  "proc-macro2",
  "quote",
  "syn",

--- a/examples/status-message/Cargo.lock
+++ b/examples/status-message/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "near-sdk"
-version = "3.1.0"
+version = "4.0.0-pre.1"
 dependencies = [
  "base64",
  "borsh",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "near-sdk-macros"
-version = "3.1.0"
+version = "4.0.0-pre.1"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/examples/test-contract/Cargo.lock
+++ b/examples/test-contract/Cargo.lock
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "near-sdk"
-version = "3.1.0"
+version = "4.0.0-pre.1"
 dependencies = [
  "base64",
  "borsh",
@@ -333,20 +333,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-sdk-core"
-version = "3.1.0"
+name = "near-sdk-macros"
+version = "4.0.0-pre.1"
 dependencies = [
  "Inflector",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "near-sdk-macros"
-version = "3.1.0"
-dependencies = [
- "near-sdk-core",
  "proc-macro2",
  "quote",
  "syn",

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-contract-standards"
-version = "3.2.0"
+version = "4.0.0-pre.1"
 authors = ["Near Inc <hello@near.org>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -12,4 +12,4 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "=3.1.0" }
+near-sdk = { path = "../near-sdk", version = "=4.0.0-pre.1" }

--- a/near-sdk-macros/Cargo.toml
+++ b/near-sdk-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sdk-macros"
-version = "3.1.0"
+version = "4.0.0-pre.1"
 authors = ["Near Inc <max@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/near-sdk-sim/Cargo.toml
+++ b/near-sdk-sim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sdk-sim"
-version = "3.2.0"
+version = "4.0.0-pre.1"
 authors = ["Near Inc <hello@near.org>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -13,7 +13,7 @@ NEAR Simulator & cross-contract testing library
 
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "=3.1.0" }
+near-sdk = { path = "../near-sdk", version = "=4.0.0-pre.1" }
 near-crypto = "=0.1.0"
 near-primitives = "=0.1.0-pre.1"
 near-vm-logic = "=4.0.0-pre.1"

--- a/near-sdk-sim/README.md
+++ b/near-sdk-sim/README.md
@@ -31,7 +31,7 @@ Currently this crate depends on a the GitHub repo of [nearcore](https://github.c
 
 ```toml
 [dev-dependencies]
-near-sdk-sim = "3.2.0"
+near-sdk-sim = "4.0.0-pre.1"
 
 ```
 
@@ -39,7 +39,7 @@ And update `near-sdk` too:
 
 ```toml
 [dependencies]
-near-sdk = "3.1.0"
+near-sdk = "4.0.0-pre.1"
 
 ```
 
@@ -64,8 +64,8 @@ Now in the root of the project (`contract-wrap`), create a new `Cargo.toml`. You
 
 ```toml
 [dev-dependencies]
-near-sdk = "3.1.0"
-near-sdk-sim = "3.2.0"
+near-sdk = "4.0.0-pre.1"
+near-sdk-sim = "4.0.0-pre.1"
 contract = { path = "./contract" }
 
 [workspace]

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sdk"
-version = "3.1.0"
+version = "4.0.0-pre.1"
 authors = ["Near Inc <max@nearprotocol.com>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -20,7 +20,7 @@ path = "compilation_tests/all.rs"
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "=3.1.0" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "=4.0.0-pre.1" }
 base64 = "0.13"
 borsh = "0.8.1"
 bs58 = "0.4"
@@ -28,7 +28,7 @@ bs58 = "0.4"
 wee_alloc = { version = "0.4.5", default-features = false, optional = true }
 
 # Used for caching, might be worth porting only functionality needed.
-once_cell = { version = "1.7.2", optional = true, default-features = false }
+once_cell = { version = "1.8", optional = true, default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 near-vm-logic = "=4.0.0-pre.1"

--- a/near-sdk/src/collections/legacy_tree_map.rs
+++ b/near-sdk/src/collections/legacy_tree_map.rs
@@ -42,6 +42,7 @@ where
     }
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl<K, V> LegacyTreeMap<K, V>
 where
     K: Ord + Clone + BorshSerialize + BorshDeserialize,

--- a/near-sdk/src/types/account_id.rs
+++ b/near-sdk/src/types/account_id.rs
@@ -51,7 +51,7 @@ impl AccountId {
     /// Constructs new AccountId from `String` without checking validity.
     /// Creating an invalid account id will result in a runtime error when being used.
     ///
-    /// For more information, read: https://docs.near.org/docs/concepts/account#account-id-rules
+    /// For more information, read: <https://docs.near.org/docs/concepts/account#account-id-rules>
     pub fn new_unchecked(id: String) -> Self {
         debug_assert!(is_valid_account_id(id.as_bytes()));
         Self(id)

--- a/near-sdk/src/utils/mod.rs
+++ b/near-sdk/src/utils/mod.rs
@@ -100,10 +100,10 @@ impl PendingContractTx {
     }
 }
 
-/// Boilerplate for setting up allocator used in Wasm binary.
-/// Sets up the [GlobalAllocator] with [`WeeAlloc`](crate::wee_alloc::WeeAlloc).
+/// Deprecated helper function which used to generate code to initialize the [`GlobalAllocator`].
+/// This is now initialized by default. Disable `wee_alloc` feature to configure manually.
 ///
-/// [GlobalAllocator]: std::alloc::GlobalAlloc
+/// [`GlobalAllocator`]: std::alloc::GlobalAlloc
 #[deprecated(
     since = "4.0.0",
     note = "Allocator is already initialized with the default `wee_alloc` feature set. \


### PR DESCRIPTION
- Bumped versions to `4.0.0-pre.1`
- Fixed broken doc links

Changes since last release: https://github.com/near/near-sdk-rs/compare/bac0ec71395c93620b215573bbaf5a4e4a9b8e85...austin/4_release

Will do a pass through to make sure nothing else needs to get cleaned up before releasing