### PR TITLE
deprecate and remove unused proc_macro_attributes

### DIFF
--- a/near-sdk-macros/src/lib.rs
+++ b/near-sdk-macros/src/lib.rs
@@ -81,29 +81,34 @@ pub fn ext_contract(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 /// `callback` is a marker attribute it does not generate code by itself.
 #[proc_macro_attribute]
+#[deprecated(since = "4.0.0", note = "Case is handled internally by macro, no need to import")]
 pub fn callback(_attr: TokenStream, item: TokenStream) -> TokenStream {
     item
 }
 
 /// `callback_args_vec` is a marker attribute it does not generate code by itself.
+#[deprecated(since = "4.0.0", note = "Case is handled internally by macro, no need to import")]
 #[proc_macro_attribute]
 pub fn callback_vec(_attr: TokenStream, item: TokenStream) -> TokenStream {
     item
 }
 
 /// `serializer` is a marker attribute it does not generate code by itself.
+#[deprecated(since = "4.0.0", note = "Case is handled internally by macro, no need to import")]
 #[proc_macro_attribute]
 pub fn serializer(_attr: TokenStream, item: TokenStream) -> TokenStream {
     item
 }
 
 /// `result_serializer` is a marker attribute it does not generate code by itself.
+#[deprecated(since = "4.0.0", note = "Case is handled internally by macro, no need to import")]
 #[proc_macro_attribute]
 pub fn result_serializer(_attr: TokenStream, item: TokenStream) -> TokenStream {
     item
 }
 
 /// `init` is a marker attribute it does not generate code by itself.
+#[deprecated(since = "4.0.0", note = "Case is handled internally by macro, no need to import")]
 #[proc_macro_attribute]
 pub fn init(_attr: TokenStream, item: TokenStream) -> TokenStream {
     item

--- a/near-sdk/src/lib.rs
+++ b/near-sdk/src/lib.rs
@@ -6,8 +6,7 @@
 extern crate quickcheck;
 
 pub use near_sdk_macros::{
-    callback, callback_vec, ext_contract, init, metadata, near_bindgen, result_serializer,
-    serializer, BorshStorageKey, FunctionError, PanicOnDefault,
+    ext_contract, metadata, near_bindgen, BorshStorageKey, FunctionError, PanicOnDefault,
 };
 
 #[cfg(feature = "unstable")]


### PR DESCRIPTION
closes #766 

There was no clean way of deprecating this re-export so I've just removed it since it's coming with a major version bump. Migration should be simple enough I think. Another option is exporting modules with the same name and deprecating them, but this clutters docs a bit too much since those are shown first.

Unless someone has a better alternative to deprecate these proc_macro_attribute macros?