### PR TITLE
feat: add an optional way to handle contract errors with `Result`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## [unreleased]
 ### Features
 - Added `Debug` and `PartialEq` implementations for `PromiseError`. [PR 728](https://github.com/near/near-sdk-rs/pull/728).
-
 - Added convenience function `env::block_timestamp_ms` to return ms since 1970. [PR 736](https://github.com/near/near-sdk-rs/pull/728)
+- Added an optional way to handle contract errors with `Result`. [PR 745](https://github.com/near/near-sdk-rs/pull/745).
 
 ## `4.0.0-pre.7` [02-02-2022]
 

--- a/near-sdk-macros/src/core_impl/code_generator/impl_item_method_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/impl_item_method_info.rs
@@ -1,6 +1,7 @@
 use crate::core_impl::info_extractor::{
     AttrSigInfo, ImplItemMethodInfo, InputStructType, MethodType, SerializerType,
 };
+use crate::core_impl::utils;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{ReturnType, Signature};
@@ -53,6 +54,7 @@ impl ImplItemMethodInfo {
             method_type,
             is_payable,
             is_private,
+            is_returns_result,
             ..
         } = attr_signature_info;
         let deposit_check = if *is_payable || matches!(method_type, &MethodType::View) {
@@ -136,6 +138,30 @@ impl ImplItemMethodInfo {
                     #method_invocation;
                     #contract_ser
                 },
+                ReturnType::Type(_, return_type)
+                    if utils::type_is_result(&return_type) && *is_returns_result =>
+                {
+                    let value_ser = match result_serializer {
+                        SerializerType::JSON => quote! {
+                            let result = near_sdk::serde_json::to_vec(&result).expect("Failed to serialize the return value using JSON.");
+                        },
+                        SerializerType::Borsh => quote! {
+                            let result = near_sdk::borsh::BorshSerialize::try_to_vec(&result).expect("Failed to serialize the return value using Borsh.");
+                        },
+                    };
+                    quote! {
+                        #contract_deser
+                        let result = #method_invocation;
+                        match result {
+                            Ok(result) => {
+                                #value_ser
+                                near_sdk::env::value_return(&result);
+                                #contract_ser
+                            }
+                            Err(err) => near_sdk::FunctionError::panic(&err)
+                        }
+                    }
+                }
                 ReturnType::Type(_, _) => {
                     let value_ser = match result_serializer {
                         SerializerType::JSON => quote! {
@@ -146,11 +172,11 @@ impl ImplItemMethodInfo {
                         },
                     };
                     quote! {
-                    #contract_deser
-                    let result = #method_invocation;
-                    #value_ser
-                    near_sdk::env::value_return(&result);
-                    #contract_ser
+                        #contract_deser
+                        let result = #method_invocation;
+                        #value_ser
+                        near_sdk::env::value_return(&result);
+                        #contract_ser
                     }
                 }
             }

--- a/near-sdk-macros/src/core_impl/code_generator/impl_item_method_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/impl_item_method_info.rs
@@ -139,7 +139,7 @@ impl ImplItemMethodInfo {
                     #contract_ser
                 },
                 ReturnType::Type(_, return_type)
-                    if utils::type_is_result(&return_type) && *is_returns_result =>
+                    if utils::type_is_result(return_type) && *is_returns_result =>
                 {
                     let value_ser = match result_serializer {
                         SerializerType::JSON => quote! {

--- a/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
@@ -18,6 +18,8 @@ pub struct AttrSigInfo {
     pub is_payable: bool,
     /// Whether method can accept calls from self (current account)
     pub is_private: bool,
+    /// Whether method returns Result type where only Ok type is serialized
+    pub is_returns_result: bool,
     /// The serializer that we use for `env::input()`.
     pub input_serializer: SerializerType,
     /// The serializer that we use for the return type.
@@ -61,6 +63,7 @@ impl AttrSigInfo {
         let mut method_type = MethodType::Regular;
         let mut is_payable = false;
         let mut is_private = false;
+        let mut is_returns_result = false;
         // By the default we serialize the result with JSON.
         let mut result_serializer = SerializerType::JSON;
 
@@ -86,6 +89,9 @@ impl AttrSigInfo {
                 "result_serializer" => {
                     let serializer: SerializerAttr = syn::parse2(attr.tokens.clone())?;
                     result_serializer = serializer.serializer_type;
+                }
+                "return_result" => {
+                    is_returns_result = true;
                 }
                 _ => {
                     non_bindgen_attrs.push((*attr).clone());
@@ -136,6 +142,7 @@ impl AttrSigInfo {
             method_type,
             is_payable,
             is_private,
+            is_returns_result,
             result_serializer,
             receiver,
             returns,

--- a/near-sdk-macros/src/core_impl/mod.rs
+++ b/near-sdk-macros/src/core_impl/mod.rs
@@ -1,6 +1,7 @@
 mod code_generator;
 mod info_extractor;
 mod metadata;
+mod utils;
 pub use code_generator::*;
 pub use info_extractor::*;
 pub use metadata::metadata_visitor::MetadataVisitor;

--- a/near-sdk-macros/src/core_impl/utils/mod.rs
+++ b/near-sdk-macros/src/core_impl/utils/mod.rs
@@ -1,0 +1,41 @@
+use syn::{Type, Path, PathArguments, GenericArgument};
+
+/// Checks whether the given path is literally "Result".
+/// Note that it won't match a fully qualified name `core::result::Result` or a type alias like
+/// `type StringResult = Result<String, String>`.
+pub(crate) fn path_is_result(path: &Path) -> bool {
+    path.leading_colon.is_none()
+        && path.segments.len() == 1
+        && path.segments.iter().next().unwrap().ident == "Result"
+}
+
+/// Equivalent to `path_is_result` except that it works on `Type` values.
+pub(crate) fn type_is_result(ty: &Type) -> bool {
+    match ty {
+        Type::Path(type_path) if type_path.qself.is_none() => path_is_result(&type_path.path),
+        _ => false,
+    }
+}
+
+/// Extracts the Ok type from a `Result` type.
+///
+/// For example, given `Result<String, u8>` type it will return `String` type.
+pub(crate) fn extract_ok_type(ty: &Type) -> Option<&Type> {
+    match ty {
+        Type::Path(type_path) if type_path.qself.is_none() && path_is_result(&type_path.path) => {
+            // Get the first segment of the path (there should be only one, in fact: "Result"):
+            let type_params = &type_path.path.segments.first()?.arguments;
+            // We are interested in the first angle-bracketed param responsible for Ok type ("<String, _>"):
+            let generic_arg = match type_params {
+                PathArguments::AngleBracketed(params) => Some(params.args.first()?),
+                _ => None,
+            }?;
+            // This argument must be a type:
+            match generic_arg {
+                GenericArgument::Type(ty) => Some(ty),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}

--- a/near-sdk-macros/src/core_impl/utils/mod.rs
+++ b/near-sdk-macros/src/core_impl/utils/mod.rs
@@ -1,4 +1,4 @@
-use syn::{Type, Path, PathArguments, GenericArgument};
+use syn::{GenericArgument, Path, PathArguments, Type};
 
 /// Checks whether the given path is literally "Result".
 /// Note that it won't match a fully qualified name `core::result::Result` or a type alias like

--- a/near-sdk-macros/src/lib.rs
+++ b/near-sdk-macros/src/lib.rs
@@ -205,8 +205,8 @@ pub fn function_error(item: TokenStream) -> TokenStream {
     };
     TokenStream::from(quote! {
         impl near_sdk::FunctionError for #name {
-            fn panic(&self) {
-                near_sdk::env::panic_str(&std::string::ToString::to_string(&self))
+            fn panic(&self) -> ! {
+                near_sdk::env::panic_str(&::std::string::ToString::to_string(&self))
             }
         }
     })

--- a/near-sdk-macros/src/lib.rs
+++ b/near-sdk-macros/src/lib.rs
@@ -184,3 +184,30 @@ pub fn borsh_storage_key(item: TokenStream) -> TokenStream {
         impl near_sdk::BorshIntoStorageKey for #name {}
     })
 }
+
+/// `FunctionError` generates implementation for `near_sdk::FunctionError` trait.
+/// It allows contract runtime to panic with the type using its `ToString` implementation
+/// as the message.
+#[proc_macro_derive(FunctionError)]
+pub fn function_error(item: TokenStream) -> TokenStream {
+    let name = if let Ok(input) = syn::parse::<ItemEnum>(item.clone()) {
+        input.ident
+    } else if let Ok(input) = syn::parse::<ItemStruct>(item) {
+        input.ident
+    } else {
+        return TokenStream::from(
+            syn::Error::new(
+                Span::call_site(),
+                "FunctionError can only be used as a derive on enums or structs.",
+            )
+            .to_compile_error(),
+        );
+    };
+    TokenStream::from(quote! {
+        impl near_sdk::FunctionError for #name {
+            fn panic(&self) {
+                near_sdk::env::panic_str(&std::string::ToString::to_string(&self))
+            }
+        }
+    })
+}

--- a/near-sdk/compilation_tests/all.rs
+++ b/near-sdk/compilation_tests/all.rs
@@ -19,4 +19,5 @@ fn compilation_tests() {
     t.pass("compilation_tests/cond_compilation.rs");
     t.compile_fail("compilation_tests/payable_view.rs");
     t.pass("compilation_tests/borsh_storage_key.rs");
+    t.pass("compilation_tests/function_error.rs");
 }

--- a/near-sdk/compilation_tests/function_error.rs
+++ b/near-sdk/compilation_tests/function_error.rs
@@ -1,0 +1,50 @@
+//! Testing FunctionError macro.
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use near_sdk::{near_bindgen, FunctionError};
+use std::fmt;
+
+#[derive(FunctionError, BorshSerialize)]
+struct ErrorStruct {
+    message: String,
+}
+
+impl fmt::Display for ErrorStruct {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "error ocurred: {}", self.message)
+    }
+}
+
+#[derive(FunctionError, BorshSerialize)]
+enum ErrorEnum {
+    NotFound,
+    Banned { account_id: String },
+}
+
+impl fmt::Display for ErrorEnum {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ErrorEnum::NotFound => write!(f, "not found"),
+            ErrorEnum::Banned { account_id } => write!(f, "account {} is banned", account_id)
+        }
+    }
+}
+
+#[near_bindgen]
+#[derive(BorshDeserialize, BorshSerialize, Default)]
+struct Contract {}
+
+#[near_bindgen]
+impl Contract {
+    #[return_result]
+    pub fn set(&self, value: String) -> Result<String, ErrorStruct> {
+        Err(ErrorStruct { message: format!("Could not set to {}", value) })
+    }
+
+    #[return_result]
+    pub fn get(&self) -> Result<String, ErrorEnum> {
+        Err(ErrorEnum::NotFound)
+    }
+}
+
+fn main() {}

--- a/near-sdk/src/lib.rs
+++ b/near-sdk/src/lib.rs
@@ -7,7 +7,7 @@ extern crate quickcheck;
 
 pub use near_sdk_macros::{
     callback, callback_vec, ext_contract, init, metadata, near_bindgen, result_serializer,
-    serializer, BorshStorageKey, PanicOnDefault,
+    serializer, BorshStorageKey, PanicOnDefault, FunctionError
 };
 
 #[cfg(feature = "unstable")]

--- a/near-sdk/src/lib.rs
+++ b/near-sdk/src/lib.rs
@@ -7,7 +7,7 @@ extern crate quickcheck;
 
 pub use near_sdk_macros::{
     callback, callback_vec, ext_contract, init, metadata, near_bindgen, result_serializer,
-    serializer, BorshStorageKey, PanicOnDefault, FunctionError
+    serializer, BorshStorageKey, FunctionError, PanicOnDefault,
 };
 
 #[cfg(feature = "unstable")]

--- a/near-sdk/src/types/error.rs
+++ b/near-sdk/src/types/error.rs
@@ -1,5 +1,3 @@
-use std::borrow::Borrow;
-
 /// Enables contract runtime to panic with the given type. Any error type used in conjunction
 /// with `#[return_result]` has to implement this trait.
 ///
@@ -12,7 +10,7 @@ use std::borrow::Borrow;
 /// }
 ///
 /// impl FunctionError for Error {
-///     fn panic(&self) {
+///     fn panic(&self) -> ! {
 ///         match self {
 ///             Error::NotFound =>
 ///                 near_sdk::env::panic_str("not found"),
@@ -23,14 +21,14 @@ use std::borrow::Borrow;
 /// }
 /// ```
 pub trait FunctionError {
-    fn panic(&self);
+    fn panic(&self) -> !;
 }
 
 impl<T> FunctionError for T
 where
-    T: Borrow<str>,
+    T: AsRef<str>,
 {
-    fn panic(&self) {
-        crate::env::panic_str(self.borrow())
+    fn panic(&self) -> ! {
+        crate::env::panic_str(self.as_ref())
     }
 }

--- a/near-sdk/src/types/error.rs
+++ b/near-sdk/src/types/error.rs
@@ -1,0 +1,36 @@
+use std::borrow::Borrow;
+
+/// Enables contract runtime to panic with the given type. Any error type used in conjunction
+/// with `#[return_result]` has to implement this trait.
+///
+/// ```
+/// use near_sdk::FunctionError;
+///
+/// enum Error {
+///     NotFound,
+///     Unexpected { message: String },
+/// }
+///
+/// impl FunctionError for Error {
+///     fn panic(&self) {
+///         match self {
+///             Error::NotFound =>
+///                 near_sdk::env::panic_str("not found"),
+///             Error::Unexpected { message } =>
+///                 near_sdk::env::panic_str(&format!("unexpected error: {}", message))
+///         }
+///     }
+/// }
+/// ```
+pub trait FunctionError {
+    fn panic(&self);
+}
+
+impl<T> FunctionError for T
+where
+    T: Borrow<str>
+{
+    fn panic(&self) {
+        crate::env::panic_str(self.borrow())
+    }
+}

--- a/near-sdk/src/types/error.rs
+++ b/near-sdk/src/types/error.rs
@@ -28,7 +28,7 @@ pub trait FunctionError {
 
 impl<T> FunctionError for T
 where
-    T: Borrow<str>
+    T: Borrow<str>,
 {
     fn panic(&self) {
         crate::env::panic_str(self.borrow())

--- a/near-sdk/src/types/mod.rs
+++ b/near-sdk/src/types/mod.rs
@@ -13,6 +13,9 @@ pub use self::account_id::{AccountId, ParseAccountIdError};
 mod gas;
 pub use self::gas::Gas;
 
+mod error;
+pub use self::error::FunctionError;
+
 /// Raw type for duration in nanoseconds
 pub type Duration = u64;
 


### PR DESCRIPTION
Fixes #574 

This PR provides an opt-in way to treat `Result` function return types as an error-handling mechanism. Meaning that only the underlying `Ok` values are serialized while the `Err` values result in panic. To do this, `FunctionError` must be implemented by the `Err`type (there are default implementations for types that have `Borrow<str>` and a derivation macro that generates a `ToString`-powered implementation).

The legacy behavior still works by default (`Result` is treated as a normal value and goes through full serialization), but it is supposed to generate compilation warnings (I am still trying to figure out a proper way to do this as`compile_warning!` seems to be missing rn, any suggestions are welcome). The user will have to mark the function with `#[return_result]` to opt-in for the new behavior.