### PR TITLE
Approval should pass U64 in callback to external contract

### DIFF
--- a/near-contract-standards/src/non_fungible_token/approval/approval_impl.rs
+++ b/near-contract-standards/src/non_fungible_token/approval/approval_impl.rs
@@ -73,7 +73,7 @@ impl NonFungibleTokenApproval for NonFungibleToken {
             ext_approval_receiver::nft_on_approve(
                 token_id,
                 owner_id,
-                approval_id: approval_id.into(),
+                approval_id.into(),
                 msg,
                 account_id,
                 NO_DEPOSIT,

--- a/near-contract-standards/src/non_fungible_token/approval/approval_impl.rs
+++ b/near-contract-standards/src/non_fungible_token/approval/approval_impl.rs
@@ -8,6 +8,7 @@ use crate::non_fungible_token::utils::{
 };
 use crate::non_fungible_token::NonFungibleToken;
 use near_sdk::{assert_one_yocto, env, ext_contract, require, AccountId, Balance, Gas, Promise};
+use near_sdk::json_types::{U64};
 
 const GAS_FOR_NFT_APPROVE: Gas = Gas(10_000_000_000_000);
 const NO_DEPOSIT: Balance = 0;

--- a/near-contract-standards/src/non_fungible_token/approval/approval_impl.rs
+++ b/near-contract-standards/src/non_fungible_token/approval/approval_impl.rs
@@ -52,7 +52,7 @@ impl NonFungibleTokenApproval for NonFungibleToken {
         let next_approval_id_by_id = expect_approval(self.next_approval_id_by_id.as_mut());
         // update HashMap of approvals for this token
         let approved_account_ids = &mut approvals_by_id.get(&token_id).unwrap_or_default();
-        let approval_id: U64 = next_approval_id_by_id.get(&token_id).unwrap_or(1u64).into();
+        let approval_id: u64 = next_approval_id_by_id.get(&token_id).unwrap_or(1u64);
         let old_approval_id = approved_account_ids.insert(account_id.clone(), approval_id);
 
         // save updated approvals HashMap to contract's LookupMap
@@ -73,7 +73,7 @@ impl NonFungibleTokenApproval for NonFungibleToken {
             ext_approval_receiver::nft_on_approve(
                 token_id,
                 owner_id,
-                approval_id,
+                approval_id: approval_id.into(),
                 msg,
                 account_id,
                 NO_DEPOSIT,

--- a/near-contract-standards/src/non_fungible_token/approval/approval_impl.rs
+++ b/near-contract-standards/src/non_fungible_token/approval/approval_impl.rs
@@ -26,7 +26,7 @@ pub trait NonFungibleTokenReceiver {
         &mut self,
         token_id: TokenId,
         owner_id: AccountId,
-        approval_id: u64,
+        approval_id: U64,
         msg: String,
     );
 }
@@ -51,7 +51,7 @@ impl NonFungibleTokenApproval for NonFungibleToken {
         let next_approval_id_by_id = expect_approval(self.next_approval_id_by_id.as_mut());
         // update HashMap of approvals for this token
         let approved_account_ids = &mut approvals_by_id.get(&token_id).unwrap_or_default();
-        let approval_id: u64 = next_approval_id_by_id.get(&token_id).unwrap_or(1u64);
+        let approval_id: U64 = next_approval_id_by_id.get(&token_id).unwrap_or(1u64).into();
         let old_approval_id = approved_account_ids.insert(account_id.clone(), approval_id);
 
         // save updated approvals HashMap to contract's LookupMap

--- a/near-contract-standards/src/non_fungible_token/approval/approval_receiver.rs
+++ b/near-contract-standards/src/non_fungible_token/approval/approval_receiver.rs
@@ -20,7 +20,7 @@ pub trait NonFungibleTokenApprovalReceiver {
         &mut self,
         token_id: TokenId,
         owner_id: AccountId,
-        approval_id: u64,
+        approval_id: U64,
         msg: String,
     ) -> near_sdk::PromiseOrValue<String>; // TODO: how to make "any"?
 }

--- a/near-contract-standards/src/non_fungible_token/approval/approval_receiver.rs
+++ b/near-contract-standards/src/non_fungible_token/approval/approval_receiver.rs
@@ -1,5 +1,6 @@
 use crate::non_fungible_token::token::TokenId;
 use near_sdk::AccountId;
+use near_sdk::json_types::{U64};
 
 /// Approval receiver is the trait for the method called (or attempted to be called) when an NFT contract adds an approval for an account.
 pub trait NonFungibleTokenApprovalReceiver {


### PR DESCRIPTION
This fixes a breaking implementation where u64 was passed instead of U64.

There are already marketplaces and NFT contracts that routinely pass U64 for `nft_on_approve` so this must be fixed in the standard implementation.

While the initial intent was to have approval IDs always be numbers/u64 because

they're never expected to exceed the JSON limit of 2^53 and
we may as well therefore save some (minimal?) serialization/deserialization costs,
at this point many applications in the wild expect to receive approval_id: U64 [also, please link to such deployed apps]. Rather than attempting to change all of these deployed contracts, we believe we should instead update the standard because:

it is the more backward-compatible change – it is possible to go from strings to numbers but not numbers to strings;
it is more consistent – in general, we could always suggest using U64/U128 for arguments, even if they theoretically will never be that large, so that developers don't have to think about which one to use;
the gas savings [can we quantify this?] do not justify the costs mentioned in points 1-2 above.

TODO please test.

TODO might want to check `nft_is_approved` as well, consider U64. Not sure.