### PR TITLE
fix: Optimize nth implementation for legacy UnorderedMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixes
+- Optimized `nth` operation for `UnorderedMap` iterator and implemented `IntoIterator` for it. [PR 801](https://github.com/near/near-sdk-rs/pull/801)
+  - This optimizes the `skip` operation, which is common with pagination
+
 ## [4.0.0-pre.8] - 2022-04-19
 
 ### Added

--- a/near-sdk/src/collections/mod.rs
+++ b/near-sdk/src/collections/mod.rs
@@ -47,7 +47,7 @@ pub use lookup_set::LookupSet;
 pub mod vector;
 pub use vector::Vector;
 
-mod unordered_map;
+pub mod unordered_map;
 pub use unordered_map::UnorderedMap;
 
 mod unordered_set;

--- a/near-sdk/src/collections/unordered_map/iter.rs
+++ b/near-sdk/src/collections/unordered_map/iter.rs
@@ -1,0 +1,84 @@
+use super::UnorderedMap;
+use crate::collections::vector;
+use borsh::{BorshDeserialize, BorshSerialize};
+use std::iter::FusedIterator;
+
+impl<'a, K, V> IntoIterator for &'a UnorderedMap<K, V>
+where
+    K: BorshSerialize + BorshDeserialize,
+    V: BorshSerialize + BorshDeserialize,
+{
+    type Item = (K, V);
+    type IntoIter = Iter<'a, K, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// An iterator over each element deserialized in the [`UnorderedMap`].
+pub struct Iter<'a, K, V> {
+    keys: vector::Iter<'a, K>,
+    values: vector::Iter<'a, V>,
+}
+
+impl<'a, K, V> Iter<'a, K, V>
+where
+    K: BorshSerialize + BorshDeserialize,
+    V: BorshSerialize + BorshDeserialize,
+{
+    pub(super) fn new(map: &'a UnorderedMap<K, V>) -> Self {
+        Self { keys: map.keys.iter(), values: map.values.iter() }
+    }
+}
+
+impl<'a, K, V> Iterator for Iter<'a, K, V>
+where
+    K: BorshSerialize + BorshDeserialize,
+    V: BorshSerialize + BorshDeserialize,
+{
+    type Item = (K, V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        <Self as Iterator>::nth(self, 0)
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        Some((self.keys.nth(n)?, self.values.nth(n)?))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.keys.size_hint()
+    }
+
+    fn count(self) -> usize {
+        self.keys.count()
+    }
+}
+
+impl<'a, K, V> ExactSizeIterator for Iter<'a, K, V>
+where
+    K: BorshSerialize + BorshDeserialize,
+    V: BorshSerialize + BorshDeserialize,
+{
+}
+impl<'a, K, V> FusedIterator for Iter<'a, K, V>
+where
+    K: BorshSerialize + BorshDeserialize,
+    V: BorshSerialize + BorshDeserialize,
+{
+}
+
+impl<'a, K, V> DoubleEndedIterator for Iter<'a, K, V>
+where
+    K: BorshSerialize + BorshDeserialize,
+    V: BorshSerialize + BorshDeserialize,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        <Self as DoubleEndedIterator>::nth_back(self, 0)
+    }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        Some((self.keys.nth_back(n)?, self.values.nth_back(n)?))
+    }
+}


### PR DESCRIPTION
Made the change minimally invasive since this is somewhat of a legacy collection. The new ones are optimized and I assumed that `zip` with the optimization done to #634 would be applied to the `UnorderedMap`, but it wasn't.

exposes `unordered_map` module to allow `Iter` type to be used. Didn't add iterator types to others since no demand. There would be a benefit (in that the aux iterator traits would be available) but I don't want to return `vector::Iter` for backwards compatibility if we wanted to switch later and didn't want to just add a bunch of redundant code for no strong reason.