### PR TITLE
feat(store): Re-implement LookupSet in a more efficient manner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Add consts for near, yocto, and tgas. [PR 640](https://github.com/near/near-sdk-rs/pull/640).
   - `near_sdk::ONE_NEAR`, `near_sdk::ONE_YOCTO`, `near_sdk::Gas::ONE_TERA`
 - Update SDK dependencies for `nearcore` crates used for mocking (`0.10`) and `borsh` (`0.9`)
-- store: Implement caching `LookupSet` type. This is the new iteration of the previous version of `near_sdk::collections::LookupSet` that has an updated API, and is located at `near_sdk::store::LookupSet`. [PR 654](https://github.com/near/near-sdk-rs/pull/654).
+- store: Implement caching `LookupSet` type. This is the new iteration of the previous version of `near_sdk::collections::LookupSet` that has an updated API, and is located at `near_sdk::store::LookupSet`. [PR 654](https://github.com/near/near-sdk-rs/pull/654), [PR 664](https://github.com/near/near-sdk-rs/pull/664).
 - Deprecate `testing_env_with_promise_results`, `setup_with_config`, and `setup` due to these functions being unneeded anymore or have unintended side effects [PR 671](https://github.com/near/near-sdk-rs/pull/671)
   - Added missing pattern for only including context and vm config to `testing_env!` to remove friction
 - Added `_array` suffix versions of `sha256`, `keccak256`, and `keccak512` hash functions in `env` [PR 646](https://github.com/near/near-sdk-rs/pull/646)

--- a/near-sdk/src/store/lookup_map/mod.rs
+++ b/near-sdk/src/store/lookup_map/mod.rs
@@ -250,7 +250,7 @@ where
             let _ = entry.hash.set(key);
             CacheEntry::new_cached(value)
         });
-        let entry = entry.value.get_mut().unwrap_or_else(|| unreachable!());
+        let entry = entry.value.get_mut().unwrap_or_else(|| env::abort());
         entry
     }
 

--- a/near-sdk/src/store/lookup_set/impls.rs
+++ b/near-sdk/src/store/lookup_set/impls.rs
@@ -11,6 +11,8 @@ where
     where
         I: IntoIterator<Item = T>,
     {
-        self.map.extend(iter.into_iter().map(|k| (k, ())))
+        iter.into_iter().for_each(move |elem| {
+            self.insert(elem);
+        });
     }
 }

--- a/near-sdk/src/store/lookup_set/impls.rs
+++ b/near-sdk/src/store/lookup_set/impls.rs
@@ -12,7 +12,7 @@ where
         I: IntoIterator<Item = T>,
     {
         iter.into_iter().for_each(move |elem| {
-            self.insert(elem);
+            self.put(elem);
         });
     }
 }


### PR DESCRIPTION
Closes #659

This PR re-implements `LookupSet` so that it tracks all elements by itself and only uses `env::storage_write` with an empty array of bytes and `env::storage_has_key` as opposed to `env::storage_read` (which is more expensive).