### PR TITLE
fix(readme): contract-builder link

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Since WebAssembly compiler includes a bunch of debug information into the binary
 different on different machines. To be able to compile the binary in a reproducible way, we added a Dockerfile
 that allows to compile the binary.
 
-**Use [contract-builder](https://github.com/near/near-sdk-rs/tree/master/contact-builder)**
+**Use [contract-builder](https://github.com/near/near-sdk-rs/tree/master/contract-builder)**
 
 ## Contributing
 


### PR DESCRIPTION
Closes #601 

Probably should update these docs at some point, because the quickest way to get reproducible builds is using the prebuilt image