### PR TITLE
feat: use rust assertions in require! debug for line numbers

### DIFF
--- a/near-sdk/src/utils/mod.rs
+++ b/near-sdk/src/utils/mod.rs
@@ -63,12 +63,16 @@ macro_rules! log {
 #[macro_export]
 macro_rules! require {
     ($cond:expr $(,)?) => {
-        if !$cond {
-            $crate::env::panic_str("require! assertion failed")
+        if cfg!(debug_assertions) {
+            assert!($cond)
+        } else if !$cond {
+            $crate::env::panic_str("require! assertion failed");
         }
     };
     ($cond:expr, $message:expr $(,)?) => {
-        if !$cond {
+        if cfg!(debug_assertions) {
+            assert!($cond, "{}", $message)
+        } else if !$cond {
             $crate::env::panic_str(&$message)
         }
     };

--- a/near-sdk/src/utils/mod.rs
+++ b/near-sdk/src/utils/mod.rs
@@ -71,7 +71,9 @@ macro_rules! require {
     };
     ($cond:expr, $message:expr $(,)?) => {
         if cfg!(debug_assertions) {
-            assert!($cond, "{}", $message)
+            // Error message must be &str to match panic_str signature
+            let msg: &str = &$message;
+            assert!($cond, "{}", msg)
         } else if !$cond {
             $crate::env::panic_str(&$message)
         }


### PR DESCRIPTION
Closes #597 

No need for a feature, since you can enable debug assertions, even if you want it in release mode