### PR TITLE
docs: specify that Balance is yoctoNEAR

### DIFF
--- a/near-sdk/src/types/primitives.rs
+++ b/near-sdk/src/types/primitives.rs
@@ -25,7 +25,7 @@ pub type BlockHeight = u64;
 pub type EpochHeight = u64;
 /// Shard index, from 0 to NUM_SHARDS - 1.
 pub type ShardId = u64;
-/// Balance is type for storing amounts of tokens.
+/// Balance is a type for storing amounts of tokens, specified in yoctoNEAR.
 pub type Balance = u128;
 
 /// Number of blocks in current group.


### PR DESCRIPTION
When I was reading the docs for Promises, I wasn't sure at first if `transfer` accepted yoctoNEAR or NEAR. This gives people a way to click through to `Balance` and find out.

Documenting it on `Balance` rather than `transfer` also means they'll be able to verify anywhere they encounter a `Balance` in the docs.