### PR TITLE
chore: add msrv check to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest]
-        toolchain: [stable]
+        toolchain: [stable, 1.56.0]
     steps:
       - uses: actions/checkout@v2
       - name: "${{ matrix.toolchain }} with rustfmt, and wasm32"


### PR DESCRIPTION
MSRV is only this high because new nearcore crates use the 2021 edition, which requires 1.56