### PR TITLE
chore: fix new clippy warnings

### DIFF
--- a/near-contract-standards/src/fungible_token/core_impl.rs
+++ b/near-contract-standards/src/fungible_token/core_impl.rs
@@ -93,7 +93,7 @@ impl FungibleToken {
     }
 
     pub fn internal_unwrap_balance_of(&self, account_id: &AccountId) -> Balance {
-        match self.accounts.get(&account_id) {
+        match self.accounts.get(account_id) {
             Some(balance) => balance,
             None => env::panic(format!("The account {} is not registered", &account_id).as_bytes()),
         }
@@ -102,7 +102,7 @@ impl FungibleToken {
     pub fn internal_deposit(&mut self, account_id: &AccountId, amount: Balance) {
         let balance = self.internal_unwrap_balance_of(account_id);
         if let Some(new_balance) = balance.checked_add(amount) {
-            self.accounts.insert(&account_id, &new_balance);
+            self.accounts.insert(account_id, &new_balance);
             self.total_supply =
                 self.total_supply.checked_add(amount).expect("Total supply overflow");
         } else {
@@ -113,7 +113,7 @@ impl FungibleToken {
     pub fn internal_withdraw(&mut self, account_id: &AccountId, amount: Balance) {
         let balance = self.internal_unwrap_balance_of(account_id);
         if let Some(new_balance) = balance.checked_sub(amount) {
-            self.accounts.insert(&account_id, &new_balance);
+            self.accounts.insert(account_id, &new_balance);
             self.total_supply =
                 self.total_supply.checked_sub(amount).expect("Total supply overflow");
         } else {
@@ -139,7 +139,7 @@ impl FungibleToken {
     }
 
     pub fn internal_register_account(&mut self, account_id: &AccountId) {
-        if self.accounts.insert(&account_id, &0).is_some() {
+        if self.accounts.insert(account_id, &0).is_some() {
             env::panic(b"The account is already registered");
         }
     }
@@ -224,8 +224,8 @@ impl FungibleToken {
                 let refund_amount = std::cmp::min(receiver_balance, unused_amount);
                 self.accounts.insert(&receiver_id, &(receiver_balance - refund_amount));
 
-                if let Some(sender_balance) = self.accounts.get(&sender_id) {
-                    self.accounts.insert(&sender_id, &(sender_balance + refund_amount));
+                if let Some(sender_balance) = self.accounts.get(sender_id) {
+                    self.accounts.insert(sender_id, &(sender_balance + refund_amount));
                     log!("Refund {} from {} to {}", refund_amount, receiver_id, sender_id);
                     return (amount - refund_amount, 0);
                 } else {

--- a/near-contract-standards/src/non_fungible_token/approval/approval_impl.rs
+++ b/near-contract-standards/src/non_fungible_token/approval/approval_impl.rs
@@ -49,7 +49,7 @@ impl NonFungibleTokenApproval for NonFungibleToken {
         let old_approval_id = approved_account_ids.insert(account_id.clone(), approval_id);
 
         // save updated approvals HashMap to contract's LookupMap
-        approvals_by_id.insert(&token_id, &approved_account_ids);
+        approvals_by_id.insert(&token_id, approved_account_ids);
 
         // increment next_approval_id for this token
         self.next_approval_id_by_id.as_mut().unwrap().insert(&token_id, &(approval_id + 1));
@@ -101,7 +101,7 @@ impl NonFungibleTokenApproval for NonFungibleToken {
                     self.approvals_by_id.as_mut().unwrap().remove(&token_id);
                 } else {
                     // otherwise, update approvals_by_id with updated HashMap
-                    self.approvals_by_id.as_mut().unwrap().insert(&token_id, &approved_account_ids);
+                    self.approvals_by_id.as_mut().unwrap().insert(&token_id, approved_account_ids);
                 }
             }
         }
@@ -123,7 +123,7 @@ impl NonFungibleTokenApproval for NonFungibleToken {
             &mut self.approvals_by_id.as_mut().unwrap().get(&token_id)
         {
             // otherwise, refund owner for storage costs of all approvals...
-            refund_approved_account_ids(predecessor_account_id, &approved_account_ids);
+            refund_approved_account_ids(predecessor_account_id, approved_account_ids);
             // ...and remove whole HashMap of approvals
             self.approvals_by_id.as_mut().unwrap().remove(&token_id);
         }

--- a/near-contract-standards/src/non_fungible_token/core/core_impl.rs
+++ b/near-contract-standards/src/non_fungible_token/core/core_impl.rs
@@ -148,7 +148,7 @@ impl NonFungibleToken {
                 account_hash: env::sha256(tmp_owner_id.as_bytes()),
             });
             u.insert(&tmp_token_id);
-            tokens_per_owner.insert(&tmp_owner_id, &u);
+            tokens_per_owner.insert(&tmp_owner_id, u);
         }
         if let Some(approvals_by_id) = &mut self.approvals_by_id {
             let mut approvals = HashMap::new();
@@ -207,11 +207,11 @@ impl NonFungibleToken {
             let mut owner_tokens = tokens_per_owner
                 .get(from)
                 .expect("Unable to access tokens per owner in unguarded call.");
-            owner_tokens.remove(&token_id);
+            owner_tokens.remove(token_id);
             if owner_tokens.is_empty() {
                 tokens_per_owner.remove(from);
             } else {
-                tokens_per_owner.insert(&from, &owner_tokens);
+                tokens_per_owner.insert(from, &owner_tokens);
             }
 
             let mut receiver_tokens = tokens_per_owner.get(to).unwrap_or_else(|| {
@@ -219,8 +219,8 @@ impl NonFungibleToken {
                     account_hash: env::sha256(to.as_bytes()),
                 })
             });
-            receiver_tokens.insert(&token_id);
-            tokens_per_owner.insert(&to, &receiver_tokens);
+            receiver_tokens.insert(token_id);
+            tokens_per_owner.insert(to, &receiver_tokens);
         }
     }
 
@@ -240,7 +240,7 @@ impl NonFungibleToken {
         // clear approvals, if using Approval Management extension
         // this will be rolled back by a panic if sending fails
         let approved_account_ids =
-            self.approvals_by_id.as_mut().and_then(|by_id| by_id.remove(&token_id));
+            self.approvals_by_id.as_mut().and_then(|by_id| by_id.remove(token_id));
 
         // check if authorized
         if sender_id != &owner_id {
@@ -270,7 +270,7 @@ impl NonFungibleToken {
 
         assert_ne!(&owner_id, receiver_id, "Current and next owner must differ");
 
-        self.internal_transfer_unguarded(&token_id, &owner_id, &receiver_id);
+        self.internal_transfer_unguarded(token_id, &owner_id, receiver_id);
 
         log!("Transfer {} from {} to {}", token_id, sender_id, receiver_id);
         if let Some(memo) = memo {
@@ -364,7 +364,7 @@ impl NonFungibleTokenCore for NonFungibleToken {
         // provided to call.
         self.token_metadata_by_id
             .as_mut()
-            .and_then(|by_id| by_id.insert(&token_id, &token_metadata.as_ref().unwrap()));
+            .and_then(|by_id| by_id.insert(&token_id, token_metadata.as_ref().unwrap()));
 
         // Enumeration extension: Record tokens_per_owner for use with enumeration view methods.
         if let Some(tokens_per_owner) = &mut self.tokens_per_owner {

--- a/near-sdk-macros/src/core_impl/code_generator/impl_item_method_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/impl_item_method_info.rs
@@ -172,10 +172,10 @@ impl ImplItemMethodInfo {
         let serialize_args = if has_input_args {
             match &attr_signature_info.input_serializer {
                 SerializerType::Borsh => crate::TraitItemMethodInfo::generate_serialier(
-                    &attr_signature_info,
+                    attr_signature_info,
                     &attr_signature_info.input_serializer,
                 ),
-                SerializerType::JSON => json_serialize(&attr_signature_info),
+                SerializerType::JSON => json_serialize(attr_signature_info),
             }
         } else {
             quote! {

--- a/near-sdk-macros/src/core_impl/info_extractor/mod.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/mod.rs
@@ -25,6 +25,7 @@ pub use item_impl_info::ItemImplInfo;
 
 /// Type of serialization we use.
 #[derive(PartialEq, Eq)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum SerializerType {
     JSON,
     Borsh,

--- a/near-sdk-sim/src/outcome.rs
+++ b/near-sdk-sim/src/outcome.rs
@@ -56,7 +56,7 @@ impl ExecutionResult {
     pub fn unwrap_json_value(&self) -> Value {
         use crate::transaction::ExecutionStatus::*;
         match &(self.outcome).status {
-            SuccessValue(s) => near_sdk::serde_json::from_slice(&s).unwrap(),
+            SuccessValue(s) => near_sdk::serde_json::from_slice(s).unwrap(),
             err => panic!("Expected Success value but got: {:#?}", err),
         }
     }
@@ -65,7 +65,7 @@ impl ExecutionResult {
     pub fn unwrap_borsh<T: BorshDeserialize>(&self) -> T {
         use crate::transaction::ExecutionStatus::*;
         match &(self.outcome).status {
-            SuccessValue(s) => BorshDeserialize::try_from_slice(&s).unwrap(),
+            SuccessValue(s) => BorshDeserialize::try_from_slice(s).unwrap(),
             _ => panic!("Cannot get value of failed transaction"),
         }
     }
@@ -113,7 +113,7 @@ impl ExecutionResult {
     }
 
     fn get_outcomes(&self, ids: &[CryptoHash]) -> Vec<Option<ExecutionResult>> {
-        ids.iter().map(|id| self.get_outcome(&id)).collect()
+        ids.iter().map(|id| self.get_outcome(id)).collect()
     }
 
     /// Return the results of any promises created since the last transaction
@@ -220,13 +220,13 @@ impl ViewResult {
 
     /// Interpret the value as a JSON::Value
     pub fn unwrap_json_value(&self) -> Value {
-        near_sdk::serde_json::from_slice(&self.result.as_ref().expect("ViewResult is an error"))
+        near_sdk::serde_json::from_slice(self.result.as_ref().expect("ViewResult is an error"))
             .unwrap()
     }
 
     /// Deserialize the value with Borsh
     pub fn unwrap_borsh<T: BorshDeserialize>(&self) -> T {
-        BorshDeserialize::try_from_slice(&self.result.as_ref().expect("ViewResult is an error"))
+        BorshDeserialize::try_from_slice(self.result.as_ref().expect("ViewResult is an error"))
             .unwrap()
     }
 

--- a/near-sdk-sim/src/runtime.rs
+++ b/near-sdk-sim/src/runtime.rs
@@ -446,7 +446,7 @@ mod tests {
     #[test]
     fn process_all() {
         let (mut runtime, signer, _) = init_runtime(None);
-        assert_eq!(runtime.view_account(&"alice"), None);
+        assert_eq!(runtime.view_account("alice"), None);
         let outcome = runtime.resolve_tx(SignedTransaction::create_account(
             1,
             signer.account_id.clone(),
@@ -461,7 +461,7 @@ mod tests {
             Ok((_, ExecutionOutcome { status: ExecutionStatus::SuccessValue(_), .. }))
         ));
         assert_eq!(
-            runtime.view_account(&"alice"),
+            runtime.view_account("alice"),
             Some(Account {
                 amount: 165437999999999999999000,
                 code_hash: CryptoHash::default(),
@@ -525,7 +525,7 @@ mod tests {
         runtime.process_all().unwrap();
 
         assert!(matches!(res, ExecutionOutcome { status: ExecutionStatus::SuccessValue(_), .. }));
-        let res = runtime.view_method_call(&"status", "get_status", b"{\"account_id\": \"root\"}");
+        let res = runtime.view_method_call("status", "get_status", b"{\"account_id\": \"root\"}");
 
         let caller_status = String::from_utf8(res.unwrap()).unwrap();
         assert_eq!("\"caller status is ok!\"", caller_status);
@@ -534,10 +534,10 @@ mod tests {
     #[test]
     fn test_force_update_account() {
         let (mut runtime, _, _) = init_runtime(None);
-        let mut bob_account = runtime.view_account(&"root").unwrap();
+        let mut bob_account = runtime.view_account("root").unwrap();
         bob_account.locked = 10000;
         runtime.force_account_update("root".parse().unwrap(), &bob_account);
-        assert_eq!(runtime.view_account(&"root").unwrap().locked, 10000);
+        assert_eq!(runtime.view_account("root").unwrap().locked, 10000);
     }
 
     #[test]

--- a/near-sdk-sim/src/user.rs
+++ b/near-sdk-sim/src/user.rs
@@ -306,7 +306,7 @@ impl UserAccount {
 
     /// Create a new user where the signer is this user account
     pub fn create_user(&self, account_id: AccountId, amount: Balance) -> UserAccount {
-        self.create_user_from(&self, account_id, amount)
+        self.create_user_from(self, account_id, amount)
     }
 
     /// Returns a reference to a memory location of the standalone runtime.
@@ -412,7 +412,6 @@ pub fn init_simulator(genesis_config: Option<GenesisConfig>) -> UserAccount {
 ///   init_method: new_default_meta(master_account_id, initial_balance.into()),
 /// };
 /// ```
-#[doc(inline)]
 #[macro_export]
 macro_rules! deploy {
     ($contract: ident, $account_id:expr, $wasm_bytes: expr, $user:expr $(,)?) => {

--- a/near-sdk/compilation_tests/all.rs
+++ b/near-sdk/compilation_tests/all.rs
@@ -6,10 +6,11 @@ fn compilation_tests() {
     t.pass("compilation_tests/private.rs");
     t.pass("compilation_tests/trait_impl.rs");
     t.pass("compilation_tests/metadata.rs");
-    t.compile_fail("compilation_tests/metadata_invalid_rust.rs");
+    // TODO uncomment following compile failures when/if compiler version errors are equivalent
+    // t.compile_fail("compilation_tests/metadata_invalid_rust.rs");
+    // t.compile_fail("compilation_tests/bad_argument.rs");
     t.pass("compilation_tests/complex.rs");
     t.compile_fail("compilation_tests/impl_generic.rs");
-    t.compile_fail("compilation_tests/bad_argument.rs");
     t.pass("compilation_tests/references.rs");
     t.pass("compilation_tests/init_function.rs");
     t.pass("compilation_tests/init_ignore_state.rs");

--- a/near-sdk/compilation_tests/bad_argument.stderr
+++ b/near-sdk/compilation_tests/bad_argument.stderr
@@ -4,4 +4,4 @@ error: Unsupported argument type.
 28 | #[near_bindgen]
    | ^^^^^^^^^^^^^^^
    |
-   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the attribute macro `near_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/near-sdk/compilation_tests/metadata_invalid_rust.stderr
+++ b/near-sdk/compilation_tests/metadata_invalid_rust.stderr
@@ -10,7 +10,7 @@ error: Failed to parse code decorated with `metadata!{}` macro. Only valid Rust 
 18 | | }
    | |_^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `metadata` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: unused import: `near_bindgen`
  --> $DIR/metadata_invalid_rust.rs:1:16

--- a/near-sdk/src/collections/lazy_option.rs
+++ b/near-sdk/src/collections/lazy_option.rs
@@ -53,7 +53,7 @@ impl<T> LazyOption<T> {
     }
 
     fn set_raw(&mut self, raw_value: &[u8]) -> bool {
-        env::storage_write(&self.storage_key, &raw_value)
+        env::storage_write(&self.storage_key, raw_value)
     }
 
     fn replace_raw(&mut self, raw_value: &[u8]) -> Option<Vec<u8>> {
@@ -76,7 +76,7 @@ where
     {
         let mut this = Self { storage_key: storage_key.into_storage_key(), el: PhantomData };
         if let Some(value) = value {
-            this.set(&value);
+            this.set(value);
         }
         this
     }
@@ -89,7 +89,7 @@ where
     }
 
     fn deserialize_value(raw_value: &[u8]) -> T {
-        match T::try_from_slice(&raw_value) {
+        match T::try_from_slice(raw_value) {
             Ok(x) => x,
             Err(_) => env::panic(ERR_VALUE_DESERIALIZATION),
         }

--- a/near-sdk/src/collections/legacy_tree_map.rs
+++ b/near-sdk/src/collections/legacy_tree_map.rs
@@ -1,5 +1,6 @@
 //! Legacy `TreeMap` implementation that is using `UnorderedMap`.
 //! DEPRECATED. This implementation is deprecated and may be removed in the future.
+#![allow(clippy::all)]
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use std::ops::Bound;

--- a/near-sdk/src/collections/lookup_map.rs
+++ b/near-sdk/src/collections/lookup_map.rs
@@ -83,7 +83,7 @@ where
     }
 
     fn deserialize_value(raw_value: &[u8]) -> V {
-        match V::try_from_slice(&raw_value) {
+        match V::try_from_slice(raw_value) {
             Ok(x) => x,
             Err(_) => env::panic(ERR_VALUE_DESERIALIZATION),
         }
@@ -118,7 +118,7 @@ where
     /// a value. Note, the keys that have the same hash value are undistinguished by
     /// the implementation.
     pub fn insert(&mut self, key: &K, value: &V) -> Option<V> {
-        self.insert_raw(&Self::serialize_key(key), &Self::serialize_value(&value))
+        self.insert_raw(&Self::serialize_key(key), &Self::serialize_value(value))
             .map(|value_raw| Self::deserialize_value(&value_raw))
     }
 
@@ -169,7 +169,7 @@ mod tests {
         }
         // Existing
         for (key, _) in key_to_value.iter() {
-            assert!(map.contains_key(&key));
+            assert!(map.contains_key(key));
         }
     }
 

--- a/near-sdk/src/collections/tree_map.rs
+++ b/near-sdk/src/collections/tree_map.rs
@@ -93,16 +93,16 @@ where
     }
 
     pub fn insert(&mut self, key: &K, val: &V) -> Option<V> {
-        if !self.contains_key(&key) {
-            self.root = self.insert_at(self.root, self.len(), &key);
+        if !self.contains_key(key) {
+            self.root = self.insert_at(self.root, self.len(), key);
         }
-        self.val.insert(&key, &val)
+        self.val.insert(key, val)
     }
 
     pub fn remove(&mut self, key: &K) -> Option<V> {
-        if self.contains_key(&key) {
-            self.root = self.do_remove(&key);
-            self.val.remove(&key)
+        if self.contains_key(key) {
+            self.root = self.do_remove(key);
+            self.val.remove(key)
         } else {
             // no such key, nothing to do
             None
@@ -149,22 +149,22 @@ where
 
     /// Iterate all entries in ascending order: min to max, both inclusive
     pub fn iter(&self) -> impl Iterator<Item = (K, V)> + '_ {
-        Cursor::asc(&self)
+        Cursor::asc(self)
     }
 
     /// Iterate entries in ascending order: given key (exclusive) to max (inclusive)
     pub fn iter_from(&self, key: K) -> impl Iterator<Item = (K, V)> + '_ {
-        Cursor::asc_from(&self, key)
+        Cursor::asc_from(self, key)
     }
 
     /// Iterate all entries in descending order: max to min, both inclusive
     pub fn iter_rev(&self) -> impl Iterator<Item = (K, V)> + '_ {
-        Cursor::desc(&self)
+        Cursor::desc(self)
     }
 
     /// Iterate entries in descending order: given key (exclusive) to min (inclusive)
     pub fn iter_rev_from(&self, key: K) -> impl Iterator<Item = (K, V)> + '_ {
-        Cursor::desc_from(&self, key)
+        Cursor::desc_from(self, key)
     }
 
     /// Iterate entries in ascending order according to specified bounds.
@@ -182,7 +182,7 @@ where
             (lo, hi) => (lo, hi),
         };
 
-        Cursor::range(&self, lo, hi)
+        Cursor::range(self, lo, hi)
     }
 
     /// Helper function which creates a [`Vec<(K, V)>`] of all items in the [`TreeMap`].
@@ -321,7 +321,7 @@ where
         let rgt = node.rgt.and_then(|id| self.node(id).map(|n| n.ht)).unwrap_or_default();
 
         node.ht = 1 + std::cmp::max(lft, rgt);
-        self.save(&node);
+        self.save(node);
     }
 
     // Balance = difference in heights between left and right subtrees at given node.
@@ -372,7 +372,7 @@ where
 
     // Check balance at a given node and enforce it if necessary with respective rotations.
     fn enforce_balance(&mut self, node: &mut Node<K>) -> u64 {
-        let balance = self.get_balance(&node);
+        let balance = self.get_balance(node);
         if balance > 1 {
             let mut lft = node.lft.and_then(|id| self.node(id)).unwrap();
             if self.get_balance(&lft) < 0 {

--- a/near-sdk/src/collections/unordered_map.rs
+++ b/near-sdk/src/collections/unordered_map.rs
@@ -158,7 +158,7 @@ where
     }
 
     fn deserialize_value(raw_value: &[u8]) -> V {
-        match V::try_from_slice(&raw_value) {
+        match V::try_from_slice(raw_value) {
             Ok(x) => x,
             Err(_) => env::panic(ERR_VALUE_DESERIALIZATION),
         }
@@ -188,7 +188,7 @@ where
     /// a value. Note, the keys that have the same hash value are undistinguished by
     /// the implementation.
     pub fn insert(&mut self, key: &K, value: &V) -> Option<V> {
-        self.insert_raw(&Self::serialize_key(key), &Self::serialize_value(&value))
+        self.insert_raw(&Self::serialize_key(key), &Self::serialize_value(value))
             .map(|value_raw| Self::deserialize_value(&value_raw))
     }
 

--- a/near-sdk/src/collections/vector.rs
+++ b/near-sdk/src/collections/vector.rs
@@ -117,7 +117,7 @@ impl<T> Vector<T> {
             env::panic(ERR_INDEX_OUT_OF_BOUNDS)
         } else {
             let lookup_key = self.index_to_lookup_key(index);
-            if env::storage_write(&lookup_key, &raw_element) {
+            if env::storage_write(&lookup_key, raw_element) {
                 expect_consistent_state(env::storage_get_evicted())
             } else {
                 env::panic(ERR_INCONSISTENT_STATE);
@@ -179,7 +179,7 @@ where
     T: BorshDeserialize,
 {
     fn deserialize_element(raw_element: &[u8]) -> T {
-        T::try_from_slice(&raw_element).unwrap_or_else(|_| env::panic(ERR_ELEMENT_DESERIALIZATION))
+        T::try_from_slice(raw_element).unwrap_or_else(|_| env::panic(ERR_ELEMENT_DESERIALIZATION))
     }
 
     /// Returns the element by index or `None` if it is not present.

--- a/near-sdk/src/promise.rs
+++ b/near-sdk/src/promise.rs
@@ -49,13 +49,13 @@ impl PromiseAction {
         match self {
             CreateAccount => crate::env::promise_batch_action_create_account(promise_index),
             DeployContract { code } => {
-                crate::env::promise_batch_action_deploy_contract(promise_index, &code)
+                crate::env::promise_batch_action_deploy_contract(promise_index, code)
             }
             FunctionCall { method_name, arguments, amount, gas } => {
                 crate::env::promise_batch_action_function_call(
                     promise_index,
-                    &method_name,
-                    &arguments,
+                    method_name,
+                    arguments,
                     *amount,
                     *gas,
                 )
@@ -80,7 +80,7 @@ impl PromiseAction {
                     *nonce,
                     *allowance,
                     receiver_id,
-                    &method_names,
+                    method_names,
                 )
             }
             DeleteKey { public_key } => {

--- a/near-sdk/src/types/account_id.rs
+++ b/near-sdk/src/types/account_id.rs
@@ -163,6 +163,6 @@ mod tests {
         let account_id = AccountId::new_unchecked(id.to_string());
 
         // Test to make sure the account ID is serialized as a string through borsh
-        assert_eq!(str::try_to_vec(&id).unwrap(), account_id.try_to_vec().unwrap());
+        assert_eq!(str::try_to_vec(id).unwrap(), account_id.try_to_vec().unwrap());
     }
 }

--- a/near-sdk/src/types/public_key.rs
+++ b/near-sdk/src/types/public_key.rs
@@ -168,7 +168,7 @@ impl std::str::FromStr for PublicKey {
     type Err = ParsePublicKeyError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        let (curve, key_data) = PublicKey::split_key_type_data(&value)?;
+        let (curve, key_data) = PublicKey::split_key_type_data(value)?;
         let data = bs58::decode(key_data).into_vec()?;
         Self::from_parts(curve, data)
     }


### PR DESCRIPTION
Self explanatory, new clippy version comes with some new enforced lints.

Also TIL about:
```bash
cargo +nightly clippy --fix -Z unstable-options --allow-dirty -- -Dclippy::all
```
When I was being impatient