### PR TITLE
fix: remove payable check for non-mutable functions

### DIFF
--- a/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
@@ -81,6 +81,25 @@ mod tests {
         assert_eq!(expected.to_string(), actual.to_string());
     }
 
+
+    #[test]
+    fn no_args_no_return_no_self() {
+        let impl_type: Type = syn::parse_str("Hello").unwrap();
+        let mut method: ImplItemMethod = syn::parse_str("pub fn method() { }").unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, impl_type).unwrap();
+        let actual = method_info.method_wrapper();
+        let expected = quote!(
+            #[cfg(target_arch = "wasm32")]
+            #[no_mangle]
+            pub extern "C" fn method() {
+                near_sdk::env::setup_panic_hook();
+                Hello::method();
+            }
+        );
+        assert_eq!(expected.to_string(), actual.to_string());
+    }
+
+
     #[test]
     fn owned_no_args_no_return_no_mut() {
         let impl_type: Type = syn::parse_str("Hello").unwrap();

--- a/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
@@ -120,7 +120,7 @@ impl AttrSigInfo {
                     "Init methods can't have `self` attribute",
                 ));
             }
-        };
+        }
 
         if let Some(payable_attr) = payable_attr {
             if matches!(method_type, MethodType::View) {


### PR DESCRIPTION
Opinionated change, probably shouldn't come in, opening for discussion. It was a foot gun for what I was just doing, but it doesn't seem super clean to just remove.

Pros:
- Removes foot gun of trying to call a method without parameters as a view call and failing

Cons:
- Silently removes non-payable check to anyone using this method and modifying state manually

Neutral:
- Moves in direction of non-payable methods by default. Unclear if developers expect this or benefit from the security of this by default (probably requires developer input cc @AustinBaggio). Is a pattern in Ethereum by default, but doesn't fit cleanly into our model because `attached_deposit` fails by default in view context. (I will follow up to ask why this is the case and not just defaulting to 0 https://near.zulipchat.com/#narrow/stream/295306-pagoda.2Fcontract-runtime/topic/attached_deposit.20view.20error/near/277355733)