### PR TITLE
add must_use; updated examples

### DIFF
--- a/examples/fungible-token/tests/sim/with_macros.rs
+++ b/examples/fungible-token/tests/sim/with_macros.rs
@@ -22,12 +22,8 @@ fn simulate_simple_transfer() {
 
     // Transfer from root to alice.
     // Uses default gas amount, `near_sdk_sim::DEFAULT_GAS`
-    call!(
-        root,
-        ft.ft_transfer(alice.account_id(), transfer_amount.into(), None),
-        deposit = 1
-    )
-    .assert_success();
+    call!(root, ft.ft_transfer(alice.account_id(), transfer_amount.into(), None), deposit = 1)
+        .assert_success();
 
     let root_balance: U128 = view!(ft.ft_balance_of(root.account_id())).unwrap_json();
     let alice_balance: U128 = view!(ft.ft_balance_of(alice.account_id())).unwrap_json();
@@ -128,10 +124,7 @@ fn simulate_transfer_call_with_burned_amount() {
     let callback_outcome = outcome.get_receipt_results().remove(1).unwrap();
 
     assert_eq!(callback_outcome.logs()[0], "The account of the sender was deleted");
-    assert_eq!(
-        callback_outcome.logs()[1],
-        format!("Account @{} burned {}", root.account_id(), 10)
-    );
+    assert_eq!(callback_outcome.logs()[1], format!("Account @{} burned {}", root.account_id(), 10));
 
     let used_amount: U128 = callback_outcome.unwrap_json();
     // Sender deleted the account. Even though the returned amount was 10, it was not refunded back
@@ -181,7 +174,7 @@ fn simulate_transfer_call_when_called_contract_not_registered_with_ft() {
     let (root, ft, defi, _alice) = init(initial_balance);
 
     // call fails because DEFI contract is not registered as FT user
-    call!(
+    let res = call!(
         root,
         ft.ft_transfer_call(
             defi.account_id(),
@@ -191,6 +184,7 @@ fn simulate_transfer_call_when_called_contract_not_registered_with_ft() {
         ),
         deposit = 1
     );
+    assert!(matches!(res.status(), ExecutionStatus::Failure(_)));
 
     // balances remain unchanged
     let root_balance: U128 = view!(ft.ft_balance_of(root.account_id())).unwrap_json();
@@ -217,7 +211,8 @@ fn simulate_transfer_call_with_promise_and_refund() {
             refund_amount.to_string()
         ),
         deposit = 1
-    );
+    )
+    .assert_success();
 
     let root_balance: U128 = view!(ft.ft_balance_of(root.account_id())).unwrap_json();
     let defi_balance: U128 = view!(ft.ft_balance_of(defi.account_id())).unwrap_json();

--- a/examples/non-fungible-token/tests/sim/test_core.rs
+++ b/examples/non-fungible-token/tests/sim/test_core.rs
@@ -39,7 +39,8 @@ fn simulate_transfer_call_fast_return_to_sender() {
             "return-it-now".into()
         ),
         deposit = 1
-    );
+    )
+    .assert_success();
 
     let token: Token = view!(nft.nft_token(TOKEN_ID.into())).unwrap_json();
     assert_eq!(token.owner_id, root.account_id());
@@ -59,7 +60,8 @@ fn simulate_transfer_call_slow_return_to_sender() {
             "return-it-later".into()
         ),
         deposit = 1
-    );
+    )
+    .assert_success();
 
     let token: Token = view!(nft.nft_token(TOKEN_ID.into())).unwrap_json();
     assert_eq!(token.owner_id, root.account_id());
@@ -79,7 +81,8 @@ fn simulate_transfer_call_fast_keep_with_sender() {
             "keep-it-now".into()
         ),
         deposit = 1
-    );
+    )
+    .assert_success();
 
     let token: Token = view!(nft.nft_token(TOKEN_ID.into())).unwrap_json();
     assert_eq!(token.owner_id, receiver.account_id());
@@ -99,7 +102,8 @@ fn simulate_transfer_call_slow_keep_with_sender() {
             "keep-it-later".into()
         ),
         deposit = 1
-    );
+    )
+    .assert_success();
 
     let token: Token = view!(nft.nft_token(TOKEN_ID.into())).unwrap_json();
     assert_eq!(token.owner_id, receiver.account_id());
@@ -119,7 +123,8 @@ fn simulate_transfer_call_receiver_panics() {
             "incorrect message".into()
         ),
         deposit = 1
-    );
+    )
+    .assert_success();
 
     let token: Token = view!(nft.nft_token(TOKEN_ID.into())).unwrap_json();
     assert_eq!(token.owner_id, root.account_id());

--- a/examples/non-fungible-token/tests/sim/utils.rs
+++ b/examples/non-fungible-token/tests/sim/utils.rs
@@ -71,7 +71,8 @@ pub fn init() -> (
             }
         ),
         deposit = 7000000000000000000000
-    );
+    )
+    .assert_success();
 
     let alice = root.create_user(AccountId::new_unchecked("alice".to_string()), to_yocto("100"));
 
@@ -126,5 +127,6 @@ pub fn helper_mint(
             }
         ),
         deposit = 7000000000000000000000
-    );
+    )
+    .assert_success();
 }

--- a/near-sdk-sim/src/outcome.rs
+++ b/near-sdk-sim/src/outcome.rs
@@ -19,6 +19,7 @@ pub type TxResult = Result<ExecutionOutcome, ExecutionOutcome>;
 
 /// An ExecutionResult is created by a UserAccount submitting a transaction.
 /// It wraps an ExecutionOutcome which is the same object returned from an RPC call.
+#[must_use]
 #[derive(Clone)]
 pub struct ExecutionResult {
     runtime: Rc<RefCell<RuntimeStandalone>>,

--- a/near-sdk-sim/src/outcome.rs
+++ b/near-sdk-sim/src/outcome.rs
@@ -186,6 +186,7 @@ pub fn outcome_into_result(
 
 /// The result of a view call.  Contains the logs made during the view method call and Result value,
 /// which can be unwrapped and deserialized.
+#[must_use]
 #[derive(Debug)]
 pub struct ViewResult {
     result: Result<Vec<u8>, Box<dyn std::error::Error>>,


### PR DESCRIPTION
* Closes #635 
* Adds `#[must_use]` on `near_sdk_sim::outcome::ExecutionResult` and `ViewResult`.
* Update `examples/`.