### PR TITLE
fix: code generation for mut self methods

### DIFF
--- a/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
@@ -82,6 +82,43 @@ mod tests {
     }
 
     #[test]
+    fn owned_no_args_no_return_no_mut() {
+        let impl_type: Type = syn::parse_str("Hello").unwrap();
+        let mut method: ImplItemMethod = syn::parse_str("pub fn method(self) { }").unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, impl_type).unwrap();
+        let actual = method_info.method_wrapper();
+        let expected = quote!(
+            #[cfg(target_arch = "wasm32")]
+            #[no_mangle]
+            pub extern "C" fn method() {
+                near_sdk::env::setup_panic_hook();
+                let contract: Hello = near_sdk::env::state_read().unwrap_or_default();
+                contract.method();
+            }
+        );
+        assert_eq!(expected.to_string(), actual.to_string());
+    }
+
+
+    #[test]
+    fn mut_owned_no_args_no_return() {
+        let impl_type: Type = syn::parse_str("Hello").unwrap();
+        let mut method: ImplItemMethod = syn::parse_str("pub fn method(mut self) { }").unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, impl_type).unwrap();
+        let actual = method_info.method_wrapper();
+        let expected = quote!(
+            #[cfg(target_arch = "wasm32")]
+            #[no_mangle]
+            pub extern "C" fn method() {
+                near_sdk::env::setup_panic_hook();
+                let mut contract: Hello = near_sdk::env::state_read().unwrap_or_default();
+                contract.method();
+            }
+        );
+        assert_eq!(expected.to_string(), actual.to_string());
+    }
+
+    #[test]
     fn no_args_no_return_mut() {
         let impl_type: Type = syn::parse_str("Hello").unwrap();
         let mut method: ImplItemMethod = syn::parse_str("pub fn method(&mut self) { }").unwrap();

--- a/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
@@ -105,7 +105,7 @@ impl AttrSigInfo {
 
         if let Some(ref receiver) = receiver {
             if matches!(method_type, MethodType::Regular) {
-                if receiver.mutability.is_none() {
+                if receiver.mutability.is_none() || receiver.reference.is_none() {
                     method_type = MethodType::View;
                 }
             } else {


### PR DESCRIPTION
Closes #615 

Probably rare someone would want to modify this structure in place for a view method, which is probably how this wasn't hit before, but good to have this functional