### PR TITLE
fix(mock): receiver id on receipt to be AccountId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - `promise_batch_action_function_call`, `Promise::function_call`, `promise_batch_action_add_key_with_function_call`, `Promise::add_access_key`, and `Promise::add_access_key_with_nonce` are afffected.
   - Instead of `b"method_name"` just use `"method_name"`, the bytes are enforced to be utf8 in the runtime.
 - Fixes `#[ext_contract]` codegen function signatures to take an `AccountId` instead of a generic `ToString` and converting unchecked to `AccountId`. [PR 518](https://github.com/near/near-sdk-rs/pull/518)
+- Fixes `receiver_id` in `mock::Receipt` to `AccountId` from string. This is a change to the type added in `4.0.0-pre.1`. [PR 529](https://github.com/near/near-sdk-rs/pull/529)
 
 ## `4.0.0-pre.1` [07-23-2021]
 * Implements new `LazyOption` type under `unstable` feature. Similar to `Lazy` but is optional to set a value. [PR 444](https://github.com/near/near-sdk-rs/pull/444).

--- a/near-sdk/src/environment/mock/external.rs
+++ b/near-sdk/src/environment/mock/external.rs
@@ -69,7 +69,11 @@ impl External for SdkExternal {
             return Err(HostError::InvalidReceiptIndex { receipt_index: *index }.into());
         }
         let res = self.receipts.len() as u64;
-        self.receipts.push(Receipt { receipt_indices, receiver_id, actions: vec![] });
+        self.receipts.push(Receipt {
+            receipt_indices,
+            receiver_id: AccountId::new_unchecked(receiver_id),
+            actions: vec![],
+        });
         Ok(res)
     }
 

--- a/near-sdk/src/environment/mock/receipt.rs
+++ b/near-sdk/src/environment/mock/receipt.rs
@@ -3,7 +3,7 @@ use crate::{AccountId, Balance, Gas, PublicKey};
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Receipt {
     pub receipt_indices: Vec<u64>,
-    pub receiver_id: String,
+    pub receiver_id: AccountId,
     pub actions: Vec<VmAction>,
 }
 
@@ -16,10 +16,6 @@ pub enum VmAction {
     },
     FunctionCall {
         method_name: Vec<u8>,
-        /// Most function calls still take JSON as input, so we'll keep it there as a string.
-        /// Once we switch to borsh, we'll have to switch to base64 encoding.
-        /// Right now, it is only used with standalone runtime when passing in Receipts or expecting
-        /// receipts. The workaround for input is to use a VMContext input.
         args: Vec<u8>,
         gas: Gas,
         deposit: Balance,


### PR DESCRIPTION
This was ported from internally, so missed that this is in fact an account id from #479.

Also removes some irrelevant docs