### PR TITLE
Add M1 support for contract builder

### DIFF
--- a/contract-builder/README.md
+++ b/contract-builder/README.md
@@ -26,6 +26,10 @@ If you need to compile some other contracts, you can first export the path to th
 export HOST_DIR=/root/contracts/
 ```
 
+## Using on Mac M1 hardware
+
+Use `build_m1.sh` and `run_m1.sh` instead.
+
 ## Build contracts in docker
 
 Enter mounted path first:

--- a/contract-builder/build_m1.sh
+++ b/contract-builder/build_m1.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker buildx build --platform linux/arm64 -t contract-builder . --load

--- a/contract-builder/run_m1.sh
+++ b/contract-builder/run_m1.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+HOST_DIR="${HOST_DIR:-$(pwd)/..}"
+
+docker run \
+     --platform linux/arm64 \
+     --mount type=bind,source=$HOST_DIR,target=/host \
+     --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+     -i -t contract-builder \
+     /bin/bash
+


### PR DESCRIPTION
Add support for Mac M1 hardware to use with contract builder. Requires to use `docker buildx` 