### PR TITLE
fix a typo in a comment

### DIFF
--- a/near-contract-standards/src/fungible_token/core_impl.rs
+++ b/near-contract-standards/src/fungible_token/core_impl.rs
@@ -48,7 +48,7 @@ pub trait FungibleTokenContract {
     /// Returns the total supply of the token in a decimal string representation.
     fn ft_total_supply(&self) -> U128;
 
-    /// Returns the balance of the account. If the account doesn't exist must return `"0"`.
+    /// Returns the balance of the account. If the account doesn't exist `"0"` must be returned.
     fn ft_balance_of(&self, account_id: AccountId) -> U128;
 }
 

--- a/near-contract-standards/src/fungible_token/core_impl.rs
+++ b/near-contract-standards/src/fungible_token/core_impl.rs
@@ -48,7 +48,7 @@ pub trait FungibleTokenContract {
     /// Returns the total supply of the token in a decimal string representation.
     fn ft_total_supply(&self) -> U128;
 
-    /// Returns the balance of the account. If the account doesn't exist `"0"` must be returned.
+    /// Returns the balance of the account. If the account doesn't exist, `"0"` must be returned.
     fn ft_balance_of(&self, account_id: AccountId) -> U128;
 }
 

--- a/near-contract-standards/src/fungible_token/core_impl.rs
+++ b/near-contract-standards/src/fungible_token/core_impl.rs
@@ -48,7 +48,7 @@ pub trait FungibleTokenContract {
     /// Returns the total supply of the token in a decimal string representation.
     fn ft_total_supply(&self) -> U128;
 
-    /// Returns the balance of the account. If the account doesn't exist must returns `"0"`.
+    /// Returns the balance of the account. If the account doesn't exist must return `"0"`.
     fn ft_balance_of(&self, account_id: AccountId) -> U128;
 }
 


### PR DESCRIPTION
not sure whether it was a "must return "0"" or "returns "0"" so correct if wrong