### PR TITLE
changed to match standard

### DIFF
--- a/near-contract-standards/src/non_fungible_token/approval/approval_receiver.rs
+++ b/near-contract-standards/src/non_fungible_token/approval/approval_receiver.rs
@@ -22,5 +22,5 @@ pub trait NonFungibleTokenApprovalReceiver {
         owner_id: AccountId,
         approval_id: u64,
         msg: String,
-    ) -> near_sdk::PromiseOrValue<String>; // TODO: how to make "any"?
+    );
 }


### PR DESCRIPTION
Standard specifies no return value for this callback method.

https://nomicon.io/Standards/NonFungibleToken/ApprovalManagement.html#approved-account-contract-interface