### PR TITLE
fix(mock): method names type within receipts to be Strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [unreleased]
+- mock: Update `method_names` field of `AddKeyWithFunctionCall` to a `Vec<String>` from `Vec<Vec<u8>>`. [PR 555](https://github.com/near/near-sdk-rs/pull/555)
+  - Method names were changed to be strings in `4.0.0-pre.2` but this one was missed
 
 ## `4.0.0-pre.2` [08-19-2021]
 - Update `panic` and `panic_utf8` syscall signatures to indicate they do not return. [PR 489](https://github.com/near/near-sdk-rs/pull/489)

--- a/near-sdk/src/environment/mock/external.rs
+++ b/near-sdk/src/environment/mock/external.rs
@@ -165,6 +165,8 @@ impl External for SdkExternal {
         method_names: Vec<Vec<u8>>,
     ) -> Result<()> {
         let public_key = PublicKey::try_from(public_key).unwrap();
+        let method_names =
+            method_names.into_iter().map(|s| String::from_utf8(s).unwrap()).collect();
         self.receipts.get_mut(receipt_index as usize).unwrap().actions.push(
             VmAction::AddKeyWithFunctionCall {
                 public_key,

--- a/near-sdk/src/environment/mock/receipt.rs
+++ b/near-sdk/src/environment/mock/receipt.rs
@@ -36,7 +36,7 @@ pub enum VmAction {
         nonce: u64,
         allowance: Option<Balance>,
         receiver_id: AccountId,
-        method_names: Vec<Vec<u8>>,
+        method_names: Vec<String>,
     },
     DeleteKey {
         public_key: PublicKey,


### PR DESCRIPTION
Noticed this was off when looking around. Method names throughout the sdk are strings, so this should be also.