### PR TITLE
fix: method parameter to string from bytes for promise and receipts

### DIFF
--- a/examples/cross-contract-low-level/src/lib.rs
+++ b/examples/cross-contract-low-level/src/lib.rs
@@ -45,21 +45,21 @@ impl CrossContract {
         let prepaid_gas = env::prepaid_gas();
         let promise0 = env::promise_create(
             account_id.clone(),
-            b"merge_sort",
+            "merge_sort",
             json!({ "arr": arr0 }).to_string().as_bytes(),
             0,
             prepaid_gas / 4,
         );
         let promise1 = env::promise_create(
             account_id.clone(),
-            b"merge_sort",
+            "merge_sort",
             json!({ "arr": arr1 }).to_string().as_bytes(),
             0,
             prepaid_gas / 4,
         );
         let promise2 = env::promise_and(&[promise0, promise1]);
         let promise3 =
-            env::promise_then(promise2, account_id.clone(), b"merge", &[], 0, prepaid_gas / 4);
+            env::promise_then(promise2, account_id.clone(), "merge", &[], 0, prepaid_gas / 4);
         env::promise_return(promise3);
     }
 
@@ -104,7 +104,7 @@ impl CrossContract {
     pub fn simple_call(&mut self, account_id: AccountId, message: String) {
         env::promise_create(
             account_id,
-            b"set_status",
+            "set_status",
             json!({ "message": message }).to_string().as_bytes(),
             0,
             SINGLE_CALL_GAS,
@@ -118,7 +118,7 @@ impl CrossContract {
         // Note, for a contract to simply call another contract (1) is sufficient.
         let promise0 = env::promise_create(
             account_id.clone(),
-            b"set_status",
+            "set_status",
             json!({ "message": message }).to_string().as_bytes(),
             0,
             SINGLE_CALL_GAS,
@@ -126,7 +126,7 @@ impl CrossContract {
         let promise1 = env::promise_then(
             promise0,
             env::current_account_id(),
-            b"check_promise",
+            "check_promise",
             json!({}).to_string().as_bytes(),
             0,
             SINGLE_CALL_GAS,
@@ -134,7 +134,7 @@ impl CrossContract {
         let promise2 = env::promise_then(
             promise1,
             account_id,
-            b"get_status",
+            "get_status",
             json!({ "account_id": env::signer_account_id() }).to_string().as_bytes(),
             0,
             SINGLE_CALL_GAS,

--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -237,7 +237,7 @@ pub fn keccak512(value: &[u8]) -> Vec<u8> {
 /// the given amount and gas.
 pub fn promise_create(
     account_id: AccountId,
-    method_name: &[u8],
+    method_name: &str,
     arguments: &[u8],
     amount: Balance,
     gas: Gas,
@@ -261,7 +261,7 @@ pub fn promise_create(
 pub fn promise_then(
     promise_idx: PromiseIndex,
     account_id: AccountId,
-    method_name: &[u8],
+    method_name: &str,
     arguments: &[u8],
     amount: Balance,
     gas: Gas,

--- a/near-sdk/src/environment/mock/external.rs
+++ b/near-sdk/src/environment/mock/external.rs
@@ -101,7 +101,9 @@ impl External for SdkExternal {
     ) -> Result<()> {
         self.receipts.get_mut(receipt_index as usize).unwrap().actions.push(
             VmAction::FunctionCall {
-                method_name,
+                method_name: String::from_utf8(method_name)
+                    // * Unwrap here is fine because this is only used in mocks
+                    .expect("method name must be utf8 bytes"),
                 args: arguments,
                 deposit: attached_deposit,
                 gas: Gas(prepaid_gas),

--- a/near-sdk/src/environment/mock/receipt.rs
+++ b/near-sdk/src/environment/mock/receipt.rs
@@ -15,7 +15,7 @@ pub enum VmAction {
         code: Vec<u8>,
     },
     FunctionCall {
-        method_name: Vec<u8>,
+        method_name: String,
         /// Most function calls still take JSON as input, so we'll keep it there as a string.
         /// Once we switch to borsh, we'll have to switch to base64 encoding.
         /// Right now, it is only used with standalone runtime when passing in Receipts or expecting


### PR DESCRIPTION
Switches remaining `method name` parameters to be a string instead of bytes. This does not affect any contracts except for the public API, to disallow non-utf8 bytes with this correct signature.

Should have noticed with https://github.com/near/near-sdk-rs/pull/515, but I missed it. This should come in soon to avoid asymmetry of functions