### PR TITLE
Allow deserialization for StorageBalance and StorageBalanceBounds

### DIFF
--- a/near-contract-standards/src/storage_management/mod.rs
+++ b/near-contract-standards/src/storage_management/mod.rs
@@ -3,8 +3,6 @@ use near_sdk::json_types::U128;
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::AccountId;
 
-/// Implements both `serde` and `borsh` serialization.
-/// `serde` is typically useful when returning a struct in JSON format for a frontend.
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
 #[serde(crate = "near_sdk::serde")]
 pub struct StorageBalance {

--- a/near-contract-standards/src/storage_management/mod.rs
+++ b/near-contract-standards/src/storage_management/mod.rs
@@ -1,15 +1,20 @@
+use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::json_types::U128;
-use near_sdk::serde::Serialize;
+use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::AccountId;
 
-#[derive(Serialize)]
+/// Implements both `serde` and `borsh` serialization.
+/// `serde` is typically useful when returning a struct in JSON format for a frontend.
+#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
 #[serde(crate = "near_sdk::serde")]
 pub struct StorageBalance {
     pub total: U128,
     pub available: U128,
 }
 
-#[derive(Serialize)]
+/// Implements both `serde` and `borsh` serialization.
+/// `serde` is typically useful when returning a struct in JSON format for a frontend.
+#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
 #[serde(crate = "near_sdk::serde")]
 pub struct StorageBalanceBounds {
     pub min: U128,

--- a/near-contract-standards/src/storage_management/mod.rs
+++ b/near-contract-standards/src/storage_management/mod.rs
@@ -10,8 +10,6 @@ pub struct StorageBalance {
     pub available: U128,
 }
 
-/// Implements both `serde` and `borsh` serialization.
-/// `serde` is typically useful when returning a struct in JSON format for a frontend.
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
 #[serde(crate = "near_sdk::serde")]
 pub struct StorageBalanceBounds {


### PR DESCRIPTION
Currently, only serialization is allowed for `StorageBalance` and `StorageBalanceBounds`. This means that we cannot use the result returned from `storage_deposit`, `storage_withdraw`, `storage_balance_bounds` and `storage_balance_of` since we cannot deserialize it.

Ex: the following will result in a compilation error
`near_sdk::serde_json::from_slice::<StorageBalance>(&result).unwrap();` where `result` is the result returned by `storage_balance_of`.