### PR TITLE
fix: new clippy warning from 1.59

### DIFF
--- a/near-sdk/tests/code_size.rs
+++ b/near-sdk/tests/code_size.rs
@@ -13,7 +13,7 @@ fn check_example_size(example: &str) -> usize {
     let wasm = std::fs::read(format!(
         "../examples/{}/target/wasm32-unknown-unknown/release/{}.wasm",
         example,
-        example.replace("-", "_")
+        example.replace('-', "_")
     ))
     .unwrap();
 


### PR DESCRIPTION
self-explanatory, CI is failing in other branches rn