### PR TITLE
refactor: Remove helper function and add safety docs

### DIFF
--- a/near-sdk/src/environment/hash.rs
+++ b/near-sdk/src/environment/hash.rs
@@ -4,10 +4,6 @@ use crate::sys;
 
 const ATOMIC_OP_REGISTER: u64 = u64::MAX - 2;
 
-fn read_register_fixed(register_id: u64, buf: &mut [MaybeUninit<u8>]) {
-    unsafe { sys::read_register(register_id, buf.as_ptr() as _) }
-}
-
 mod private {
     /// Seal `CryptoHasher` implementations to limit usage to the builtin implementations
     pub trait Sealed {}
@@ -36,9 +32,14 @@ impl CryptoHasher for Sha256 {
     fn hash(ingest: &[u8]) -> Self::Digest {
         unsafe { sys::sha256(ingest.len() as _, ingest.as_ptr() as _, ATOMIC_OP_REGISTER) };
 
-        let mut hash = [MaybeUninit::uninit(); 32];
-        read_register_fixed(ATOMIC_OP_REGISTER, &mut hash);
-        unsafe { std::mem::transmute(hash) }
+        let mut hash = [MaybeUninit::<u8>::uninit(); 32];
+        //* SAFETY: sha256 syscall will always generate 32 bytes inside of the atomic op register
+        //*         so the read will have a sufficient buffer of 32, and can transmute from uninit
+        //*         because all bytes are filled. This assumes a valid sha256 implementation.
+        unsafe {
+            sys::read_register(ATOMIC_OP_REGISTER, hash.as_mut_ptr() as _);
+            std::mem::transmute(hash)
+        }
     }
 }
 
@@ -53,8 +54,13 @@ impl CryptoHasher for Keccak256 {
     fn hash(ingest: &[u8]) -> Self::Digest {
         unsafe { sys::keccak256(ingest.len() as _, ingest.as_ptr() as _, ATOMIC_OP_REGISTER) };
 
-        let mut hash = [MaybeUninit::uninit(); 32];
-        read_register_fixed(ATOMIC_OP_REGISTER, &mut hash);
-        unsafe { std::mem::transmute(hash) }
+        let mut hash = [MaybeUninit::<u8>::uninit(); 32];
+        //* SAFETY: keccak256 syscall will always generate 32 bytes inside of the atomic op register
+        //*         so the read will have a sufficient buffer of 32, and can transmute from uninit
+        //*         because all bytes are filled. This assumes a valid keccak256 implementation.
+        unsafe {
+            sys::read_register(ATOMIC_OP_REGISTER, hash.as_mut_ptr() as _);
+            std::mem::transmute(hash)
+        }
     }
 }

--- a/near-sdk/src/environment/hash.rs
+++ b/near-sdk/src/environment/hash.rs
@@ -30,13 +30,13 @@ impl CryptoHasher for Sha256 {
     type Digest = [u8; 32];
 
     fn hash(ingest: &[u8]) -> Self::Digest {
-        unsafe { sys::sha256(ingest.len() as _, ingest.as_ptr() as _, ATOMIC_OP_REGISTER) };
-
-        let mut hash = [MaybeUninit::<u8>::uninit(); 32];
         //* SAFETY: sha256 syscall will always generate 32 bytes inside of the atomic op register
         //*         so the read will have a sufficient buffer of 32, and can transmute from uninit
         //*         because all bytes are filled. This assumes a valid sha256 implementation.
         unsafe {
+            sys::sha256(ingest.len() as _, ingest.as_ptr() as _, ATOMIC_OP_REGISTER);
+
+            let mut hash = [MaybeUninit::<u8>::uninit(); 32];
             sys::read_register(ATOMIC_OP_REGISTER, hash.as_mut_ptr() as _);
             std::mem::transmute(hash)
         }
@@ -52,13 +52,13 @@ impl CryptoHasher for Keccak256 {
     type Digest = [u8; 32];
 
     fn hash(ingest: &[u8]) -> Self::Digest {
-        unsafe { sys::keccak256(ingest.len() as _, ingest.as_ptr() as _, ATOMIC_OP_REGISTER) };
-
-        let mut hash = [MaybeUninit::<u8>::uninit(); 32];
         //* SAFETY: keccak256 syscall will always generate 32 bytes inside of the atomic op register
         //*         so the read will have a sufficient buffer of 32, and can transmute from uninit
         //*         because all bytes are filled. This assumes a valid keccak256 implementation.
         unsafe {
+            sys::keccak256(ingest.len() as _, ingest.as_ptr() as _, ATOMIC_OP_REGISTER);
+
+            let mut hash = [MaybeUninit::<u8>::uninit(); 32];
             sys::read_register(ATOMIC_OP_REGISTER, hash.as_mut_ptr() as _);
             std::mem::transmute(hash)
         }


### PR DESCRIPTION
Helper function was only needed when there were more steps, not needed now as it somewhat hides the unsafety constraints of the operations. Added the safety docs as well to describe why this is safe.