### PR TITLE
fix: consistent naming to only using function over method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Add drain iterator for `near_sdk::store::UnorderedMap`. [PR 613](https://github.com/near/near-sdk-rs/pull/613).
   - Will remove all values and iterate over owned values that were removed
 - Fix codegen for methods inside a `#[near_bindgen]` to allow using `mut self` which will generate the same code as `self` and will not persist state. [PR 616](https://github.com/near/near-sdk-rs/pull/616).
+- Make function call terminology consistent by switching from method name usages. [PR 633](https://github.com/near/near-sdk-rs/pull/633).
+  - This is only a breaking change if inspecting the `VmAction`s of receipts in mocked environments. All other changes are positional argument names.
 
 ## `4.0.0-pre.4` [10-15-2021]
 - Unpin `syn` dependency in macros from `=1.0.57` to be more composable with other crates. [PR 605](https://github.com/near/near-sdk-rs/pull/605)

--- a/near-sdk-sim/src/runtime.rs
+++ b/near-sdk-sim/src/runtime.rs
@@ -347,7 +347,12 @@ impl RuntimeStandalone {
     }
 
     /// Returns a ViewResult containing the value or error and any logs
-    pub fn view_method_call(&self, account_id: &str, method_name: &str, args: &[u8]) -> ViewResult {
+    pub fn view_method_call(
+        &self,
+        account_id: &str,
+        function_name: &str,
+        args: &[u8],
+    ) -> ViewResult {
         let trie_update = self.tries.new_trie_update(0, self.cur_block.state_root);
         let viewer = TrieViewer {};
         let mut logs = vec![];
@@ -365,7 +370,7 @@ impl RuntimeStandalone {
             trie_update,
             view_state,
             &account_id.to_string(),
-            method_name,
+            function_name,
             args,
             &mut logs,
             self.epoch_info_provider.as_ref(),

--- a/near-sdk-sim/src/user.rs
+++ b/near-sdk-sim/src/user.rs
@@ -77,12 +77,12 @@ impl UserTransaction {
     /// Execute contract call to receiver
     pub fn function_call(
         mut self,
-        method_name: String,
+        function_name: String,
         args: Vec<u8>,
         gas: Gas,
         deposit: Balance,
     ) -> Self {
-        self.transaction = self.transaction.function_call(method_name, args, gas, deposit);
+        self.transaction = self.transaction.function_call(function_name, args, gas, deposit);
         self
     }
 

--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -241,7 +241,7 @@ pub fn keccak512(value: &[u8]) -> Vec<u8> {
 /// the given amount and gas.
 pub fn promise_create(
     account_id: AccountId,
-    method_name: &str,
+    function_name: &str,
     arguments: &[u8],
     amount: Balance,
     gas: Gas,
@@ -251,8 +251,8 @@ pub fn promise_create(
         sys::promise_create(
             account_id.len() as _,
             account_id.as_ptr() as _,
-            method_name.len() as _,
-            method_name.as_ptr() as _,
+            function_name.len() as _,
+            function_name.as_ptr() as _,
             arguments.len() as _,
             arguments.as_ptr() as _,
             &amount as *const Balance as _,
@@ -265,7 +265,7 @@ pub fn promise_create(
 pub fn promise_then(
     promise_idx: PromiseIndex,
     account_id: AccountId,
-    method_name: &str,
+    function_name: &str,
     arguments: &[u8],
     amount: Balance,
     gas: Gas,
@@ -276,8 +276,8 @@ pub fn promise_then(
             promise_idx,
             account_id.len() as _,
             account_id.as_ptr() as _,
-            method_name.len() as _,
-            method_name.as_ptr() as _,
+            function_name.len() as _,
+            function_name.as_ptr() as _,
             arguments.len() as _,
             arguments.as_ptr() as _,
             &amount as *const Balance as _,
@@ -324,7 +324,7 @@ pub fn promise_batch_action_deploy_contract(promise_index: u64, code: &[u8]) {
 
 pub fn promise_batch_action_function_call(
     promise_index: PromiseIndex,
-    method_name: &str,
+    function_name: &str,
     arguments: &[u8],
     amount: Balance,
     gas: Gas,
@@ -332,8 +332,8 @@ pub fn promise_batch_action_function_call(
     unsafe {
         sys::promise_batch_action_function_call(
             promise_index,
-            method_name.len() as _,
-            method_name.as_ptr() as _,
+            function_name.len() as _,
+            function_name.as_ptr() as _,
             arguments.len() as _,
             arguments.as_ptr() as _,
             &amount as *const Balance as _,
@@ -380,7 +380,7 @@ pub fn promise_batch_action_add_key_with_function_call(
     nonce: u64,
     allowance: Balance,
     receiver_id: &AccountId,
-    method_names: &str,
+    function_names: &str,
 ) {
     let receiver_id: &str = receiver_id.as_ref();
     unsafe {
@@ -392,8 +392,8 @@ pub fn promise_batch_action_add_key_with_function_call(
             &allowance as *const Balance as _,
             receiver_id.len() as _,
             receiver_id.as_ptr() as _,
-            method_names.len() as _,
-            method_names.as_ptr() as _,
+            function_names.len() as _,
+            function_names.as_ptr() as _,
         )
     }
 }

--- a/near-sdk/src/environment/mock/external.rs
+++ b/near-sdk/src/environment/mock/external.rs
@@ -98,14 +98,14 @@ impl External for SdkExternal {
     fn append_action_function_call(
         &mut self,
         receipt_index: u64,
-        method_name: Vec<u8>,
+        function_name: Vec<u8>,
         arguments: Vec<u8>,
         attached_deposit: u128,
         prepaid_gas: u64,
     ) -> Result<()> {
         self.receipts.get_mut(receipt_index as usize).unwrap().actions.push(
             VmAction::FunctionCall {
-                method_name: String::from_utf8(method_name)
+                function_name: String::from_utf8(function_name)
                     // * Unwrap here is fine because this is only used in mocks
                     .expect("method name must be utf8 bytes"),
                 args: arguments,
@@ -162,18 +162,18 @@ impl External for SdkExternal {
         nonce: u64,
         allowance: Option<u128>,
         receiver_id: String,
-        method_names: Vec<Vec<u8>>,
+        function_names: Vec<Vec<u8>>,
     ) -> Result<()> {
         let public_key = PublicKey::try_from(public_key).unwrap();
-        let method_names =
-            method_names.into_iter().map(|s| String::from_utf8(s).unwrap()).collect();
+        let function_names =
+            function_names.into_iter().map(|s| String::from_utf8(s).unwrap()).collect();
         self.receipts.get_mut(receipt_index as usize).unwrap().actions.push(
             VmAction::AddKeyWithFunctionCall {
                 public_key,
                 nonce,
                 allowance,
                 receiver_id: AccountId::new_unchecked(receiver_id),
-                method_names,
+                function_names,
             },
         );
         Ok(())

--- a/near-sdk/src/environment/mock/mocked_blockchain.rs
+++ b/near-sdk/src/environment/mock/mocked_blockchain.rs
@@ -217,8 +217,8 @@ mod mock_chain {
     extern "C" fn promise_create(
         account_id_len: u64,
         account_id_ptr: u64,
-        method_name_len: u64,
-        method_name_ptr: u64,
+        function_name_len: u64,
+        function_name_ptr: u64,
         arguments_len: u64,
         arguments_ptr: u64,
         amount_ptr: u64,
@@ -228,8 +228,8 @@ mod mock_chain {
             b.promise_create(
                 account_id_len,
                 account_id_ptr,
-                method_name_len,
-                method_name_ptr,
+                function_name_len,
+                function_name_ptr,
                 arguments_len,
                 arguments_ptr,
                 amount_ptr,
@@ -242,8 +242,8 @@ mod mock_chain {
         promise_index: u64,
         account_id_len: u64,
         account_id_ptr: u64,
-        method_name_len: u64,
-        method_name_ptr: u64,
+        function_name_len: u64,
+        function_name_ptr: u64,
         arguments_len: u64,
         arguments_ptr: u64,
         amount_ptr: u64,
@@ -254,8 +254,8 @@ mod mock_chain {
                 promise_index,
                 account_id_len,
                 account_id_ptr,
-                method_name_len,
-                method_name_ptr,
+                function_name_len,
+                function_name_ptr,
                 arguments_len,
                 arguments_ptr,
                 amount_ptr,
@@ -296,8 +296,8 @@ mod mock_chain {
     #[no_mangle]
     extern "C" fn promise_batch_action_function_call(
         promise_index: u64,
-        method_name_len: u64,
-        method_name_ptr: u64,
+        function_name_len: u64,
+        function_name_ptr: u64,
         arguments_len: u64,
         arguments_ptr: u64,
         amount_ptr: u64,
@@ -306,8 +306,8 @@ mod mock_chain {
         with_mock_interface(|b| {
             b.promise_batch_action_function_call(
                 promise_index,
-                method_name_len,
-                method_name_ptr,
+                function_name_len,
+                function_name_ptr,
                 arguments_len,
                 arguments_ptr,
                 amount_ptr,
@@ -355,8 +355,8 @@ mod mock_chain {
         allowance_ptr: u64,
         receiver_id_len: u64,
         receiver_id_ptr: u64,
-        method_names_len: u64,
-        method_names_ptr: u64,
+        function_names_len: u64,
+        function_names_ptr: u64,
     ) {
         with_mock_interface(|b| {
             b.promise_batch_action_add_key_with_function_call(
@@ -367,8 +367,8 @@ mod mock_chain {
                 allowance_ptr,
                 receiver_id_len,
                 receiver_id_ptr,
-                method_names_len,
-                method_names_ptr,
+                function_names_len,
+                function_names_ptr,
             )
         })
     }

--- a/near-sdk/src/environment/mock/receipt.rs
+++ b/near-sdk/src/environment/mock/receipt.rs
@@ -15,7 +15,7 @@ pub enum VmAction {
         code: Vec<u8>,
     },
     FunctionCall {
-        method_name: String,
+        function_name: String,
         args: Vec<u8>,
         gas: Gas,
         deposit: Balance,
@@ -36,7 +36,7 @@ pub enum VmAction {
         nonce: u64,
         allowance: Option<Balance>,
         receiver_id: AccountId,
-        method_names: Vec<String>,
+        function_names: Vec<String>,
     },
     DeleteKey {
         public_key: PublicKey,

--- a/near-sdk/src/promise.rs
+++ b/near-sdk/src/promise.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 
 use crate::{AccountId, Balance, Gas, PromiseIndex, PublicKey};
 
-pub enum PromiseAction {
+enum PromiseAction {
     CreateAccount,
     DeployContract {
         code: Vec<u8>,
@@ -93,7 +93,7 @@ impl PromiseAction {
     }
 }
 
-pub struct PromiseSingle {
+struct PromiseSingle {
     pub account_id: AccountId,
     pub actions: RefCell<Vec<PromiseAction>>,
     pub after: RefCell<Option<Promise>>,
@@ -203,7 +203,7 @@ impl BorshSchema for Promise {
 }
 
 #[derive(Clone)]
-pub enum PromiseSubtype {
+enum PromiseSubtype {
     Single(Rc<PromiseSingle>),
     Joint(Rc<PromiseJoint>),
 }

--- a/near-sdk/src/promise.rs
+++ b/near-sdk/src/promise.rs
@@ -12,7 +12,7 @@ pub enum PromiseAction {
         code: Vec<u8>,
     },
     FunctionCall {
-        method_name: String,
+        function_name: String,
         arguments: Vec<u8>,
         amount: Balance,
         gas: Gas,
@@ -32,7 +32,7 @@ pub enum PromiseAction {
         public_key: PublicKey,
         allowance: Balance,
         receiver_id: AccountId,
-        method_names: String,
+        function_names: String,
         nonce: u64,
     },
     DeleteKey {
@@ -51,10 +51,10 @@ impl PromiseAction {
             DeployContract { code } => {
                 crate::env::promise_batch_action_deploy_contract(promise_index, code)
             }
-            FunctionCall { method_name, arguments, amount, gas } => {
+            FunctionCall { function_name, arguments, amount, gas } => {
                 crate::env::promise_batch_action_function_call(
                     promise_index,
-                    method_name,
+                    function_name,
                     arguments,
                     *amount,
                     *gas,
@@ -73,14 +73,14 @@ impl PromiseAction {
                     *nonce,
                 )
             }
-            AddAccessKey { public_key, allowance, receiver_id, method_names, nonce } => {
+            AddAccessKey { public_key, allowance, receiver_id, function_names, nonce } => {
                 crate::env::promise_batch_action_add_key_with_function_call(
                     promise_index,
                     public_key,
                     *nonce,
                     *allowance,
                     receiver_id,
-                    method_names,
+                    function_names,
                 )
             }
             DeleteKey { public_key } => {
@@ -245,12 +245,12 @@ impl Promise {
     /// A low-level interface for making a function call to the account that this promise acts on.
     pub fn function_call(
         self,
-        method_name: String,
+        function_name: String,
         arguments: Vec<u8>,
         amount: Balance,
         gas: Gas,
     ) -> Self {
-        self.add_action(PromiseAction::FunctionCall { method_name, arguments, amount, gas })
+        self.add_action(PromiseAction::FunctionCall { function_name, arguments, amount, gas })
     }
 
     /// Transfer tokens to the account that this promise acts on.
@@ -274,16 +274,16 @@ impl Promise {
     }
 
     /// Add an access key that is restricted to only calling a smart contract on some account using
-    /// only a restricted set of methods. Here `method_names` is a comma separated list of methods,
+    /// only a restricted set of methods. Here `function_names` is a comma separated list of methods,
     /// e.g. `"method_a,method_b".to_string()`.
     pub fn add_access_key(
         self,
         public_key: PublicKey,
         allowance: Balance,
         receiver_id: AccountId,
-        method_names: String,
+        function_names: String,
     ) -> Self {
-        self.add_access_key_with_nonce(public_key, allowance, receiver_id, method_names, 0)
+        self.add_access_key_with_nonce(public_key, allowance, receiver_id, function_names, 0)
     }
 
     /// Add an access key with a provided nonce.
@@ -292,14 +292,14 @@ impl Promise {
         public_key: PublicKey,
         allowance: Balance,
         receiver_id: AccountId,
-        method_names: String,
+        function_names: String,
         nonce: u64,
     ) -> Self {
         self.add_action(PromiseAction::AddAccessKey {
             public_key,
             allowance,
             receiver_id,
-            method_names,
+            function_names,
             nonce,
         })
     }

--- a/sys/src/lib.rs
+++ b/sys/src/lib.rs
@@ -59,8 +59,8 @@ extern "C" {
     pub fn promise_create(
         account_id_len: u64,
         account_id_ptr: u64,
-        method_name_len: u64,
-        method_name_ptr: u64,
+        function_name_len: u64,
+        function_name_ptr: u64,
         arguments_len: u64,
         arguments_ptr: u64,
         amount_ptr: u64,
@@ -70,8 +70,8 @@ extern "C" {
         promise_index: u64,
         account_id_len: u64,
         account_id_ptr: u64,
-        method_name_len: u64,
-        method_name_ptr: u64,
+        function_name_len: u64,
+        function_name_ptr: u64,
         arguments_len: u64,
         arguments_ptr: u64,
         amount_ptr: u64,
@@ -87,8 +87,8 @@ extern "C" {
     pub fn promise_batch_action_deploy_contract(promise_index: u64, code_len: u64, code_ptr: u64);
     pub fn promise_batch_action_function_call(
         promise_index: u64,
-        method_name_len: u64,
-        method_name_ptr: u64,
+        function_name_len: u64,
+        function_name_ptr: u64,
         arguments_len: u64,
         arguments_ptr: u64,
         amount_ptr: u64,
@@ -115,8 +115,8 @@ extern "C" {
         allowance_ptr: u64,
         receiver_id_len: u64,
         receiver_id_ptr: u64,
-        method_names_len: u64,
-        method_names_ptr: u64,
+        function_names_len: u64,
+        function_names_ptr: u64,
     );
     pub fn promise_batch_action_delete_key(
         promise_index: u64,


### PR DESCRIPTION
inline with https://github.com/near/docs/issues/905, naming within the SDK is mixed, even within the same function, so this changes method terminology to function.

This should only be a breaking change for mock receipts, others are all positional and I don't think the promise enums are exposed in any way, which I will follow up on now. (They were private)