### PR TITLE
feat(store): UnorderedMap v2 implementation

### DIFF
--- a/near-sdk/src/store/bucket/mod.rs
+++ b/near-sdk/src/store/bucket/mod.rs
@@ -101,6 +101,11 @@ where
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    /// Flushes cached changes to storage. This retains any cached values in memory.
+    pub fn flush(&mut self) {
+        self.elements.flush()
+    }
 }
 
 impl<T> Bucket<T>
@@ -169,11 +174,6 @@ where
         self.occupied_count -= 1;
 
         prev.into_value()
-    }
-
-    /// Flushes cached changes to storage. This retains any cached values in memory.
-    pub fn flush(&mut self) {
-        self.elements.flush()
     }
 
     /// Generates iterator for shared references to each value in the bucket.

--- a/near-sdk/src/store/lookup_map/entry.rs
+++ b/near-sdk/src/store/lookup_map/entry.rs
@@ -7,10 +7,7 @@ pub enum Entry<'a, K: 'a, V: 'a> {
     Vacant(VacantEntry<'a, K, V>),
 }
 
-impl<'a, K, V> Entry<'a, K, V>
-where
-    K: Ord,
-{
+impl<'a, K, V> Entry<'a, K, V> {
     /// Returns a reference to this entry's key.
     ///
     /// # Examples
@@ -154,7 +151,7 @@ where
 /// View into an occupied entry in a [`LookupMap`](super::LookupMap).
 /// This is part of the [`Entry`] enum.
 pub struct OccupiedEntry<'a, K, V> {
-    pub(crate) key: K,
+    pub(super) key: K,
     pub(super) entry: &'a mut CacheEntry<V>,
 }
 
@@ -315,14 +312,11 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
 /// View into a vacant entry in a [`LookupMap`](super::LookupMap).
 /// This is part of the [`Entry`] enum.
 pub struct VacantEntry<'a, K, V> {
-    pub(crate) key: K,
+    pub(super) key: K,
     pub(super) entry: &'a mut CacheEntry<V>,
 }
 
-impl<'a, K, V> VacantEntry<'a, K, V>
-where
-    K: Ord,
-{
+impl<'a, K, V> VacantEntry<'a, K, V> {
     /// Gets a reference to the key that would be used when inserting a value
     /// through the `VacantEntry`.
     pub fn key(&self) -> &K {

--- a/near-sdk/src/store/lookup_map/mod.rs
+++ b/near-sdk/src/store/lookup_map/mod.rs
@@ -238,7 +238,7 @@ where
         entry.value().as_ref()
     }
 
-    fn get_mut_inner<Q: ?Sized>(&mut self, k: &Q) -> &mut CacheEntry<V>
+    pub(crate) fn get_mut_inner<Q: ?Sized>(&mut self, k: &Q) -> &mut CacheEntry<V>
     where
         K: Borrow<Q>,
         Q: BorshSerialize + ToOwned<Owned = K>,

--- a/near-sdk/src/store/mod.rs
+++ b/near-sdk/src/store/mod.rs
@@ -10,6 +10,9 @@ pub use vec::Vector;
 pub mod lookup_map;
 pub use self::lookup_map::LookupMap;
 
+pub mod unordered_map;
+pub use self::unordered_map::UnorderedMap;
+
 mod index_map;
 pub(crate) use self::index_map::IndexMap;
 

--- a/near-sdk/src/store/unordered_map/entry.rs
+++ b/near-sdk/src/store/unordered_map/entry.rs
@@ -29,7 +29,7 @@ where
 
 impl<'a, K, V> Entry<'a, K, V>
 where
-    K: Ord + BorshSerialize,
+    K: BorshSerialize,
 {
     /// Returns a reference to this entry's key.
     ///
@@ -51,7 +51,7 @@ where
 
 impl<'a, K, V> Entry<'a, K, V>
 where
-    K: Ord + BorshSerialize + BorshDeserialize + Clone,
+    K: BorshSerialize + BorshDeserialize + Clone,
 {
     /// Ensures a value is in the entry by inserting the default if empty, and returns
     /// a mutable reference to the value in the entry.
@@ -360,7 +360,7 @@ where
 
 impl<'a, K, V> VacantEntry<'a, K, V>
 where
-    K: Ord + BorshSerialize,
+    K: BorshSerialize,
 {
     /// Gets a reference to the key that would be used when inserting a value
     /// through the `VacantEntry`.

--- a/near-sdk/src/store/unordered_map/entry.rs
+++ b/near-sdk/src/store/unordered_map/entry.rs
@@ -195,7 +195,7 @@ where
 {
     /// Gets a reference to the key in the entry.
     pub fn key(&self) -> &K {
-        &self.value_entry.key()
+        self.value_entry.key()
     }
 
     /// Take the ownership of the key and value from the map.

--- a/near-sdk/src/store/unordered_map/entry.rs
+++ b/near-sdk/src/store/unordered_map/entry.rs
@@ -1,24 +1,44 @@
-use crate::env::abort;
-use crate::utils::CacheEntry;
+use borsh::{BorshDeserialize, BorshSerialize};
+
+use super::ValueAndIndex;
+use crate::store::{lookup_map as lm, Bucket};
 
 /// A view into a single entry in the map, which can be vacant or occupied.
-pub enum Entry<'a, K: 'a, V: 'a> {
+pub enum Entry<'a, K: 'a, V: 'a>
+where
+    K: BorshSerialize,
+{
     Occupied(OccupiedEntry<'a, K, V>),
     Vacant(VacantEntry<'a, K, V>),
 }
 
 impl<'a, K, V> Entry<'a, K, V>
 where
-    K: Ord,
+    K: BorshSerialize,
+{
+    pub(super) fn new(
+        lm_entry: lm::Entry<'a, K, ValueAndIndex<V>>,
+        keys: &'a mut Bucket<K>,
+    ) -> Self {
+        match lm_entry {
+            lm::Entry::Occupied(value_entry) => Self::Occupied(OccupiedEntry { value_entry, keys }),
+            lm::Entry::Vacant(value_entry) => Self::Vacant(VacantEntry { value_entry, keys }),
+        }
+    }
+}
+
+impl<'a, K, V> Entry<'a, K, V>
+where
+    K: Ord + BorshSerialize,
 {
     /// Returns a reference to this entry's key.
     ///
     /// # Examples
     ///
     /// ```
-    /// use near_sdk::store::LookupMap;
+    /// use near_sdk::store::UnorderedMap;
     ///
-    /// let mut map: LookupMap<String, u32> = LookupMap::new(b"m");
+    /// let mut map: UnorderedMap<String, u32> = UnorderedMap::new(b"m");
     /// assert_eq!(map.entry("poneyland".to_string()).key(), &"poneyland");
     /// ```
     pub fn key(&self) -> &K {
@@ -27,16 +47,21 @@ where
             Entry::Vacant(entry) => entry.key(),
         }
     }
+}
 
+impl<'a, K, V> Entry<'a, K, V>
+where
+    K: Ord + BorshSerialize + BorshDeserialize + Clone,
+{
     /// Ensures a value is in the entry by inserting the default if empty, and returns
     /// a mutable reference to the value in the entry.
     ///
     /// # Examples
     ///
     /// ```
-    /// use near_sdk::store::LookupMap;
+    /// use near_sdk::store::UnorderedMap;
     ///
-    /// let mut map: LookupMap<String, u32> = LookupMap::new(b"m");
+    /// let mut map: UnorderedMap<String, u32> = UnorderedMap::new(b"m");
     ///
     /// map.entry("poneyland".to_string()).or_insert(3);
     /// assert_eq!(map["poneyland"], 3);
@@ -54,9 +79,9 @@ where
     /// # Examples
     ///
     /// ```
-    /// use near_sdk::store::LookupMap;
+    /// use near_sdk::store::UnorderedMap;
     ///
-    /// let mut map: LookupMap<String, String> = LookupMap::new(b"m");
+    /// let mut map: UnorderedMap<String, String> = UnorderedMap::new(b"m");
     /// let s = "hoho".to_string();
     ///
     /// map.entry("poneyland".to_string()).or_insert_with(|| s);
@@ -77,15 +102,18 @@ where
     /// # Examples
     ///
     /// ```
-    /// use near_sdk::store::LookupMap;
+    /// use near_sdk::store::UnorderedMap;
     ///
-    /// let mut map: LookupMap<String, u32> = LookupMap::new(b"m");
+    /// let mut map: UnorderedMap<String, u32> = UnorderedMap::new(b"m");
     ///
     /// map.entry("poneyland".to_string()).or_insert_with_key(|key| key.chars().count() as u32);
     ///
     /// assert_eq!(map["poneyland"], 9);
     /// ```
-    pub fn or_insert_with_key<F: FnOnce(&K) -> V>(self, default: F) -> &'a mut V {
+    pub fn or_insert_with_key<F: FnOnce(&K) -> V>(self, default: F) -> &'a mut V
+    where
+        K: BorshDeserialize,
+    {
         match self {
             Self::Occupied(entry) => entry.into_mut(),
             Self::Vacant(entry) => {
@@ -102,9 +130,9 @@ where
     ///
     /// ```
     /// # fn main() {
-    /// use near_sdk::store::LookupMap;
+    /// use near_sdk::store::UnorderedMap;
     ///
-    /// let mut map: LookupMap<String, Option<u32>> = LookupMap::new(b"m");
+    /// let mut map: UnorderedMap<String, Option<u32>> = UnorderedMap::new(b"m");
     /// map.entry("poneyland".to_string()).or_default();
     ///
     /// assert_eq!(map["poneyland"], None);
@@ -126,9 +154,9 @@ where
     /// # Examples
     ///
     /// ```
-    /// use near_sdk::store::LookupMap;
+    /// use near_sdk::store::UnorderedMap;
     ///
-    /// let mut map: LookupMap<String, u32> = LookupMap::new(b"m");
+    /// let mut map: UnorderedMap<String, u32> = UnorderedMap::new(b"m");
     ///
     /// map.entry("poneyland".to_string())
     ///    .and_modify(|e| { *e += 1 })
@@ -151,17 +179,23 @@ where
     }
 }
 
-/// View into an occupied entry in a [`LookupMap`](super::LookupMap).
+/// View into an occupied entry in a [`UnorderedMap`](super::UnorderedMap).
 /// This is part of the [`Entry`] enum.
-pub struct OccupiedEntry<'a, K, V> {
-    pub(crate) key: K,
-    pub(super) entry: &'a mut CacheEntry<V>,
+pub struct OccupiedEntry<'a, K, V>
+where
+    K: BorshSerialize,
+{
+    value_entry: lm::OccupiedEntry<'a, K, ValueAndIndex<V>>,
+    keys: &'a mut Bucket<K>,
 }
 
-impl<'a, K, V> OccupiedEntry<'a, K, V> {
+impl<'a, K, V> OccupiedEntry<'a, K, V>
+where
+    K: BorshSerialize,
+{
     /// Gets a reference to the key in the entry.
     pub fn key(&self) -> &K {
-        &self.key
+        &self.value_entry.key()
     }
 
     /// Take the ownership of the key and value from the map.
@@ -169,10 +203,10 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     /// # Examples
     ///
     /// ```
-    /// use near_sdk::store::LookupMap;
-    /// use near_sdk::store::lookup_map::Entry;
+    /// use near_sdk::store::UnorderedMap;
+    /// use near_sdk::store::unordered_map::Entry;
     ///
-    /// let mut map: LookupMap<String, u32> = LookupMap::new(b"m");
+    /// let mut map: UnorderedMap<String, u32> = UnorderedMap::new(b"m");
     /// map.entry("poneyland".to_string()).or_insert(12);
     ///
     /// if let Entry::Occupied(o) = map.entry("poneyland".to_string()) {
@@ -182,11 +216,13 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     ///
     /// assert_eq!(map.contains_key("poneyland"), false);
     /// ```
-    pub fn remove_entry(self) -> (K, V) {
-        // OnceCell guaranteed to be filled and value to be `Some` in occupied entry
-        let value = self.entry.value_mut().take().unwrap_or_else(|| abort());
-
-        (self.key, value)
+    pub fn remove_entry(self) -> (K, V)
+    where
+        K: BorshDeserialize,
+    {
+        let (key, value) = self.value_entry.remove_entry();
+        self.keys.remove(value.key_index);
+        (key, value.value)
     }
 
     /// Gets a reference to the value in the entry.
@@ -194,10 +230,10 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     /// # Examples
     ///
     /// ```
-    /// use near_sdk::store::LookupMap;
-    /// use near_sdk::store::lookup_map::Entry;
+    /// use near_sdk::store::UnorderedMap;
+    /// use near_sdk::store::unordered_map::Entry;
     ///
-    /// let mut map: LookupMap<String, u32> = LookupMap::new(b"m");
+    /// let mut map: UnorderedMap<String, u32> = UnorderedMap::new(b"m");
     /// map.entry("poneyland".to_string()).or_insert(12);
     ///
     /// if let Entry::Occupied(o) = map.entry("poneyland".to_string()) {
@@ -205,8 +241,7 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     /// }
     /// ```
     pub fn get(&self) -> &V {
-        // Value guaranteed to be `Some` as it's occupied
-        self.entry.value().as_ref().unwrap_or_else(|| abort())
+        &self.value_entry.get().value
     }
 
     /// Gets a mutable reference to the value in the entry.
@@ -219,10 +254,10 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     /// # Examples
     ///
     /// ```
-    /// use near_sdk::store::LookupMap;
-    /// use near_sdk::store::lookup_map::Entry;
+    /// use near_sdk::store::UnorderedMap;
+    /// use near_sdk::store::unordered_map::Entry;
     ///
-    /// let mut map: LookupMap<String, u32> = LookupMap::new(b"m");
+    /// let mut map: UnorderedMap<String, u32> = UnorderedMap::new(b"m");
     /// map.entry("poneyland".to_string()).or_insert(12);
     ///
     /// assert_eq!(map["poneyland"], 12);
@@ -237,8 +272,7 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     /// assert_eq!(map["poneyland"], 24);
     /// ```
     pub fn get_mut(&mut self) -> &mut V {
-        // Value guaranteed to be `Some` as it's occupied
-        self.entry.value_mut().as_mut().unwrap_or_else(|| abort())
+        &mut self.value_entry.get_mut().value
     }
 
     /// Converts the `OccupiedEntry` into a mutable reference to the value in the entry
@@ -251,10 +285,10 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     /// # Examples
     ///
     /// ```
-    /// use near_sdk::store::LookupMap;
-    /// use near_sdk::store::lookup_map::Entry;
+    /// use near_sdk::store::UnorderedMap;
+    /// use near_sdk::store::unordered_map::Entry;
     ///
-    /// let mut map: LookupMap<String, u32> = LookupMap::new(b"m");
+    /// let mut map: UnorderedMap<String, u32> = UnorderedMap::new(b"m");
     /// map.entry("poneyland".to_string()).or_insert(12);
     ///
     /// assert_eq!(map["poneyland"], 12);
@@ -265,8 +299,7 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     /// assert_eq!(map["poneyland"], 22);
     /// ```
     pub fn into_mut(self) -> &'a mut V {
-        // If entry is occupied, value is guaranteed to be `Some`
-        self.entry.value_mut().as_mut().unwrap_or_else(|| abort())
+        &mut self.value_entry.into_mut().value
     }
 
     /// Sets the value of the entry, and returns the entry's old value.
@@ -274,10 +307,10 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     /// # Examples
     ///
     /// ```
-    /// use near_sdk::store::LookupMap;
-    /// use near_sdk::store::lookup_map::Entry;
+    /// use near_sdk::store::UnorderedMap;
+    /// use near_sdk::store::unordered_map::Entry;
     ///
-    /// let mut map: LookupMap<String, u32> = LookupMap::new(b"m");
+    /// let mut map: UnorderedMap<String, u32> = UnorderedMap::new(b"m");
     /// map.entry("poneyland".to_string()).or_insert(12);
     ///
     /// if let Entry::Occupied(mut o) = map.entry("poneyland".to_string()) {
@@ -287,7 +320,7 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     /// assert_eq!(map["poneyland"], 15);
     /// ```
     pub fn insert(&mut self, value: V) -> V {
-        self.entry.replace(Some(value)).unwrap_or_else(|| abort())
+        core::mem::replace(&mut self.value_entry.get_mut().value, value)
     }
 
     /// Takes the value out of the entry, and returns it.
@@ -295,10 +328,10 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     /// # Examples
     ///
     /// ```
-    /// use near_sdk::store::LookupMap;
-    /// use near_sdk::store::lookup_map::Entry;
+    /// use near_sdk::store::UnorderedMap;
+    /// use near_sdk::store::unordered_map::Entry;
     ///
-    /// let mut map: LookupMap<String, u32> = LookupMap::new(b"m");
+    /// let mut map: UnorderedMap<String, u32> = UnorderedMap::new(b"m");
     /// map.entry("poneyland".to_string()).or_insert(12);
     ///
     /// if let Entry::Occupied(o) = map.entry("poneyland".to_string()) {
@@ -307,26 +340,32 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     ///
     /// assert_eq!(map.contains_key("poneyland"), false);
     /// ```
-    pub fn remove(self) -> V {
+    pub fn remove(self) -> V
+    where
+        K: BorshDeserialize,
+    {
         self.remove_entry().1
     }
 }
 
-/// View into a vacant entry in a [`LookupMap`](super::LookupMap).
+/// View into a vacant entry in a [`UnorderedMap`](super::UnorderedMap).
 /// This is part of the [`Entry`] enum.
-pub struct VacantEntry<'a, K, V> {
-    pub(crate) key: K,
-    pub(super) entry: &'a mut CacheEntry<V>,
+pub struct VacantEntry<'a, K, V>
+where
+    K: BorshSerialize,
+{
+    value_entry: lm::VacantEntry<'a, K, ValueAndIndex<V>>,
+    keys: &'a mut Bucket<K>,
 }
 
 impl<'a, K, V> VacantEntry<'a, K, V>
 where
-    K: Ord,
+    K: Ord + BorshSerialize,
 {
     /// Gets a reference to the key that would be used when inserting a value
     /// through the `VacantEntry`.
     pub fn key(&self) -> &K {
-        &self.key
+        self.value_entry.key()
     }
 
     /// Take ownership of the key.
@@ -334,17 +373,17 @@ where
     /// # Examples
     ///
     /// ```
-    /// use near_sdk::store::LookupMap;
-    /// use near_sdk::store::lookup_map::Entry;
+    /// use near_sdk::store::UnorderedMap;
+    /// use near_sdk::store::unordered_map::Entry;
     ///
-    /// let mut map: LookupMap<String, u32> = LookupMap::new(b"m");
+    /// let mut map: UnorderedMap<String, u32> = UnorderedMap::new(b"m");
     ///
     /// if let Entry::Vacant(v) = map.entry("poneyland".to_string()) {
     ///     v.into_key();
     /// }
     /// ```
     pub fn into_key(self) -> K {
-        self.key
+        self.value_entry.into_key()
     }
 
     /// Sets the value of the entry with the `VacantEntry`'s key,
@@ -353,19 +392,22 @@ where
     /// # Examples
     ///
     /// ```
-    /// use near_sdk::store::LookupMap;
-    /// use near_sdk::store::lookup_map::Entry;
+    /// use near_sdk::store::UnorderedMap;
+    /// use near_sdk::store::unordered_map::Entry;
     ///
-    /// let mut map: LookupMap<String, u32> = LookupMap::new(b"m");
+    /// let mut map: UnorderedMap<String, u32> = UnorderedMap::new(b"m");
     ///
     /// if let Entry::Vacant(o) = map.entry("poneyland".to_string()) {
     ///     o.insert(37);
     /// }
     /// assert_eq!(map["poneyland"], 37);
     /// ```
-    pub fn insert(self, value: V) -> &'a mut V {
-        self.entry.replace(Some(value));
-        // Insertion done above, cache is filled and the value is Some
-        self.entry.value_mut().as_mut().unwrap_or_else(|| abort())
+    pub fn insert(self, value: V) -> &'a mut V
+    where
+        K: BorshDeserialize + Clone,
+    {
+        // Vacant entry so we know key doesn't exist
+        let key_index = self.keys.insert(self.key().to_owned());
+        &mut self.value_entry.insert(ValueAndIndex { value, key_index }).value
     }
 }

--- a/near-sdk/src/store/unordered_map/impls.rs
+++ b/near-sdk/src/store/unordered_map/impls.rs
@@ -2,13 +2,13 @@ use std::borrow::Borrow;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
-use super::{LookupMap, ERR_NOT_EXIST};
+use super::{UnorderedMap, ERR_NOT_EXIST};
 use crate::{crypto_hash::CryptoHasher, env};
 
-impl<K, V, H> Extend<(K, V)> for LookupMap<K, V, H>
+impl<K, V, H> Extend<(K, V)> for UnorderedMap<K, V, H>
 where
-    K: BorshSerialize + Ord,
-    V: BorshSerialize,
+    K: BorshSerialize + Ord + BorshDeserialize + Clone,
+    V: BorshSerialize + BorshDeserialize,
     H: CryptoHasher<Digest = [u8; 32]>,
 {
     fn extend<I>(&mut self, iter: I)
@@ -16,12 +16,12 @@ where
         I: IntoIterator<Item = (K, V)>,
     {
         for (key, value) in iter {
-            self.set(key, Some(value))
+            self.insert(key, value);
         }
     }
 }
 
-impl<K, V, H, Q: ?Sized> core::ops::Index<&Q> for LookupMap<K, V, H>
+impl<K, V, H, Q: ?Sized> core::ops::Index<&Q> for UnorderedMap<K, V, H>
 where
     K: BorshSerialize + Ord + Clone + Borrow<Q>,
     V: BorshSerialize + BorshDeserialize,
@@ -40,14 +40,14 @@ where
     }
 }
 
-impl<K, V, H, Q: ?Sized> core::ops::IndexMut<&Q> for LookupMap<K, V, H>
+impl<K, V, H, Q: ?Sized> core::ops::IndexMut<&Q> for UnorderedMap<K, V, H>
 where
     K: BorshSerialize + Ord + Clone + Borrow<Q>,
     V: BorshSerialize + BorshDeserialize,
     H: CryptoHasher<Digest = [u8; 32]>,
     Q: BorshSerialize + ToOwned<Owned = K>,
 {
-    /// Returns reference to value corresponding to key.
+    /// Returns exclusive reference to value corresponding to key.
     ///
     /// # Panics
     ///

--- a/near-sdk/src/store/unordered_map/iter.rs
+++ b/near-sdk/src/store/unordered_map/iter.rs
@@ -345,3 +345,80 @@ where
         self.inner.nth_back(n).map(|(_, v)| v)
     }
 }
+
+/// A mutable iterator over values of a [`UnorderedMap`].
+///
+/// This `struct` is created by the `values_mut` method on [`UnorderedMap`].
+pub struct ValuesMut<'a, K, V, H>
+where
+    K: BorshSerialize + Ord + BorshDeserialize,
+    V: BorshSerialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+    inner: IterMut<'a, K, V, H>,
+}
+
+impl<'a, K, V, H> ValuesMut<'a, K, V, H>
+where
+    K: BorshSerialize + Ord + BorshDeserialize,
+    V: BorshSerialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+    pub(super) fn new(map: &'a mut UnorderedMap<K, V, H>) -> Self {
+        Self { inner: map.iter_mut() }
+    }
+}
+
+impl<'a, K, V, H> Iterator for ValuesMut<'a, K, V, H>
+where
+    K: BorshSerialize + Ord + BorshDeserialize + Clone,
+    V: BorshSerialize + BorshDeserialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+    type Item = &'a mut V;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        <Self as Iterator>::nth(self, 0)
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.inner.nth(n).map(|(_, v)| v)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+
+    fn count(self) -> usize {
+        self.inner.count()
+    }
+}
+
+impl<'a, K, V, H> ExactSizeIterator for ValuesMut<'a, K, V, H>
+where
+    K: BorshSerialize + Ord + BorshDeserialize + Clone,
+    V: BorshSerialize + BorshDeserialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+}
+impl<'a, K, V, H> FusedIterator for ValuesMut<'a, K, V, H>
+where
+    K: BorshSerialize + Ord + BorshDeserialize + Clone,
+    V: BorshSerialize + BorshDeserialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+}
+
+impl<'a, K, V, H> DoubleEndedIterator for ValuesMut<'a, K, V, H>
+where
+    K: BorshSerialize + Ord + BorshDeserialize + Clone,
+    V: BorshSerialize + BorshDeserialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        <Self as DoubleEndedIterator>::nth_back(self, 0)
+    }
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.inner.nth_back(n).map(|(_, v)| v)
+    }
+}

--- a/near-sdk/src/store/unordered_map/iter.rs
+++ b/near-sdk/src/store/unordered_map/iter.rs
@@ -35,8 +35,7 @@ where
 
 /// An iterator over elements of a [`UnorderedMap`].
 ///
-/// This `struct` is created by the `iter` method on [`UnorderedMap`]. See its
-/// documentation for more.
+/// This `struct` is created by the `iter` method on [`UnorderedMap`].
 pub struct Iter<'a, K, V, H>
 where
     K: BorshSerialize + Ord + BorshDeserialize,
@@ -122,8 +121,7 @@ where
 
 /// A mutable iterator over elements of a [`UnorderedMap`].
 ///
-/// This `struct` is created by the `iter_mut` method on [`UnorderedMap`]. See its
-/// documentation for more.
+/// This `struct` is created by the `iter_mut` method on [`UnorderedMap`].
 pub struct IterMut<'a, K, V, H>
 where
     K: BorshSerialize + Ord + BorshDeserialize,
@@ -220,8 +218,7 @@ where
 
 /// An iterator over the keys of a [`UnorderedMap`].
 ///
-/// This `struct` is created by the `keys` method on [`UnorderedMap`]. See its
-/// documentation for more.
+/// This `struct` is created by the `keys` method on [`UnorderedMap`].
 pub struct Keys<'a, K: 'a>
 where
     K: BorshSerialize + BorshDeserialize,
@@ -269,5 +266,82 @@ where
 {
     fn next_back(&mut self) -> Option<&'a K> {
         self.inner.next_back()
+    }
+}
+
+/// An iterator over the values of a [`UnorderedMap`].
+///
+/// This `struct` is created by the `values` method on [`UnorderedMap`].
+pub struct Values<'a, K, V, H>
+where
+    K: BorshSerialize + Ord + BorshDeserialize,
+    V: BorshSerialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+    inner: Iter<'a, K, V, H>,
+}
+
+impl<'a, K, V, H> Values<'a, K, V, H>
+where
+    K: BorshSerialize + Ord + BorshDeserialize,
+    V: BorshSerialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+    pub(super) fn new(map: &'a UnorderedMap<K, V, H>) -> Self {
+        Self { inner: map.iter() }
+    }
+}
+
+impl<'a, K, V, H> Iterator for Values<'a, K, V, H>
+where
+    K: BorshSerialize + Ord + BorshDeserialize + Clone,
+    V: BorshSerialize + BorshDeserialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+    type Item = &'a V;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        <Self as Iterator>::nth(self, 0)
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.inner.nth(n).map(|(_, v)| v)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+
+    fn count(self) -> usize {
+        self.inner.count()
+    }
+}
+
+impl<'a, K, V, H> ExactSizeIterator for Values<'a, K, V, H>
+where
+    K: BorshSerialize + Ord + BorshDeserialize + Clone,
+    V: BorshSerialize + BorshDeserialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+}
+impl<'a, K, V, H> FusedIterator for Values<'a, K, V, H>
+where
+    K: BorshSerialize + Ord + BorshDeserialize + Clone,
+    V: BorshSerialize + BorshDeserialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+}
+
+impl<'a, K, V, H> DoubleEndedIterator for Values<'a, K, V, H>
+where
+    K: BorshSerialize + Ord + BorshDeserialize + Clone,
+    V: BorshSerialize + BorshDeserialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        <Self as DoubleEndedIterator>::nth_back(self, 0)
+    }
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.inner.nth_back(n).map(|(_, v)| v)
     }
 }

--- a/near-sdk/src/store/unordered_map/iter.rs
+++ b/near-sdk/src/store/unordered_map/iter.rs
@@ -33,7 +33,10 @@ where
     }
 }
 
-/// An iterator over elements in the storage bucket. This only yields the occupied entries.
+/// An iterator over elements of a [`UnorderedMap`].
+///
+/// This `struct` is created by the `iter` method on [`UnorderedMap`]. See its
+/// documentation for more.
 pub struct Iter<'a, K, V, H>
 where
     K: BorshSerialize + Ord + BorshDeserialize,
@@ -116,7 +119,11 @@ where
         Some((key, &entry.value))
     }
 }
-/// An iterator over elements in the storage bucket. This only yields the occupied entries.
+
+/// A mutable iterator over elements of a [`UnorderedMap`].
+///
+/// This `struct` is created by the `iter_mut` method on [`UnorderedMap`]. See its
+/// documentation for more.
 pub struct IterMut<'a, K, V, H>
 where
     K: BorshSerialize + Ord + BorshDeserialize,
@@ -208,5 +215,59 @@ where
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
         let key = self.keys.nth_back(n)?;
         Some(self.get_entry_mut(key))
+    }
+}
+
+/// An iterator over the keys of a [`UnorderedMap`].
+///
+/// This `struct` is created by the `keys` method on [`UnorderedMap`]. See its
+/// documentation for more.
+pub struct Keys<'a, K: 'a>
+where
+    K: BorshSerialize + BorshDeserialize,
+{
+    inner: bucket::Iter<'a, K>,
+}
+
+impl<'a, K> Keys<'a, K>
+where
+    K: BorshSerialize + BorshDeserialize,
+{
+    pub(super) fn new<V, H>(map: &'a UnorderedMap<K, V, H>) -> Self
+    where
+        K: Ord,
+        V: BorshSerialize,
+        H: CryptoHasher<Digest = [u8; 32]>,
+    {
+        Self { inner: map.keys.iter() }
+    }
+}
+
+impl<'a, K> Iterator for Keys<'a, K>
+where
+    K: BorshSerialize + BorshDeserialize,
+{
+    type Item = &'a K;
+
+    fn next(&mut self) -> Option<&'a K> {
+        self.inner.next()
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+    fn count(self) -> usize {
+        self.inner.count()
+    }
+}
+
+impl<'a, K> ExactSizeIterator for Keys<'a, K> where K: BorshSerialize + BorshDeserialize {}
+impl<'a, K> FusedIterator for Keys<'a, K> where K: BorshSerialize + BorshDeserialize {}
+
+impl<'a, K> DoubleEndedIterator for Keys<'a, K>
+where
+    K: BorshSerialize + Ord + BorshDeserialize,
+{
+    fn next_back(&mut self) -> Option<&'a K> {
+        self.inner.next_back()
     }
 }

--- a/near-sdk/src/store/unordered_map/iter.rs
+++ b/near-sdk/src/store/unordered_map/iter.rs
@@ -1,0 +1,206 @@
+use std::iter::FusedIterator;
+
+use borsh::{BorshDeserialize, BorshSerialize};
+
+use super::{CryptoHasher, LookupMap, UnorderedMap, ValueAndIndex, ERR_INCONSISTENT_STATE};
+use crate::{env, store::bucket};
+
+impl<'a, K, V, H> IntoIterator for &'a UnorderedMap<K, V, H>
+where
+    K: BorshSerialize + Ord + BorshDeserialize + Clone,
+    V: BorshSerialize + BorshDeserialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+    type Item = (&'a K, &'a V);
+    type IntoIter = Iter<'a, K, V, H>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+// impl<'a, K, V, H> IntoIterator for &'a mut UnorderedMap<K, V, H>
+// where
+//     K: BorshSerialize + Ord + BorshDeserialize,
+//     V: BorshSerialize,
+//     H: CryptoHasher<Digest = [u8; 32]>,
+// {
+//     type Item = (&'a mut K, &'a mut V);
+//     type IntoIter = IterMut<'a, K, V, H>;
+
+//     fn into_iter(self) -> Self::IntoIter {
+//         self.iter_mut()
+//     }
+// }
+
+/// An iterator over elements in the storage bucket. This only yields the occupied entries.
+pub struct Iter<'a, K, V, H>
+where
+    K: BorshSerialize + Ord + BorshDeserialize,
+    V: BorshSerialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+    /// Values iterator which contains empty and filled cells.
+    keys: bucket::Iter<'a, K>,
+    /// Amount of valid elements left to iterate.
+    values: &'a LookupMap<K, ValueAndIndex<V>, H>,
+}
+
+impl<'a, K, V, H> Iter<'a, K, V, H>
+where
+    K: BorshSerialize + Ord + BorshDeserialize,
+    V: BorshSerialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+    pub(super) fn new(map: &'a UnorderedMap<K, V, H>) -> Self {
+        Self { keys: map.keys.iter(), values: &map.values }
+    }
+}
+
+impl<'a, K, V, H> Iterator for Iter<'a, K, V, H>
+where
+    K: BorshSerialize + Ord + BorshDeserialize + Clone,
+    V: BorshSerialize + BorshDeserialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+    type Item = (&'a K, &'a V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let key = self.keys.next()?;
+        let entry = self.values.get(key).unwrap_or_else(|| env::panic_str(ERR_INCONSISTENT_STATE));
+
+        Some((key, &entry.value))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.keys.size_hint()
+    }
+
+    fn count(self) -> usize {
+        self.keys.count()
+    }
+}
+
+impl<'a, K, V, H> ExactSizeIterator for Iter<'a, K, V, H>
+where
+    K: BorshSerialize + Ord + BorshDeserialize + Clone,
+    V: BorshSerialize + BorshDeserialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+}
+impl<'a, K, V, H> FusedIterator for Iter<'a, K, V, H>
+where
+    K: BorshSerialize + Ord + BorshDeserialize + Clone,
+    V: BorshSerialize + BorshDeserialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+}
+
+impl<'a, K, V, H> DoubleEndedIterator for Iter<'a, K, V, H>
+where
+    K: BorshSerialize + Ord + BorshDeserialize + Clone,
+    V: BorshSerialize + BorshDeserialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let key = self.keys.next_back()?;
+        let entry = self.values.get(key).unwrap_or_else(|| env::panic_str(ERR_INCONSISTENT_STATE));
+
+        Some((key, &entry.value))
+    }
+}
+
+// /// An iterator over elements in the storage bucket. This only yields the occupied entries.
+// pub struct IterMut<'a, K, V, H>
+// where
+//     K: BorshSerialize + Ord + BorshDeserialize,
+//     V: BorshSerialize,
+//     H: CryptoHasher<Digest = [u8; 32]>,
+// {
+//     /// Values iterator which contains empty and filled cells.
+//     values: bucket::IterMut<'a, Container<K, V, H>>,
+//     /// Amount of valid elements left to iterate.
+//     elements_left: u32,
+// }
+
+// impl<'a, K, V, H> IterMut<'a, K, V, H>
+// where
+//     T: BorshDeserialize + BorshSerialize,
+// {
+//     pub(super) fn new(bucket: &'a mut UnorderedMap<K, V, H>) -> Self {
+//         Self { values: bucket.elements.iter_mut(), elements_left: bucket.occupied_count }
+//     }
+//     fn decrement_elements(&mut self) {
+//         self.elements_left = self
+//             .elements_left
+//             .checked_sub(1)
+//             .unwrap_or_else(|| env::panic_str(ERR_INCONSISTENT_STATE));
+//     }
+// }
+
+// impl<'a, K, V, H> Iterator for IterMut<'a, K, V, H>
+// where
+//     T: BorshDeserialize + BorshSerialize,
+// {
+//     type Item = &'a mut T;
+
+//     fn next(&mut self) -> Option<Self::Item> {
+//         if self.elements_left == 0 {
+//             return None;
+//         }
+//         loop {
+//             match self.values.next() {
+//                 Some(Container::Empty { .. }) => continue,
+//                 Some(Container::Occupied(value)) => {
+//                     self.decrement_elements();
+//                     return Some(value);
+//                 }
+//                 None => {
+//                     // This should never be hit, because if 0 occupied elements, should have
+//                     // returned before the loop
+//                     env::panic_str(ERR_INCONSISTENT_STATE)
+//                 }
+//             }
+//         }
+//     }
+
+//     fn size_hint(&self) -> (usize, Option<usize>) {
+//         let elements_left = self.elements_left as usize;
+//         (elements_left, Some(elements_left))
+//     }
+
+//     fn count(self) -> usize {
+//         self.elements_left as usize
+//     }
+// }
+
+// impl<'a, K, V, H> ExactSizeIterator for IterMut<'a, K, V, H> where
+//     T: BorshSerialize + BorshDeserialize
+// {
+// }
+// impl<'a, K, V, H> FusedIterator for IterMut<'a, K, V, H> where T: BorshSerialize + BorshDeserialize {}
+
+// impl<'a, K, V, H> DoubleEndedIterator for IterMut<'a, K, V, H>
+// where
+//     T: BorshSerialize + BorshDeserialize,
+// {
+//     fn next_back(&mut self) -> Option<Self::Item> {
+//         if self.elements_left == 0 {
+//             return None;
+//         }
+//         loop {
+//             match self.values.next_back() {
+//                 Some(Container::Empty { .. }) => continue,
+//                 Some(Container::Occupied(value)) => {
+//                     self.decrement_elements();
+//                     return Some(value);
+//                 }
+//                 None => {
+//                     // This should never be hit, because if 0 occupied elements, should have
+//                     // returned before the loop
+//                     env::panic_str(ERR_INCONSISTENT_STATE)
+//                 }
+//             }
+//         }
+//     }
+// }

--- a/near-sdk/src/store/unordered_map/iter.rs
+++ b/near-sdk/src/store/unordered_map/iter.rs
@@ -66,7 +66,11 @@ where
     type Item = (&'a K, &'a V);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let key = self.keys.next()?;
+        <Self as Iterator>::nth(self, 0)
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        let key = self.keys.nth(n)?;
         let entry = self.values.get(key).unwrap_or_else(|| env::panic_str(ERR_INCONSISTENT_STATE));
 
         Some((key, &entry.value))
@@ -103,7 +107,10 @@ where
     H: CryptoHasher<Digest = [u8; 32]>,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        let key = self.keys.next_back()?;
+        <Self as DoubleEndedIterator>::nth_back(self, 0)
+    }
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        let key = self.keys.nth_back(n)?;
         let entry = self.values.get(key).unwrap_or_else(|| env::panic_str(ERR_INCONSISTENT_STATE));
 
         Some((key, &entry.value))
@@ -158,7 +165,10 @@ where
     type Item = (&'a K, &'a mut V);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let key = self.keys.next()?;
+        <Self as Iterator>::nth(self, 0)
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        let key = self.keys.nth(n)?;
         Some(self.get_entry_mut(key))
     }
 
@@ -193,7 +203,10 @@ where
     H: CryptoHasher<Digest = [u8; 32]>,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        let key = self.keys.next_back()?;
+        <Self as DoubleEndedIterator>::nth_back(self, 0)
+    }
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        let key = self.keys.nth_back(n)?;
         Some(self.get_entry_mut(key))
     }
 }

--- a/near-sdk/src/store/unordered_map/mod.rs
+++ b/near-sdk/src/store/unordered_map/mod.rs
@@ -453,15 +453,22 @@ mod tests {
         assert_eq!(iter.collect::<Vec<_>>(), [(&0, &0), (&2, &2), (&3, &3)]);
 
         let iter = map.iter_mut().rev();
-        assert_eq!(iter.collect::<Vec<_>>(), [(&3, &mut 3), (&3, &mut 2), (&0, &mut 0)]);
+        assert_eq!(iter.collect::<Vec<_>>(), [(&3, &mut 3), (&2, &mut 2), (&0, &mut 0)]);
 
         let mut iter = map.iter();
         assert_eq!(iter.nth(2), Some((&3, &3)));
         // Check fused iterator assumption that each following one will be None
         assert_eq!(iter.next(), None);
-    }
 
-    // TODO keys, values iter tests
+        // Double all values
+        map.values_mut().for_each(|v| {
+            *v *= 2;
+        });
+        assert_eq!(map.values().collect::<Vec<_>>(), [&0, &4, &6]);
+
+        // Collect all keys
+        assert_eq!(map.keys().collect::<Vec<_>>(), [&0, &2, &3]);
+    }
 
     #[derive(Arbitrary, Debug)]
     enum Op {

--- a/near-sdk/src/store/unordered_map/mod.rs
+++ b/near-sdk/src/store/unordered_map/mod.rs
@@ -12,7 +12,7 @@ use crate::{env, IntoStorageKey};
 
 pub use entry::{Entry, OccupiedEntry, VacantEntry};
 
-pub use self::iter::{Iter, IterMut, Keys};
+pub use self::iter::{Iter, IterMut, Keys, Values};
 use super::bucket::BucketIndex;
 use super::{Bucket, LookupMap, ERR_INCONSISTENT_STATE};
 
@@ -196,6 +196,42 @@ where
     pub fn is_empty(&self) -> bool {
         self.keys.is_empty()
     }
+
+    /// An iterator visiting all key-value pairs in arbitrary order.
+    /// The iterator element type is `(&'a K, &'a V)`.
+    pub fn iter(&self) -> Iter<K, V, H>
+    where
+        K: BorshDeserialize,
+    {
+        Iter::new(self)
+    }
+
+    /// An iterator visiting all key-value pairs in arbitrary order,
+    /// with exclusive references to the values.
+    /// The iterator element type is `(&'a K, &'a mut V)`.
+    pub fn iter_mut(&mut self) -> IterMut<K, V, H>
+    where
+        K: BorshDeserialize,
+    {
+        IterMut::new(self)
+    }
+    /// An iterator visiting all keys in arbitrary order.
+    /// The iterator element type is `&'a K`.
+    pub fn keys(&self) -> Keys<K>
+    where
+        K: BorshDeserialize,
+    {
+        Keys::new(self)
+    }
+    /// An iterator visiting all values in arbitrary order.
+    /// The iterator element type is `&'a V`.
+    pub fn values(&self) -> Values<K, V, H>
+    where
+        K: BorshDeserialize,
+    {
+        Values::new(self)
+    }
+    // TODO keys, values iterators
 }
 
 impl<K, V, H> UnorderedMap<K, V, H>
@@ -337,34 +373,6 @@ where
     {
         Entry::new(self.values.entry(key), &mut self.keys)
     }
-
-    /// An iterator visiting all key-value pairs in arbitrary order.
-    /// The iterator element type is `(&'a K, &'a V)`.
-    pub fn iter(&self) -> Iter<K, V, H>
-    where
-        K: BorshDeserialize,
-    {
-        Iter::new(self)
-    }
-
-    /// An iterator visiting all key-value pairs in arbitrary order,
-    /// with exclusive references to the values.
-    /// The iterator element type is `(&'a K, &'a mut V)`.
-    pub fn iter_mut(&mut self) -> IterMut<K, V, H>
-    where
-        K: BorshDeserialize,
-    {
-        IterMut::new(self)
-    }
-    /// An iterator visiting all keys in arbitrary order.
-    /// The iterator element type is `&'a K`.
-    pub fn keys(&self) -> Keys<K>
-    where
-        K: BorshDeserialize,
-    {
-        Keys::new(self)
-    }
-    // TODO keys, values iterators
 }
 
 impl<K, V, H> UnorderedMap<K, V, H>

--- a/near-sdk/src/store/unordered_map/mod.rs
+++ b/near-sdk/src/store/unordered_map/mod.rs
@@ -12,9 +12,9 @@ use crate::{env, IntoStorageKey};
 
 pub use entry::{Entry, OccupiedEntry, VacantEntry};
 
+pub use self::iter::Iter;
 use super::bucket::BucketIndex;
 use super::{Bucket, LookupMap, ERR_INCONSISTENT_STATE};
-// pub use self::iter::{Iter, IterMut};
 
 const ERR_NOT_EXIST: &str = "Key does not exist in map";
 
@@ -196,18 +196,6 @@ where
     pub fn is_empty(&self) -> bool {
         self.keys.is_empty()
     }
-
-    // fn lookup_key<Q: ?Sized>(prefix: &[u8], key: &Q, buffer: &mut Vec<u8>) -> LookupKey
-    // where
-    //     Q: BorshSerialize,
-    //     K: Borrow<Q>,
-    // {
-    //     // Concat the prefix with serialized key and hash the bytes for the lookup key.
-    //     buffer.extend(prefix);
-    //     key.serialize(buffer).unwrap_or_else(|_| env::panic_str(ERR_ELEMENT_SERIALIZATION));
-
-    //     H::hash(buffer)
-    // }
 }
 
 impl<K, V, H> UnorderedMap<K, V, H>
@@ -323,6 +311,19 @@ where
     {
         Entry::new(self.values.entry(key), &mut self.keys)
     }
+
+    /// Generates iterator for shared references to each value in the bucket.
+    pub fn iter(&self) -> Iter<K, V, H>
+    where
+        K: BorshDeserialize,
+    {
+        Iter::new(self)
+    }
+
+    // /// Generates iterator for exclusive references to each value in the bucket.
+    // pub fn iter_mut(&mut self) -> IterMut<T> {
+    //     IterMut::new(self)
+    // }
 }
 
 impl<K, V, H> UnorderedMap<K, V, H>
@@ -348,7 +349,7 @@ mod tests {
     use arbitrary::{Arbitrary, Unstructured};
     use borsh::{BorshDeserialize, BorshSerialize};
     use rand::RngCore;
-    use rand::{Rng, SeedableRng};
+    use rand::SeedableRng;
     use std::collections::HashMap;
 
     #[test]

--- a/near-sdk/src/store/unordered_map/mod.rs
+++ b/near-sdk/src/store/unordered_map/mod.rs
@@ -12,7 +12,7 @@ use crate::{env, IntoStorageKey};
 
 pub use entry::{Entry, OccupiedEntry, VacantEntry};
 
-pub use self::iter::{Iter, IterMut, Keys, Values};
+pub use self::iter::{Iter, IterMut, Keys, Values, ValuesMut};
 use super::bucket::BucketIndex;
 use super::{Bucket, LookupMap, ERR_INCONSISTENT_STATE};
 
@@ -231,7 +231,14 @@ where
     {
         Values::new(self)
     }
-    // TODO keys, values iterators
+    /// An iterator visiting all values in arbitrary order.
+    /// The iterator element type is `&'a V`.
+    pub fn values_mut(&mut self) -> ValuesMut<K, V, H>
+    where
+        K: BorshDeserialize,
+    {
+        ValuesMut::new(self)
+    }
 }
 
 impl<K, V, H> UnorderedMap<K, V, H>

--- a/near-sdk/src/store/unordered_map/mod.rs
+++ b/near-sdk/src/store/unordered_map/mod.rs
@@ -1,0 +1,460 @@
+mod entry;
+mod impls;
+mod iter;
+
+use std::borrow::Borrow;
+use std::{fmt, mem};
+
+use borsh::{BorshDeserialize, BorshSerialize};
+
+use crate::crypto_hash::{CryptoHasher, Sha256};
+use crate::{env, IntoStorageKey};
+
+pub use entry::{Entry, OccupiedEntry, VacantEntry};
+
+use super::bucket::BucketIndex;
+use super::{Bucket, LookupMap, ERR_INCONSISTENT_STATE};
+// pub use self::iter::{Iter, IterMut};
+
+const ERR_NOT_EXIST: &str = "Key does not exist in map";
+
+/// A non-iterable, lazily loaded storage map that stores its content directly on the storage trie.
+///
+/// This map stores the values under a hash of the map's `prefix` and [`BorshSerialize`] of the key
+/// using the map's [`CryptoHasher`] implementation.
+///
+/// The default hash function for [`UnorderedMap`] is [`Sha256`] which uses a syscall
+/// (or host function) built into the NEAR runtime to hash the key. To use a custom function,
+/// use [`with_hasher`]. Alternative builtin hash functions can be found at
+/// [`near_sdk::crypto_hash`](crate::crypto_hash).
+///
+/// # Examples
+/// ```
+/// use near_sdk::store::UnorderedMap;
+///
+/// // Initializes a map, the generic types can be inferred to `UnorderedMap<String, u8, Sha256>`
+/// // The `b"a"` parameter is a prefix for the storage keys of this data structure.
+/// let mut map = UnorderedMap::new(b"a");
+///
+/// map.insert("test".to_string(), 7u8);
+/// assert!(map.contains_key("test"));
+/// assert_eq!(map.get("test"), Some(&7u8));
+///
+/// let prev = std::mem::replace(&mut map["test"], 5u8);
+/// assert_eq!(prev, 7u8);
+/// assert_eq!(map["test"], 5u8);
+/// ```
+///
+/// `UnorderedMap` also implements an [`Entry API`](Self::entry), which allows
+/// for more complex methods of getting, setting, updating and removing keys and
+/// their values:
+///
+/// ```
+/// use near_sdk::store::UnorderedMap;
+///
+/// // type inference lets us omit an explicit type signature (which
+/// // would be `UnorderedMap<String, u8>` in this example).
+/// let mut player_stats = UnorderedMap::new(b"m");
+///
+/// fn random_stat_buff() -> u8 {
+///     // could actually return some random value here - let's just return
+///     // some fixed value for now
+///     42
+/// }
+///
+/// // insert a key only if it doesn't already exist
+/// player_stats.entry("health".to_string()).or_insert(100);
+///
+/// // insert a key using a function that provides a new value only if it
+/// // doesn't already exist
+/// player_stats.entry("defence".to_string()).or_insert_with(random_stat_buff);
+///
+/// // update a key, guarding against the key possibly not being set
+/// let stat = player_stats.entry("attack".to_string()).or_insert(100);
+/// *stat += random_stat_buff();
+/// ```
+///
+/// [`with_hasher`]: Self::with_hasher
+pub struct UnorderedMap<K, V, H = Sha256>
+where
+    K: BorshSerialize + Ord,
+    V: BorshSerialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+    keys: Bucket<K>,
+    values: LookupMap<K, ValueAndIndex<V>, H>,
+}
+
+#[derive(BorshSerialize, BorshDeserialize)]
+struct ValueAndIndex<V> {
+    value: V,
+    key_index: BucketIndex,
+}
+
+//? Manual implementations needed only because borsh derive is leaking field types
+// https://github.com/near/borsh-rs/issues/41
+impl<K, V, H> BorshSerialize for UnorderedMap<K, V, H>
+where
+    K: BorshSerialize + Ord,
+    V: BorshSerialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+    fn serialize<W: borsh::maybestd::io::Write>(
+        &self,
+        writer: &mut W,
+    ) -> Result<(), borsh::maybestd::io::Error> {
+        BorshSerialize::serialize(&self.keys, writer)?;
+        BorshSerialize::serialize(&self.values, writer)?;
+        Ok(())
+    }
+}
+
+impl<K, V, H> BorshDeserialize for UnorderedMap<K, V, H>
+where
+    K: BorshSerialize + Ord,
+    V: BorshSerialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+    fn deserialize(buf: &mut &[u8]) -> Result<Self, borsh::maybestd::io::Error> {
+        Ok(Self {
+            keys: BorshDeserialize::deserialize(buf)?,
+            values: BorshDeserialize::deserialize(buf)?,
+        })
+    }
+}
+
+impl<K, V, H> Drop for UnorderedMap<K, V, H>
+where
+    K: BorshSerialize + Ord,
+    V: BorshSerialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+    fn drop(&mut self) {
+        self.flush()
+    }
+}
+
+impl<K, V, H> fmt::Debug for UnorderedMap<K, V, H>
+where
+    K: BorshSerialize + Ord + BorshDeserialize + fmt::Debug,
+    V: BorshSerialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UnorderedMap")
+            .field("keys", &self.keys)
+            .field("values", &self.values)
+            .finish()
+    }
+}
+
+impl<K, V> UnorderedMap<K, V, Sha256>
+where
+    K: BorshSerialize + Ord,
+    V: BorshSerialize,
+{
+    #[inline]
+    pub fn new<S>(prefix: S) -> Self
+    where
+        S: IntoStorageKey,
+    {
+        Self::with_hasher(prefix)
+    }
+}
+
+impl<K, V, H> UnorderedMap<K, V, H>
+where
+    K: BorshSerialize + Ord,
+    V: BorshSerialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+    /// Initialize a [`UnorderedMap`] with a custom hash function.
+    ///
+    /// # Example
+    /// ```
+    /// use near_sdk::crypto_hash::Keccak256;
+    /// use near_sdk::store::UnorderedMap;
+    ///
+    /// let map = UnorderedMap::<String, String, Keccak256>::with_hasher(b"m");
+    /// ```
+    pub fn with_hasher<S>(prefix: S) -> Self
+    where
+        S: IntoStorageKey,
+    {
+        let mut vec_key = prefix.into_storage_key();
+        let map_key = [vec_key.as_slice(), b"m"].concat();
+        vec_key.push(b'v');
+        Self { keys: Bucket::new(vec_key), values: LookupMap::with_hasher(map_key) }
+    }
+
+    /// Return the amount of elements inside of the map.
+    pub fn len(&self) -> u32 {
+        self.keys.len()
+    }
+
+    /// Returns true if there are no elements inside of the map.
+    pub fn is_empty(&self) -> bool {
+        self.keys.is_empty()
+    }
+
+    // fn lookup_key<Q: ?Sized>(prefix: &[u8], key: &Q, buffer: &mut Vec<u8>) -> LookupKey
+    // where
+    //     Q: BorshSerialize,
+    //     K: Borrow<Q>,
+    // {
+    //     // Concat the prefix with serialized key and hash the bytes for the lookup key.
+    //     buffer.extend(prefix);
+    //     key.serialize(buffer).unwrap_or_else(|_| env::panic_str(ERR_ELEMENT_SERIALIZATION));
+
+    //     H::hash(buffer)
+    // }
+}
+
+impl<K, V, H> UnorderedMap<K, V, H>
+where
+    K: BorshSerialize + Ord,
+    V: BorshSerialize + BorshDeserialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+    /// Returns a reference to the value corresponding to the key.
+    ///
+    /// The key may be any borrowed form of the map's key type, but
+    /// [`BorshSerialize`] and [`ToOwned<Owned = K>`](ToOwned) on the borrowed form *must* match those for
+    /// the key type.
+    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: BorshSerialize + ToOwned<Owned = K>,
+    {
+        self.values.get(k).map(|v| &v.value)
+    }
+
+    /// Returns a mutable reference to the value corresponding to the key.
+    ///
+    /// The key may be any borrowed form of the map's key type, but
+    /// [`BorshSerialize`] and [`ToOwned<Owned = K>`](ToOwned) on the borrowed form *must* match those for
+    /// the key type.
+    pub fn get_mut<Q: ?Sized>(&mut self, k: &Q) -> Option<&mut V>
+    where
+        K: Borrow<Q>,
+        Q: BorshSerialize + ToOwned<Owned = K>,
+    {
+        self.values.get_mut(k).map(|v| &mut v.value)
+    }
+
+    /// Inserts a key-value pair into the map.
+    ///
+    /// If the map did not have this key present, [`None`] is returned.
+    ///
+    /// If the map did have this key present, the value is updated, and the old
+    /// value is returned. The key is not updated, though; this matters for
+    /// types that can be `==` without being identical.
+    pub fn insert(&mut self, k: K, value: V) -> Option<V>
+    where
+        K: Clone + BorshDeserialize,
+    {
+        // Check if value is in map to replace first
+        let entry = self.values.get_mut_inner(&k);
+        if let Some(existing) = entry.value_mut() {
+            return Some(mem::replace(&mut existing.value, value));
+        }
+
+        // At this point, we know that the key-value doesn't exist in the map, add key to bucket.
+        let key_index = self.keys.insert(k);
+        entry.replace(Some(ValueAndIndex { value, key_index }));
+        None
+    }
+
+    /// Returns `true` if the map contains a value for the specified key.
+    ///
+    /// The key may be any borrowed form of the map's key type, but
+    /// [`BorshSerialize`] and [`ToOwned<Owned = K>`](ToOwned) on the borrowed form *must* match those for
+    /// the key type.
+    pub fn contains_key<Q: ?Sized>(&self, k: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: BorshSerialize + ToOwned<Owned = K> + Ord,
+    {
+        self.values.contains_key(k)
+    }
+
+    /// Removes a key from the map, returning the value at the key if the key
+    /// was previously in the map.
+    ///
+    /// The key may be any borrowed form of the map's key type, but
+    /// [`BorshSerialize`] and [`ToOwned<Owned = K>`](ToOwned) on the borrowed form *must* match those for
+    /// the key type.
+    pub fn remove<Q: ?Sized>(&mut self, k: &Q) -> Option<V>
+    where
+        K: Borrow<Q> + BorshDeserialize,
+        Q: BorshSerialize + ToOwned<Owned = K>,
+    {
+        // Remove value
+        let old_value = self.values.remove(k)?;
+
+        // Remove key with index if value exists
+        self.keys
+            .remove(old_value.key_index)
+            .unwrap_or_else(|| env::panic_str(ERR_INCONSISTENT_STATE));
+
+        // Return removed value
+        Some(old_value.value)
+    }
+
+    /// Gets the given key's corresponding entry in the map for in-place manipulation.
+    /// ```
+    /// use near_sdk::store::UnorderedMap;
+    ///
+    /// let mut count = UnorderedMap::new(b"m");
+    ///
+    /// for ch in [7, 2, 4, 7, 4, 1, 7] {
+    ///     let counter = count.entry(ch).or_insert(0);
+    ///     *counter += 1;
+    /// }
+    ///
+    /// assert_eq!(count[&4], 2);
+    /// assert_eq!(count[&7], 3);
+    /// assert_eq!(count[&1], 1);
+    /// assert_eq!(count.get(&8), None);
+    /// ```
+    pub fn entry(&mut self, key: K) -> Entry<K, V>
+    where
+        K: Clone,
+    {
+        Entry::new(self.values.entry(key), &mut self.keys)
+    }
+}
+
+impl<K, V, H> UnorderedMap<K, V, H>
+where
+    K: BorshSerialize + Ord,
+    V: BorshSerialize,
+    H: CryptoHasher<Digest = [u8; 32]>,
+{
+    /// Flushes the intermediate values of the map before this is called when the structure is
+    /// [`Drop`]ed. This will write all modified values to storage but keep all cached values
+    /// in memory.
+    pub fn flush(&mut self) {
+        self.keys.flush();
+        self.values.flush();
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(test)]
+mod tests {
+    use super::UnorderedMap;
+    use crate::test_utils::test_env::setup_free;
+    use arbitrary::{Arbitrary, Unstructured};
+    use borsh::{BorshDeserialize, BorshSerialize};
+    use rand::RngCore;
+    use rand::{Rng, SeedableRng};
+    use std::collections::HashMap;
+
+    #[test]
+    fn basic_functionality() {
+        let mut map = UnorderedMap::new(b"b");
+        assert!(map.is_empty());
+        assert!(map.insert("test".to_string(), 5u8).is_none());
+        assert_eq!(map.get("test"), Some(&5));
+        assert_eq!(map.len(), 1);
+
+        map["test"] = 6;
+        assert_eq!(map["test"], 6);
+
+        assert_eq!(map.remove("test"), Some(6));
+        assert_eq!(map.len(), 0);
+    }
+
+    #[test]
+    fn entry_api() {
+        let mut map = UnorderedMap::new(b"b");
+        {
+            let test_entry = map.entry("test".to_string());
+            assert_eq!(test_entry.key(), "test");
+            let entry_ref = test_entry.or_insert(8u8);
+            *entry_ref += 1;
+        }
+        assert_eq!(map["test"], 9);
+
+        // Try getting entry of filled value
+        let value = map.entry("test".to_string()).and_modify(|v| *v += 3).or_default();
+        assert_eq!(*value, 12);
+    }
+
+    #[test]
+    fn map_iterator() {
+        let mut map = UnorderedMap::new(b"b");
+
+        map.insert(0u8, 0u8);
+        map.insert(1, 1);
+        map.insert(2, 2);
+        map.insert(3, 3);
+        map.remove(&1);
+        // let iter = map.iter();
+        // assert_eq!(iter.len(), 3);
+        // assert_eq!(iter.collect::<Vec<_>>(), [&0, &2, &3]);
+
+        // let iter = map.iter_mut().rev();
+        // assert_eq!(iter.collect::<Vec<_>>(), [&mut 3, &mut 2, &mut 0]);
+
+        // let mut iter = map.iter();
+        // assert_eq!(iter.nth(2), Some(&3));
+        // // Check fused iterator assumption that each following one will be None
+        // assert_eq!(iter.next(), None);
+    }
+
+    #[derive(Arbitrary, Debug)]
+    enum Op {
+        Insert(u8, u8),
+        Remove(u8),
+        Flush,
+        Restore,
+        Get(u8),
+    }
+
+    #[test]
+    fn arbitrary() {
+        setup_free();
+
+        let mut rng = rand_xorshift::XorShiftRng::seed_from_u64(0);
+        let mut buf = vec![0; 4096];
+        for _ in 0..512 {
+            // Clear storage in-between runs
+            crate::mock::with_mocked_blockchain(|b| b.take_storage());
+            rng.fill_bytes(&mut buf);
+
+            let mut um = UnorderedMap::new(b"l");
+            let mut hm = HashMap::new();
+            let u = Unstructured::new(&buf);
+            if let Ok(ops) = Vec::<Op>::arbitrary_take_rest(u) {
+                for op in ops {
+                    match op {
+                        Op::Insert(k, v) => {
+                            let r1 = um.insert(k, v);
+                            let r2 = hm.insert(k, v);
+                            assert_eq!(r1, r2)
+                        }
+                        Op::Remove(k) => {
+                            let r1 = um.remove(&k);
+                            let r2 = hm.remove(&k);
+                            assert_eq!(r1, r2)
+                        }
+                        Op::Flush => {
+                            um.flush();
+                        }
+                        Op::Restore => {
+                            let serialized = um.try_to_vec().unwrap();
+                            um = UnorderedMap::deserialize(&mut serialized.as_slice()).unwrap();
+                        }
+                        Op::Get(k) => {
+                            let r1 = um.get(&k);
+                            let r2 = hm.get(&k);
+                            assert_eq!(r1, r2)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/near-sdk/src/store/unordered_map/mod.rs
+++ b/near-sdk/src/store/unordered_map/mod.rs
@@ -12,7 +12,7 @@ use crate::{env, IntoStorageKey};
 
 pub use entry::{Entry, OccupiedEntry, VacantEntry};
 
-pub use self::iter::{Iter, IterMut};
+pub use self::iter::{Iter, IterMut, Keys};
 use super::bucket::BucketIndex;
 use super::{Bucket, LookupMap, ERR_INCONSISTENT_STATE};
 
@@ -355,6 +355,14 @@ where
         K: BorshDeserialize,
     {
         IterMut::new(self)
+    }
+    /// An iterator visiting all keys in arbitrary order.
+    /// The iterator element type is `&'a K`.
+    pub fn keys(&self) -> Keys<K>
+    where
+        K: BorshDeserialize,
+    {
+        Keys::new(self)
     }
     // TODO keys, values iterators
 }


### PR DESCRIPTION
Closes #580 

Also removes some unnecessary bounds in `LookupMap` and replaces the `unreachable!()` code with aborts