### PR TITLE
Changed comment for the owner_id field in the NFT struct

### DIFF
--- a/near-contract-standards/src/non_fungible_token/core/core_impl.rs
+++ b/near-contract-standards/src/non_fungible_token/core/core_impl.rs
@@ -53,7 +53,7 @@ pub trait NonFungibleTokenReceiver {
 /// For example usage, see examples/non-fungible-token/src/lib.rs.
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct NonFungibleToken {
-    // owner of contract; this is the only account allowed to call `mint`
+    // owner of contract
     pub owner_id: AccountId,
 
     // The storage size in bytes for each new token


### PR DESCRIPTION
Fixes #594 

Removed the comment that stated only the owner could mint in the NFT struct. 