### PR TITLE
fix: mock sys interface panic signature

### DIFF
--- a/near-sdk/src/environment/mock/mocked_blockchain.rs
+++ b/near-sdk/src/environment/mock/mocked_blockchain.rs
@@ -198,12 +198,14 @@ mod mock_chain {
         with_mock_interface(|b| b.value_return(value_len, value_ptr))
     }
     #[no_mangle]
-    extern "C" fn panic() {
-        with_mock_interface(|b| b.panic())
+    extern "C" fn panic() -> ! {
+        with_mock_interface(|b| b.panic());
+        unreachable!()
     }
     #[no_mangle]
-    extern "C" fn panic_utf8(len: u64, ptr: u64) {
-        with_mock_interface(|b| b.panic_utf8(len, ptr))
+    extern "C" fn panic_utf8(len: u64, ptr: u64) -> ! {
+        with_mock_interface(|b| b.panic_utf8(len, ptr));
+        unreachable!()
     }
     #[no_mangle]
     extern "C" fn log_utf8(len: u64, ptr: u64) {


### PR DESCRIPTION
Interface was changed in #489 but the mock implementation didn't indicate the same with the function not returning. I don't think this has any affect on anything, but probably safe to make sure these match.

The panic calls to VM logic always error and that gets unwrapped, which is why unreachable