### PR TITLE
fix(unordered_map): remove unnecessary clear call

### DIFF
--- a/near-sdk/src/store/free_list/mod.rs
+++ b/near-sdk/src/store/free_list/mod.rs
@@ -341,6 +341,7 @@ mod tests {
             assert_eq!(bl_d.len(), bu_d.len());
             assert!(Iterator::eq(bl_d, bu_d));
         }
+        assert!(bucket.elements.is_empty());
         assert!(bucket.is_empty());
         crate::mock::with_mocked_blockchain(|m| assert!(m.take_storage().is_empty()));
     }

--- a/near-sdk/src/store/unordered_map/mod.rs
+++ b/near-sdk/src/store/unordered_map/mod.rs
@@ -211,7 +211,6 @@ where
             // This enforces a clone, but this is better th
             self.values.set(k, None);
         }
-        self.keys.clear();
     }
 
     /// An iterator visiting all key-value pairs in arbitrary order.


### PR DESCRIPTION
Was needed before `drain`, this is redundant now and could lead to unnecessary CPU cycles.