### PR TITLE
refactor!: Impl Promise generics at the type level

### DIFF
--- a/examples/callback-results/src/lib.rs
+++ b/examples/callback-results/src/lib.rs
@@ -1,5 +1,5 @@
 use near_sdk::{env, near_bindgen, PromiseError};
-use near_sdk::{require, ScheduledFn};
+use near_sdk::{require, Promise};
 
 const A_VALUE: u8 = 8;
 
@@ -9,7 +9,7 @@ pub struct Callback;
 #[near_bindgen]
 impl Callback {
     /// Call functions a, b, and c asynchronously and handle results with `handle_callbacks`.
-    pub fn call_all(fail_b: bool, c_value: u8, d_value: u8) -> ScheduledFn<(bool, bool, bool)> {
+    pub fn call_all(fail_b: bool, c_value: u8, d_value: u8) -> Promise<(bool, bool, bool)> {
         let id = env::current_account_id();
         Self::ext(&id)
             .a()
@@ -21,7 +21,7 @@ impl Callback {
     }
 
     /// Calls function c with a value that will always succeed
-    pub fn a() -> ScheduledFn<u8> {
+    pub fn a() -> Promise<u8> {
         Self::ext(&env::current_account_id()).c(A_VALUE).schedule_as_return()
     }
 

--- a/examples/callback-results/src/lib.rs
+++ b/examples/callback-results/src/lib.rs
@@ -69,16 +69,13 @@ mod tests {
 
     #[tokio::test]
     async fn workspaces_test() -> anyhow::Result<()> {
-        println!("HERE");
         let wasm = fs::read("res/callback_results.wasm").await?;
         let worker = workspaces::sandbox().await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         // Call function a only to ensure it has correct behaviour
         let res = contract.call("a").transact().await?;
-        println!("Result: {:?}", res.logs());
         assert_eq!(res.json::<u8>()?, 8);
-        println!("POST A");
 
         // Following tests the function call where the `call_all` function always succeeds and handles
         // the result of the async calls made from within the function with callbacks.

--- a/examples/callback-results/src/lib.rs
+++ b/examples/callback-results/src/lib.rs
@@ -10,17 +10,18 @@ pub struct Callback;
 impl Callback {
     /// Call functions a, b, and c asynchronously and handle results with `handle_callbacks`.
     pub fn call_all(fail_b: bool, c_value: u8, d_value: u8) -> Promise<(bool, bool, bool)> {
-        Self::ext(env::current_account_id())
+        let id = env::current_account_id();
+        Self::ext(id)
             .a()
-            .and(Self::ext(env::current_account_id()).b(fail_b))
-            .and(Self::ext(env::current_account_id()).c(c_value))
-            .and(Self::ext(env::current_account_id()).d(d_value))
-            .then(Self::ext(env::current_account_id()).handle_callbacks())
+            .and(Self::ext(id).b(fail_b))
+            .and(Self::ext(id).c(c_value))
+            .and(Self::ext(id).d(d_value))
+            .then(Self::ext(id).handle_callbacks())
     }
 
     /// Calls function c with a value that will always succeed
     pub fn a() -> Promise<u8> {
-        Self::ext(env::current_account_id()).c(A_VALUE)
+        Self::ext(&env::current_account_id()).c(A_VALUE)
     }
 
     /// Returns a static string if fail is false, return

--- a/examples/callback-results/src/lib.rs
+++ b/examples/callback-results/src/lib.rs
@@ -9,7 +9,7 @@ pub struct Callback;
 #[near_bindgen]
 impl Callback {
     /// Call functions a, b, and c asynchronously and handle results with `handle_callbacks`.
-    pub fn call_all(fail_b: bool, c_value: u8, d_value: u8) -> Promise {
+    pub fn call_all(fail_b: bool, c_value: u8, d_value: u8) -> Promise<(bool, bool, bool)> {
         Self::ext(env::current_account_id())
             .a()
             .and(Self::ext(env::current_account_id()).b(fail_b))
@@ -19,7 +19,7 @@ impl Callback {
     }
 
     /// Calls function c with a value that will always succeed
-    pub fn a() -> Promise {
+    pub fn a() -> Promise<u8> {
         Self::ext(env::current_account_id()).c(A_VALUE)
     }
 

--- a/examples/cross-contract-calls/high-level/src/lib.rs
+++ b/examples/cross-contract-calls/high-level/src/lib.rs
@@ -14,10 +14,11 @@ impl CrossContract {
         }
         let account_id = env::current_account_id();
 
-        Self::ext(account_id.clone())
+        Self::ext(&account_id)
             .with_unused_gas_weight(6)
             .factorial(n - 1)
-            .then(Self::ext(account_id).factorial_mult(n))
+            .then(Self::ext(&account_id).factorial_mult(n))
+            .schedule_as_return()
             .into()
     }
 

--- a/examples/factory-contract/high-level/src/lib.rs
+++ b/examples/factory-contract/high-level/src/lib.rs
@@ -1,6 +1,6 @@
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
-use near_sdk::{env, ext_contract, json_types::U128, near_bindgen, AccountId, Promise};
-use near_sdk::{PromiseError, ScheduledFn};
+use near_sdk::{env, ext_contract, json_types::U128, near_bindgen, AccountId};
+use near_sdk::{Promise, PromiseBuilder, PromiseError};
 
 #[near_bindgen]
 #[derive(Default, BorshDeserialize, BorshSerialize)]
@@ -17,7 +17,7 @@ pub trait ExtStatusMessage {
 #[near_bindgen]
 impl FactoryContract {
     pub fn deploy_status_message(&self, account_id: AccountId, amount: U128) {
-        Promise::new(&account_id)
+        PromiseBuilder::new(&account_id)
             .create_account()
             .transfer(amount.0)
             .add_full_access_key(&env::signer_account_pk())
@@ -34,7 +34,7 @@ impl FactoryContract {
         &mut self,
         account_id: AccountId,
         message: String,
-    ) -> ScheduledFn<Option<String>> {
+    ) -> Promise<Option<String>> {
         // 1) call status_message to record a message from the signer.
         // 2) call status_message to retrieve the message of the signer.
         // 3) return that message as its own result.
@@ -50,7 +50,7 @@ impl FactoryContract {
         &self,
         account_id: &AccountId,
         #[callback_result] set_status_result: Result<(), PromiseError>,
-    ) -> Result<ScheduledFn<Option<String>>, &'static str> {
+    ) -> Result<Promise<Option<String>>, &'static str> {
         match set_status_result {
             Ok(_) => Ok(ext_status_message::ext(&account_id)
                 .get_status(&env::signer_account_id())

--- a/examples/factory-contract/high-level/src/lib.rs
+++ b/examples/factory-contract/high-level/src/lib.rs
@@ -22,7 +22,7 @@ impl FactoryContract {
             .transfer(amount.0)
             .add_full_access_key(&env::signer_account_pk())
             .deploy_contract(
-                include_bytes!("../../../status-message/res/status_message.wasm").to_vec(),
+                &include_bytes!("../../../status-message/res/status_message.wasm").to_vec(),
             )
             .schedule();
     }

--- a/examples/factory-contract/high-level/src/lib.rs
+++ b/examples/factory-contract/high-level/src/lib.rs
@@ -29,7 +29,7 @@ impl FactoryContract {
     pub fn simple_call(&mut self, account_id: AccountId, message: String) {
         ext_status_message::ext(account_id).set_status(message);
     }
-    pub fn complex_call(&mut self, account_id: AccountId, message: String) -> Promise {
+    pub fn complex_call(&mut self, account_id: AccountId, message: String) -> Promise<Promise<Option<String>>> {
         // 1) call status_message to record a message from the signer.
         // 2) call status_message to retrieve the message of the signer.
         // 3) return that message as its own result.
@@ -44,7 +44,7 @@ impl FactoryContract {
         &self,
         account_id: AccountId,
         #[callback_result] set_status_result: Result<(), PromiseError>,
-    ) -> Result<Promise, &'static str> {
+    ) -> Result<Promise<Option<String>>, &'static str> {
         match set_status_result {
             Ok(_) => Ok(ext_status_message::ext(account_id).get_status(env::signer_account_id())),
             Err(_) => Err("Failed to set status"),

--- a/examples/factory-contract/high-level/src/lib.rs
+++ b/examples/factory-contract/high-level/src/lib.rs
@@ -36,7 +36,7 @@ impl FactoryContract {
         // Note, for a contract to simply call another contract (1) is sufficient.
         ext_status_message::ext(account_id.clone())
             .set_status(message)
-            .then(Self::ext(env::current_account_id()).get_result(account_id))
+            .then(Self::ext(&env::current_account_id()).get_result(account_id))
     }
 
     #[handle_result]

--- a/examples/factory-contract/high-level/src/lib.rs
+++ b/examples/factory-contract/high-level/src/lib.rs
@@ -34,7 +34,7 @@ impl FactoryContract {
         &mut self,
         account_id: AccountId,
         message: String,
-    ) -> ScheduledFn<ScheduledFn<Option<String>>> {
+    ) -> ScheduledFn<Option<String>> {
         // 1) call status_message to record a message from the signer.
         // 2) call status_message to retrieve the message of the signer.
         // 3) return that message as its own result.

--- a/examples/factory-contract/high-level/src/lib.rs
+++ b/examples/factory-contract/high-level/src/lib.rs
@@ -1,6 +1,6 @@
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
-use near_sdk::PromiseError;
 use near_sdk::{env, ext_contract, json_types::U128, near_bindgen, AccountId, Promise};
+use near_sdk::{PromiseError, ScheduledFn};
 
 #[near_bindgen]
 #[derive(Default, BorshDeserialize, BorshSerialize)]
@@ -11,42 +11,50 @@ pub struct FactoryContract {}
 #[ext_contract]
 pub trait ExtStatusMessage {
     fn set_status(&mut self, message: String);
-    fn get_status(&self, account_id: AccountId) -> Option<String>;
+    fn get_status(&self, account_id: &AccountId) -> Option<String>;
 }
 
 #[near_bindgen]
 impl FactoryContract {
     pub fn deploy_status_message(&self, account_id: AccountId, amount: U128) {
-        Promise::new(account_id)
+        Promise::new(&account_id)
             .create_account()
             .transfer(amount.0)
-            .add_full_access_key(env::signer_account_pk())
+            .add_full_access_key(&env::signer_account_pk())
             .deploy_contract(
                 include_bytes!("../../../status-message/res/status_message.wasm").to_vec(),
-            );
+            )
+            .schedule();
     }
 
     pub fn simple_call(&mut self, account_id: AccountId, message: String) {
-        ext_status_message::ext(account_id).set_status(message);
+        ext_status_message::ext(&account_id).set_status(message).schedule();
     }
-    pub fn complex_call(&mut self, account_id: AccountId, message: String) -> Promise<Promise<Option<String>>> {
+    pub fn complex_call(
+        &mut self,
+        account_id: AccountId,
+        message: String,
+    ) -> ScheduledFn<ScheduledFn<Option<String>>> {
         // 1) call status_message to record a message from the signer.
         // 2) call status_message to retrieve the message of the signer.
         // 3) return that message as its own result.
         // Note, for a contract to simply call another contract (1) is sufficient.
-        ext_status_message::ext(account_id.clone())
+        ext_status_message::ext(&account_id)
             .set_status(message)
-            .then(Self::ext(&env::current_account_id()).get_result(account_id))
+            .then(Self::ext(&env::current_account_id()).get_result(&account_id))
+            .schedule_as_return()
     }
 
     #[handle_result]
     pub fn get_result(
         &self,
-        account_id: AccountId,
+        account_id: &AccountId,
         #[callback_result] set_status_result: Result<(), PromiseError>,
-    ) -> Result<Promise<Option<String>>, &'static str> {
+    ) -> Result<ScheduledFn<Option<String>>, &'static str> {
         match set_status_result {
-            Ok(_) => Ok(ext_status_message::ext(account_id).get_status(env::signer_account_id())),
+            Ok(_) => Ok(ext_status_message::ext(&account_id)
+                .get_status(&env::signer_account_id())
+                .schedule_as_return()),
             Err(_) => Err("Failed to set status"),
         }
     }

--- a/examples/fungible-token/test-contract-defi/src/lib.rs
+++ b/examples/fungible-token/test-contract-defi/src/lib.rs
@@ -5,8 +5,7 @@ use near_contract_standards::fungible_token::receiver::FungibleTokenReceiver;
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::json_types::U128;
 use near_sdk::{
-    env, log, near_bindgen, require, AccountId, Balance, Gas, PanicOnDefault,
-    PromiseOrValue,
+    env, log, near_bindgen, require, AccountId, Balance, Gas, PanicOnDefault, PromiseOrValue,
 };
 
 const BASE_GAS: u64 = 5_000_000_000_000;
@@ -55,9 +54,10 @@ impl FungibleTokenReceiver for DeFi {
             _ => {
                 let prepaid_gas = env::prepaid_gas();
                 let account_id = env::current_account_id();
-                Self::ext(account_id)
+                Self::ext(&account_id)
                     .with_static_gas(prepaid_gas - GAS_FOR_FT_ON_TRANSFER)
                     .value_please(msg)
+                    .schedule_as_return()
                     .into()
             }
         }

--- a/examples/fungible-token/test-contract-defi/src/lib.rs
+++ b/examples/fungible-token/test-contract-defi/src/lib.rs
@@ -21,7 +21,7 @@ pub struct DeFi {
 
 // Have to repeat the same trait for our own implementation.
 trait ValueReturnTrait {
-    fn value_please(&self, amount_to_return: String) -> PromiseOrValue<U128>;
+    fn value_please(&self, amount_to_return: String) -> U128;
 }
 
 #[near_bindgen]
@@ -66,9 +66,9 @@ impl FungibleTokenReceiver for DeFi {
 
 #[near_bindgen]
 impl ValueReturnTrait for DeFi {
-    fn value_please(&self, amount_to_return: String) -> PromiseOrValue<U128> {
+    fn value_please(&self, amount_to_return: String) -> U128 {
         log!("in value_please, amount_to_return = {}", amount_to_return);
         let amount: Balance = amount_to_return.parse().expect("Not an integer");
-        PromiseOrValue::Value(amount.into())
+        amount.into()
     }
 }

--- a/examples/non-fungible-token/nft/src/lib.rs
+++ b/examples/non-fungible-token/nft/src/lib.rs
@@ -23,7 +23,7 @@ use near_contract_standards::non_fungible_token::{Token, TokenId};
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::collections::LazyOption;
 use near_sdk::{
-    env, near_bindgen, require, AccountId, BorshStorageKey, PanicOnDefault, Promise, PromiseOrValue,
+    env, near_bindgen, require, AccountId, BorshStorageKey, PanicOnDefault, PromiseOrValue,
 };
 
 #[near_bindgen]

--- a/examples/non-fungible-token/test-approval-receiver/src/lib.rs
+++ b/examples/non-fungible-token/test-approval-receiver/src/lib.rs
@@ -4,10 +4,7 @@ A stub contract that implements nft_on_approve for e2e testing nft_approve.
 use near_contract_standards::non_fungible_token::approval::NonFungibleTokenApprovalReceiver;
 use near_contract_standards::non_fungible_token::TokenId;
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
-use near_sdk::{
-    env, log, near_bindgen, require, AccountId, Gas, PanicOnDefault,
-    PromiseOrValue,
-};
+use near_sdk::{env, log, near_bindgen, require, AccountId, Gas, PanicOnDefault, PromiseOrValue};
 
 const BASE_GAS: u64 = 5_000_000_000_000;
 const PROMISE_CALL: u64 = 5_000_000_000_000;
@@ -64,9 +61,10 @@ impl NonFungibleTokenApprovalReceiver for ApprovalReceiver {
             _ => {
                 let prepaid_gas = env::prepaid_gas();
                 let account_id = env::current_account_id();
-                Self::ext(account_id)
+                Self::ext(&account_id)
                     .with_static_gas(prepaid_gas - GAS_FOR_NFT_ON_APPROVE)
                     .ok_go(msg)
+                    .schedule_as_return()
                     .into()
             }
         }

--- a/examples/non-fungible-token/test-approval-receiver/src/lib.rs
+++ b/examples/non-fungible-token/test-approval-receiver/src/lib.rs
@@ -18,7 +18,7 @@ pub struct ApprovalReceiver {
 
 // Have to repeat the same trait for our own implementation.
 trait ValueReturnTrait {
-    fn ok_go(&self, msg: String) -> PromiseOrValue<String>;
+    fn ok_go(&self, msg: String) -> Option<String>;
 }
 
 #[near_bindgen]
@@ -43,7 +43,7 @@ impl NonFungibleTokenApprovalReceiver for ApprovalReceiver {
         owner_id: AccountId,
         approval_id: u64,
         msg: String,
-    ) -> PromiseOrValue<String> {
+    ) -> PromiseOrValue<Option<String>> {
         // Verifying that we were called by non-fungible token contract that we expect.
         require!(
             env::predecessor_account_id() == self.non_fungible_token_account_id,
@@ -57,7 +57,7 @@ impl NonFungibleTokenApprovalReceiver for ApprovalReceiver {
             msg
         );
         match msg.as_str() {
-            "return-now" => PromiseOrValue::Value("cool".to_string()),
+            "return-now" => PromiseOrValue::Value(Some("cool".to_string())),
             _ => {
                 let prepaid_gas = env::prepaid_gas();
                 let account_id = env::current_account_id();
@@ -73,8 +73,8 @@ impl NonFungibleTokenApprovalReceiver for ApprovalReceiver {
 
 #[near_bindgen]
 impl ValueReturnTrait for ApprovalReceiver {
-    fn ok_go(&self, msg: String) -> PromiseOrValue<String> {
+    fn ok_go(&self, msg: String) -> Option<String> {
         log!("in ok_go, msg={}", msg);
-        PromiseOrValue::Value(msg)
+        Some(msg)
     }
 }

--- a/examples/non-fungible-token/test-token-receiver/src/lib.rs
+++ b/examples/non-fungible-token/test-token-receiver/src/lib.rs
@@ -20,7 +20,7 @@ pub struct TokenReceiver {
 
 // Have to repeat the same trait for our own implementation.
 trait ValueReturnTrait {
-    fn ok_go(&self, return_it: bool) -> PromiseOrValue<bool>;
+    fn ok_go(&self, return_it: bool) -> bool;
 }
 
 #[near_bindgen]
@@ -85,8 +85,8 @@ impl NonFungibleTokenReceiver for TokenReceiver {
 
 #[near_bindgen]
 impl ValueReturnTrait for TokenReceiver {
-    fn ok_go(&self, return_it: bool) -> PromiseOrValue<bool> {
+    fn ok_go(&self, return_it: bool) -> bool {
         log!("in ok_go, return_it={}", return_it);
-        PromiseOrValue::Value(return_it)
+        return_it
     }
 }

--- a/examples/non-fungible-token/test-token-receiver/src/lib.rs
+++ b/examples/non-fungible-token/test-token-receiver/src/lib.rs
@@ -4,9 +4,7 @@ A stub contract that implements nft_on_transfer for simulation testing nft_trans
 use near_contract_standards::non_fungible_token::core::NonFungibleTokenReceiver;
 use near_contract_standards::non_fungible_token::TokenId;
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
-use near_sdk::{
-    env, log, near_bindgen, require, AccountId, Gas, PanicOnDefault, PromiseOrValue,
-};
+use near_sdk::{env, log, near_bindgen, require, AccountId, Gas, PanicOnDefault, PromiseOrValue};
 
 const BASE_GAS: u64 = 5_000_000_000_000;
 const PROMISE_CALL: u64 = 5_000_000_000_000;
@@ -64,18 +62,20 @@ impl NonFungibleTokenReceiver for TokenReceiver {
             "return-it-later" => {
                 let prepaid_gas = env::prepaid_gas();
                 let account_id = env::current_account_id();
-                Self::ext(account_id)
+                Self::ext(&account_id)
                     .with_static_gas(prepaid_gas - GAS_FOR_NFT_ON_TRANSFER)
                     .ok_go(true)
+                    .schedule_as_return()
                     .into()
             }
             "keep-it-now" => PromiseOrValue::Value(false),
             "keep-it-later" => {
                 let prepaid_gas = env::prepaid_gas();
                 let account_id = env::current_account_id();
-                Self::ext(account_id)
+                Self::ext(&account_id)
                     .with_static_gas(prepaid_gas - GAS_FOR_NFT_ON_TRANSFER)
                     .ok_go(false)
+                    .schedule_as_return()
                     .into()
             }
             _ => env::panic_str("unsupported msg"),

--- a/near-contract-standards/src/fungible_token/core_impl.rs
+++ b/near-contract-standards/src/fungible_token/core_impl.rs
@@ -142,11 +142,12 @@ impl FungibleTokenCore for FungibleToken {
             .checked_sub(GAS_FOR_FT_TRANSFER_CALL.0)
             .unwrap_or_else(|| env::panic_str("Prepaid gas overflow"));
         // Initiating receiver's call and the callback
-        ext_ft_receiver::ext(receiver_id.clone())
+        // TODO find a way if to resolve removing this clone, shouldn't be needed
+        ext_ft_receiver::ext(&receiver_id.clone())
             .with_static_gas(receiver_gas.into())
             .ft_on_transfer(sender_id.clone(), amount.into(), msg)
             .then(
-                ext_ft_resolver::ext(env::current_account_id())
+                ext_ft_resolver::ext(&env::current_account_id())
                     .with_static_gas(GAS_FOR_RESOLVE_TRANSFER)
                     .ft_resolve_transfer(sender_id, receiver_id, amount.into()),
             )

--- a/near-contract-standards/src/fungible_token/storage_impl.rs
+++ b/near-contract-standards/src/fungible_token/storage_impl.rs
@@ -17,7 +17,9 @@ impl FungibleToken {
             if balance == 0 || force {
                 self.accounts.remove(&account_id);
                 self.total_supply -= balance;
-                Promise::new(account_id.clone()).transfer(self.storage_balance_bounds().min.0 + 1);
+                Promise::new(&account_id)
+                    .transfer(self.storage_balance_bounds().min.0 + 1)
+                    .schedule();
                 Some((account_id, balance))
             } else {
                 env::panic_str(
@@ -52,7 +54,7 @@ impl StorageManagement for FungibleToken {
         if self.accounts.contains_key(&account_id) {
             log!("The account is already registered, refunding the deposit");
             if amount > 0 {
-                Promise::new(env::predecessor_account_id()).transfer(amount);
+                Promise::new(&env::predecessor_account_id()).transfer(amount).schedule();
             }
         } else {
             let min_balance = self.storage_balance_bounds().min.0;
@@ -63,7 +65,7 @@ impl StorageManagement for FungibleToken {
             self.internal_register_account(&account_id);
             let refund = amount - min_balance;
             if refund > 0 {
-                Promise::new(env::predecessor_account_id()).transfer(refund);
+                Promise::new(&env::predecessor_account_id()).transfer(refund).schedule();
             }
         }
         self.internal_storage_balance_of(&account_id).unwrap()

--- a/near-contract-standards/src/non_fungible_token/approval/approval_impl.rs
+++ b/near-contract-standards/src/non_fungible_token/approval/approval_impl.rs
@@ -58,10 +58,10 @@ impl NonFungibleTokenApproval for NonFungibleToken {
 
         // if given `msg`, schedule call to `nft_on_approve` and return it. Else, return None.
         msg.and_then(|msg| {
-            ext_nft_approval_receiver::ext(account_id)
+            ext_nft_approval_receiver::ext(&account_id)
                 .with_static_gas(env::prepaid_gas() - GAS_FOR_NFT_APPROVE)
                 .nft_on_approve(token_id, owner_id, approval_id, msg)
-                .as_return();
+                .schedule_as_return();
             //* This potentially does have a return value, but the API is incorrect and we need
             //* to express this as None for now. `as_return` above indicates the return value
             None
@@ -84,7 +84,7 @@ impl NonFungibleTokenApproval for NonFungibleToken {
             // if account_id was already not approved, do nothing
             if approved_account_ids.remove(&account_id).is_some() {
                 refund_approved_account_ids_iter(
-                    predecessor_account_id,
+                    &predecessor_account_id,
                     core::iter::once(&account_id),
                 );
                 // if this was the last approval, remove the whole HashMap to save space.
@@ -112,7 +112,7 @@ impl NonFungibleTokenApproval for NonFungibleToken {
         // if token has no approvals, do nothing
         if let Some(approved_account_ids) = &mut approvals_by_id.get(&token_id) {
             // otherwise, refund owner for storage costs of all approvals...
-            refund_approved_account_ids(predecessor_account_id, approved_account_ids);
+            refund_approved_account_ids(&predecessor_account_id, approved_account_ids);
             // ...and remove whole HashMap of approvals
             approvals_by_id.remove(&token_id);
         }

--- a/near-contract-standards/src/non_fungible_token/approval/approval_impl.rs
+++ b/near-contract-standards/src/non_fungible_token/approval/approval_impl.rs
@@ -57,10 +57,14 @@ impl NonFungibleTokenApproval for NonFungibleToken {
         refund_deposit(storage_used);
 
         // if given `msg`, schedule call to `nft_on_approve` and return it. Else, return None.
-        msg.map(|msg| {
+        msg.and_then(|msg| {
             ext_nft_approval_receiver::ext(account_id)
                 .with_static_gas(env::prepaid_gas() - GAS_FOR_NFT_APPROVE)
                 .nft_on_approve(token_id, owner_id, approval_id, msg)
+                .as_return();
+            //* This potentially does have a return value, but the API is incorrect and we need
+            //* to express this as None for now. `as_return` above indicates the return value
+            None
         })
     }
 

--- a/near-contract-standards/src/non_fungible_token/approval/approval_impl.rs
+++ b/near-contract-standards/src/non_fungible_token/approval/approval_impl.rs
@@ -8,7 +8,8 @@ use crate::non_fungible_token::utils::{
     refund_approved_account_ids_iter, refund_deposit,
 };
 use crate::non_fungible_token::NonFungibleToken;
-use near_sdk::{assert_one_yocto, env, require, AccountId, Gas, Promise};
+use near_sdk::ScheduledFn;
+use near_sdk::{assert_one_yocto, env, require, AccountId, Gas};
 
 const GAS_FOR_NFT_APPROVE: Gas = Gas(10_000_000_000_000);
 
@@ -26,7 +27,7 @@ impl NonFungibleTokenApproval for NonFungibleToken {
         token_id: TokenId,
         account_id: AccountId,
         msg: Option<String>,
-    ) -> Option<Promise> {
+    ) -> Option<ScheduledFn<String>> {
         assert_at_least_one_yocto();
         let approvals_by_id = self
             .approvals_by_id
@@ -57,14 +58,12 @@ impl NonFungibleTokenApproval for NonFungibleToken {
         refund_deposit(storage_used);
 
         // if given `msg`, schedule call to `nft_on_approve` and return it. Else, return None.
-        msg.and_then(|msg| {
+        msg.map(|msg| {
             ext_nft_approval_receiver::ext(&account_id)
                 .with_static_gas(env::prepaid_gas() - GAS_FOR_NFT_APPROVE)
                 .nft_on_approve(token_id, owner_id, approval_id, msg)
-                .schedule_as_return();
-            //* This potentially does have a return value, but the API is incorrect and we need
-            //* to express this as None for now. `as_return` above indicates the return value
-            None
+                .schedule_as_return()
+                .into()
         })
     }
 

--- a/near-contract-standards/src/non_fungible_token/approval/approval_receiver.rs
+++ b/near-contract-standards/src/non_fungible_token/approval/approval_receiver.rs
@@ -23,5 +23,5 @@ pub trait NonFungibleTokenApprovalReceiver {
         owner_id: AccountId,
         approval_id: u64,
         msg: String,
-    ) -> near_sdk::PromiseOrValue<Option<String> > ;
+    ) -> near_sdk::PromiseOrValue<Option<String>>;
 }

--- a/near-contract-standards/src/non_fungible_token/approval/approval_receiver.rs
+++ b/near-contract-standards/src/non_fungible_token/approval/approval_receiver.rs
@@ -23,5 +23,5 @@ pub trait NonFungibleTokenApprovalReceiver {
         owner_id: AccountId,
         approval_id: u64,
         msg: String,
-    ) -> near_sdk::PromiseOrValue<String>; // TODO: how to make "any"?
+    ) -> near_sdk::PromiseOrValue<Option<String> > ;
 }

--- a/near-contract-standards/src/non_fungible_token/approval/mod.rs
+++ b/near-contract-standards/src/non_fungible_token/approval/mod.rs
@@ -3,10 +3,10 @@ mod approval_receiver;
 
 pub use approval_impl::*;
 pub use approval_receiver::*;
+use near_sdk::ScheduledFn;
 
 use crate::non_fungible_token::token::TokenId;
 use near_sdk::AccountId;
-use near_sdk::Promise;
 
 /// Trait used when it's desired to have a non-fungible token that has a
 /// traditional escrow or approval system. This allows Alice to allow Bob
@@ -45,7 +45,7 @@ pub trait NonFungibleTokenApproval {
         token_id: TokenId,
         account_id: AccountId,
         msg: Option<String>,
-    ) -> Option<Promise>;
+    ) -> Option<ScheduledFn<String>>;
 
     /// Revoke an approved account for a specific token.
     ///

--- a/near-contract-standards/src/non_fungible_token/approval/mod.rs
+++ b/near-contract-standards/src/non_fungible_token/approval/mod.rs
@@ -3,7 +3,7 @@ mod approval_receiver;
 
 pub use approval_impl::*;
 pub use approval_receiver::*;
-use near_sdk::ScheduledFn;
+use near_sdk::PromiseOrValue;
 
 use crate::non_fungible_token::token::TokenId;
 use near_sdk::AccountId;
@@ -45,7 +45,7 @@ pub trait NonFungibleTokenApproval {
         token_id: TokenId,
         account_id: AccountId,
         msg: Option<String>,
-    ) -> Option<ScheduledFn<String>>;
+    ) -> PromiseOrValue<Option<String>>;
 
     /// Revoke an approved account for a specific token.
     ///

--- a/near-contract-standards/src/non_fungible_token/macros.rs
+++ b/near-contract-standards/src/non_fungible_token/macros.rs
@@ -72,7 +72,7 @@ macro_rules! impl_non_fungible_token_approval {
                 token_id: TokenId,
                 account_id: AccountId,
                 msg: Option<String>,
-            ) -> Option<Promise> {
+            ) -> Option<near_sdk::ScheduledFn<String>> {
                 self.$token.nft_approve(token_id, account_id, msg)
             }
 

--- a/near-contract-standards/src/non_fungible_token/macros.rs
+++ b/near-contract-standards/src/non_fungible_token/macros.rs
@@ -72,7 +72,7 @@ macro_rules! impl_non_fungible_token_approval {
                 token_id: TokenId,
                 account_id: AccountId,
                 msg: Option<String>,
-            ) -> Option<near_sdk::ScheduledFn<String>> {
+            ) -> PromiseOrValue<Option<String>> {
                 self.$token.nft_approve(token_id, account_id, msg)
             }
 

--- a/near-contract-standards/src/non_fungible_token/utils.rs
+++ b/near-contract-standards/src/non_fungible_token/utils.rs
@@ -1,4 +1,4 @@
-use near_sdk::{env, require, AccountId, Balance, Promise, PromiseIndex};
+use near_sdk::{env, require, AccountId, Balance, PromiseBuilder, PromiseIndex};
 use std::collections::HashMap;
 use std::mem::size_of;
 
@@ -16,7 +16,7 @@ where
     I: Iterator<Item = &'a AccountId>,
 {
     let storage_released: u64 = approved_account_ids.map(bytes_for_approved_account_id).sum();
-    Promise::new(account_id)
+    PromiseBuilder::new(account_id)
         .transfer(Balance::from(storage_released) * env::storage_byte_cost())
         .schedule()
 }
@@ -39,7 +39,7 @@ pub fn refund_deposit_to_account(storage_used: u64, account_id: &AccountId) {
 
     let refund = attached_deposit - required_cost;
     if refund > 1 {
-        Promise::new(account_id).transfer(refund).schedule();
+        PromiseBuilder::new(account_id).transfer(refund).schedule();
     }
 }
 

--- a/near-contract-standards/src/upgrade/mod.rs
+++ b/near-contract-standards/src/upgrade/mod.rs
@@ -1,6 +1,6 @@
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::json_types::U64;
-use near_sdk::{env, require, AccountId, Duration, Promise, ScheduledFn, Timestamp};
+use near_sdk::{env, require, AccountId, Duration, Promise, PromiseBuilder, Timestamp};
 
 type WrappedDuration = U64;
 
@@ -15,7 +15,7 @@ pub trait Ownable {
 pub trait Upgradable {
     fn get_staging_duration(&self) -> WrappedDuration;
     fn stage_code(&mut self, code: Vec<u8>, timestamp: Timestamp);
-    fn deploy_code(&mut self) -> ScheduledFn;
+    fn deploy_code(&mut self) -> Promise;
 
     /// Implement migration for the next version.
     /// Should be `unimplemented` for a new contract.
@@ -65,7 +65,7 @@ impl Upgradable for Upgrade {
         self.staging_timestamp = timestamp;
     }
 
-    fn deploy_code(&mut self) -> near_sdk::ScheduledFn {
+    fn deploy_code(&mut self) -> near_sdk::Promise {
         if self.staging_timestamp < env::block_timestamp() {
             env::panic_str(
                 format!(
@@ -78,6 +78,6 @@ impl Upgradable for Upgrade {
         let code = env::storage_read(b"upgrade")
             .unwrap_or_else(|| env::panic_str("No upgrade code available"));
         env::storage_remove(b"upgrade");
-        Promise::new(&env::current_account_id()).deploy_contract(code).schedule_as_return()
+        PromiseBuilder::new(&env::current_account_id()).deploy_contract(code).schedule_as_return()
     }
 }

--- a/near-contract-standards/src/upgrade/mod.rs
+++ b/near-contract-standards/src/upgrade/mod.rs
@@ -1,6 +1,6 @@
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::json_types::U64;
-use near_sdk::{env, require, AccountId, Duration, Promise, Timestamp, ScheduledFn};
+use near_sdk::{env, require, AccountId, Duration, Promise, ScheduledFn, Timestamp};
 
 type WrappedDuration = U64;
 

--- a/near-contract-standards/src/upgrade/mod.rs
+++ b/near-contract-standards/src/upgrade/mod.rs
@@ -78,6 +78,6 @@ impl Upgradable for Upgrade {
         let code = env::storage_read(b"upgrade")
             .unwrap_or_else(|| env::panic_str("No upgrade code available"));
         env::storage_remove(b"upgrade");
-        PromiseBuilder::new(&env::current_account_id()).deploy_contract(code).schedule_as_return()
+        PromiseBuilder::new(&env::current_account_id()).deploy_contract(&code).schedule_as_return()
     }
 }

--- a/near-sdk-macros/src/core_impl/code_generator/ext.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/ext.rs
@@ -93,7 +93,9 @@ fn generate_ext_function(attr_signature_info: &AttrSigInfo) -> TokenStream2 {
         syn::ReturnType::Default => quote! {<'__ext_a, near_sdk::promise::NoReturn>},
         syn::ReturnType::Type(_, ty) => {
             // Unwrap result type if using `handle_result`
+            // TODO double check this, seems like it's extracting regardless of attr
             let ty = crate::core_impl::utils::extract_ok_type(ty).unwrap_or(ty);
+            let ty = crate::core_impl::utils::remove_promise_types_recursively(ty);
             quote! {<'__ext_a, #ty>}
         }
     };

--- a/near-sdk-macros/src/core_impl/code_generator/ext.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/ext.rs
@@ -101,9 +101,9 @@ fn generate_ext_function(attr_signature_info: &AttrSigInfo) -> TokenStream2 {
     };
     quote! {
         #new_non_bindgen_attrs
-        pub fn #ident #generics (self, #pat_type_list) -> near_sdk::Promise #promise_generics {
+        pub fn #ident #generics (self, #pat_type_list) -> near_sdk::PromiseBuilder #promise_generics {
             let __args = #serialize;
-            near_sdk::Promise::new(self.account_id)
+            near_sdk::PromiseBuilder::new(self.account_id)
                 .function_call(
                     #ident_str,
                     __args,
@@ -215,7 +215,7 @@ mod tests {
         let method_info = ImplItemMethodInfo::new(&mut method, impl_type).unwrap();
         let actual = generate_ext_function(&method_info.attr_signature_info);
         let expected = quote!(
-            pub fn method(self, k: &String,) -> near_sdk::Promise<'__ext_a, near_sdk::promise::NoReturn> {
+            pub fn method(self, k: &String,) -> near_sdk::PromiseBuilder<'__ext_a, near_sdk::promise::NoReturn> {
                 let __args = {#[derive(near_sdk :: serde :: Serialize)]
                     #[serde(crate = "near_sdk::serde")]
                     struct Input<'nearinput> {
@@ -225,7 +225,7 @@ mod tests {
                     near_sdk::serde_json::to_vec(&__args)
                         .expect("Failed to serialize the cross contract args using JSON.")
                 };
-                near_sdk::Promise::new(self.account_id)
+                near_sdk::PromiseBuilder::new(self.account_id)
                     .function_call(
                         "method",
                         __args,
@@ -249,7 +249,7 @@ mod tests {
         let method_info = ImplItemMethodInfo::new(&mut method, impl_type).unwrap();
         let actual = generate_ext_function(&method_info.attr_signature_info);
         let expected = quote!(
-          pub fn borsh_test(self, a: String,) -> near_sdk::Promise<'__ext_a, near_sdk::promise::NoReturn> {
+          pub fn borsh_test(self, a: String,) -> near_sdk::PromiseBuilder<'__ext_a, near_sdk::promise::NoReturn> {
             let __args = {
                 #[derive(near_sdk :: borsh :: BorshSerialize)]
                 struct Input<'nearinput> {
@@ -259,7 +259,7 @@ mod tests {
                 near_sdk::borsh::BorshSerialize::try_to_vec(&__args)
                     .expect("Failed to serialize the cross contract args using Borsh.")
                 };
-                near_sdk::Promise::new(self.account_id)
+                near_sdk::PromiseBuilder::new(self.account_id)
                     .function_call(
                         "borsh_test",
                         __args,

--- a/near-sdk-macros/src/core_impl/code_generator/impl_item_method_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/impl_item_method_info.rs
@@ -256,8 +256,8 @@ fn generate_serialization_code(
     };
 
     match utils::function_return_variant(return_type) {
-        utils::PromiseVariant::Promise(_) => quote! {},
-        utils::PromiseVariant::PromiseOrValue(_) => {
+        utils::ReturnVariant::Promise => quote! {},
+        utils::ReturnVariant::PromiseOrValue => {
             let serialize_codegen = generate_result_serialization();
             quote! {
                 match result {
@@ -268,6 +268,6 @@ fn generate_serialization_code(
                 };
             }
         }
-        utils::PromiseVariant::Value(_) => generate_result_serialization(),
+        utils::ReturnVariant::Value => generate_result_serialization(),
     }
 }

--- a/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
@@ -861,7 +861,7 @@ mod tests {
             #[handle_result]
             pub fn method(
                 &self,
-            ) -> Result<ScheduledFn<Option<String>>, &'static str> { }
+            ) -> Result<Promise<Option<String>>, &'static str> { }
         };
         let method_info = ImplItemMethodInfo::new(&mut method, impl_type).unwrap();
         let actual = method_info.method_wrapper();

--- a/near-sdk-macros/src/core_impl/code_generator/item_trait_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/item_trait_info.rs
@@ -89,7 +89,7 @@ mod tests {
                     pub fn merge_sort(
                         self,
                         arr: Vec<u8>,
-                    ) -> near_sdk::Promise<'__ext_a, Vec<u8> > {
+                    ) -> near_sdk::PromiseBuilder<'__ext_a, Vec<u8> > {
                         let __args = {
                             #[derive(near_sdk :: serde :: Serialize)]
                             #[serde(crate = "near_sdk::serde")]
@@ -100,7 +100,7 @@ mod tests {
                             near_sdk::serde_json::to_vec(&__args)
                                 .expect("Failed to serialize the cross contract args using JSON.")
                         };
-                        near_sdk::Promise::new(self.account_id)
+                        near_sdk::PromiseBuilder::new(self.account_id)
                             .function_call(
                                 "merge_sort",
                                 __args,
@@ -111,9 +111,9 @@ mod tests {
                                 }
                             )
                     }
-                    pub fn merge(self,) -> near_sdk::Promise<'__ext_a, Vec<u8> > {
+                    pub fn merge(self,) -> near_sdk::PromiseBuilder<'__ext_a, Vec<u8> > {
                         let __args = vec![];
-                        near_sdk::Promise::new(self.account_id)
+                        near_sdk::PromiseBuilder::new(self.account_id)
                             .function_call(
                                 "merge",
                                 __args,
@@ -180,7 +180,7 @@ mod tests {
                 pub fn test(
                     self,
                     v: Vec<String>,
-                ) -> near_sdk::Promise<'__ext_a, Vec<String> > {
+                ) -> near_sdk::PromiseBuilder<'__ext_a, Vec<String> > {
                     let __args = {
                         #[derive(near_sdk :: borsh :: BorshSerialize)]
                         struct Input<'nearinput> {
@@ -190,7 +190,7 @@ mod tests {
                         near_sdk::borsh::BorshSerialize::try_to_vec(&__args)
                             .expect("Failed to serialize the cross contract args using Borsh.")
                     };
-                    near_sdk::Promise::new(self.account_id)
+                    near_sdk::PromiseBuilder::new(self.account_id)
                         .function_call(
                             "test",
                             __args,

--- a/near-sdk-macros/src/core_impl/code_generator/item_trait_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/item_trait_info.rs
@@ -28,14 +28,14 @@ impl ItemTraitInfo {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use syn::ItemTrait;
+    use syn::{ItemTrait, parse_quote};
     use quote::quote;
     use crate::core_impl::info_extractor::ItemTraitInfo;
 
     #[test]
     fn ext_basic() {
-        let mut t: ItemTrait = syn::parse2(
-            quote!{
+        let mut t: ItemTrait = 
+            parse_quote!{
                 pub trait ExternalCrossContract {
                     fn merge_sort(&self, arr: Vec<u8>) -> PromiseOrValue<Vec<u8>>;
                     fn merge(
@@ -48,8 +48,7 @@ mod tests {
                         data1: Vec<u8>,
                     ) -> Vec<u8>;
                 }
-            }
-        ).unwrap();
+            };
         let info = ItemTraitInfo::new(&mut t, None).unwrap();
         let actual = info.wrap_trait_ext();
 
@@ -90,7 +89,7 @@ mod tests {
                     pub fn merge_sort(
                         self,
                         arr: Vec<u8>,
-                    ) -> near_sdk::Promise<'__ext_a, PromiseOrValue<Vec<u8> > > {
+                    ) -> near_sdk::Promise<'__ext_a, Vec<u8> > {
                         let __args = {
                             #[derive(near_sdk :: serde :: Serialize)]
                             #[serde(crate = "near_sdk::serde")]

--- a/near-sdk-macros/src/core_impl/code_generator/item_trait_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/item_trait_info.rs
@@ -90,7 +90,7 @@ mod tests {
                     pub fn merge_sort(
                         self,
                         arr: Vec<u8>,
-                    ) -> near_sdk::Promise {
+                    ) -> near_sdk::Promise<PromiseOrValue<Vec<u8> > > {
                         let __args = {
                             #[derive(near_sdk :: serde :: Serialize)]
                             #[serde(crate = "near_sdk::serde")]
@@ -101,7 +101,7 @@ mod tests {
                             near_sdk::serde_json::to_vec(&__args)
                                 .expect("Failed to serialize the cross contract args using JSON.")
                         };
-                        near_sdk::Promise::new(self.account_id)
+                        near_sdk::Promise::new_with_return(self.account_id)
                             .function_call_weight(
                                 "merge_sort".to_string(),
                                 __args,
@@ -110,9 +110,9 @@ mod tests {
                                 self.gas_weight,
                             )
                     }
-                    pub fn merge(self,) -> near_sdk::Promise {
+                    pub fn merge(self,) -> near_sdk::Promise<Vec<u8> > {
                         let __args = vec![];
-                        near_sdk::Promise::new(self.account_id)
+                        near_sdk::Promise::new_with_return(self.account_id)
                             .function_call_weight(
                                 "merge".to_string(),
                                 __args,
@@ -177,7 +177,7 @@ mod tests {
                 pub fn test(
                     self,
                     v: Vec<String>,
-                ) -> near_sdk::Promise {
+                ) -> near_sdk::Promise<Vec<String> > {
                     let __args = {
                         #[derive(near_sdk :: borsh :: BorshSerialize)]
                         struct Input<'nearinput> {
@@ -187,7 +187,7 @@ mod tests {
                         near_sdk::borsh::BorshSerialize::try_to_vec(&__args)
                             .expect("Failed to serialize the cross contract args using Borsh.")
                     };
-                    near_sdk::Promise::new(self.account_id)
+                    near_sdk::Promise::new_with_return(self.account_id)
                         .function_call_weight(
                             "test".to_string(),
                             __args,

--- a/near-sdk-macros/src/core_impl/code_generator/item_trait_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/item_trait_info.rs
@@ -57,13 +57,13 @@ mod tests {
             pub mod external_cross_contract {
                 use super::*;
                 #[must_use]
-                pub struct ExternalCrossContractExt {
-                    pub(crate) account_id: near_sdk::AccountId,
+                pub struct ExternalCrossContractExt<'__ext_a> {
+                    pub(crate) account_id: &'__ext_a near_sdk::AccountId,
                     pub(crate) deposit: near_sdk::Balance,
                     pub(crate) static_gas: near_sdk::Gas,
                     pub(crate) gas_weight: near_sdk::GasWeight,
                 }
-                impl ExternalCrossContractExt {
+                impl ExternalCrossContractExt<'_> {
                     pub fn with_attached_deposit(mut self, amount: near_sdk::Balance) -> Self {
                         self.deposit = amount;
                         self
@@ -78,7 +78,7 @@ mod tests {
                     }
                 }
                 /// API for calling this contract's functions in a subsequent execution.
-                pub fn ext(account_id: near_sdk::AccountId) -> ExternalCrossContractExt {
+                pub fn ext<'__ext_a>(account_id: &'__ext_a near_sdk::AccountId) -> ExternalCrossContractExt<'__ext_a> {
                     ExternalCrossContractExt {
                         account_id,
                         deposit: 0,
@@ -86,11 +86,11 @@ mod tests {
                         gas_weight: near_sdk::GasWeight::default(),
                     }
                 }
-                impl ExternalCrossContractExt {
+                impl<'__ext_a> ExternalCrossContractExt<'__ext_a> {
                     pub fn merge_sort(
                         self,
                         arr: Vec<u8>,
-                    ) -> near_sdk::Promise<PromiseOrValue<Vec<u8> > > {
+                    ) -> near_sdk::Promise<'__ext_a, PromiseOrValue<Vec<u8> > > {
                         let __args = {
                             #[derive(near_sdk :: serde :: Serialize)]
                             #[serde(crate = "near_sdk::serde")]
@@ -101,24 +101,28 @@ mod tests {
                             near_sdk::serde_json::to_vec(&__args)
                                 .expect("Failed to serialize the cross contract args using JSON.")
                         };
-                        near_sdk::Promise::new_with_return(self.account_id)
-                            .function_call_weight(
-                                "merge_sort".to_string(),
+                        near_sdk::Promise::new(self.account_id)
+                            .function_call(
+                                "merge_sort",
                                 __args,
-                                self.deposit,
-                                self.static_gas,
-                                self.gas_weight,
+                                near_sdk::promise::FunctionCallOpts {
+                                    deposit: Some(self.deposit),
+                                    static_gas: Some(self.static_gas),
+                                    gas_weight: Some(self.gas_weight),
+                                }
                             )
                     }
-                    pub fn merge(self,) -> near_sdk::Promise<Vec<u8> > {
+                    pub fn merge(self,) -> near_sdk::Promise<'__ext_a, Vec<u8> > {
                         let __args = vec![];
-                        near_sdk::Promise::new_with_return(self.account_id)
-                            .function_call_weight(
-                                "merge".to_string(),
+                        near_sdk::Promise::new(self.account_id)
+                            .function_call(
+                                "merge",
                                 __args,
-                                self.deposit,
-                                self.static_gas,
-                                self.gas_weight,
+                                near_sdk::promise::FunctionCallOpts {
+                                    deposit: Some(self.deposit),
+                                    static_gas: Some(self.static_gas),
+                                    gas_weight: Some(self.gas_weight),
+                                }
                             )
                     }
                 }
@@ -144,13 +148,13 @@ mod tests {
           pub mod test {
             use super::*;
             #[must_use]
-            pub struct TestExt {
-                pub(crate) account_id: near_sdk::AccountId,
+            pub struct TestExt<'__ext_a> {
+                pub(crate) account_id: &'__ext_a near_sdk::AccountId,
                 pub(crate) deposit: near_sdk::Balance,
                 pub(crate) static_gas: near_sdk::Gas,
                 pub(crate) gas_weight: near_sdk::GasWeight,
             }
-            impl TestExt {
+            impl TestExt<'_> {
                 pub fn with_attached_deposit(mut self, amount: near_sdk::Balance) -> Self {
                     self.deposit = amount;
                     self
@@ -165,7 +169,7 @@ mod tests {
                 }
             }
             /// API for calling this contract's functions in a subsequent execution.
-            pub fn ext(account_id: near_sdk::AccountId) -> TestExt {
+            pub fn ext<'__ext_a>(account_id: &'__ext_a near_sdk::AccountId) -> TestExt<'__ext_a> {
                 TestExt {
                     account_id,
                     deposit: 0,
@@ -173,11 +177,11 @@ mod tests {
                     gas_weight: near_sdk::GasWeight::default(),
                 }
             }
-            impl TestExt {
+            impl<'__ext_a> TestExt<'__ext_a> {
                 pub fn test(
                     self,
                     v: Vec<String>,
-                ) -> near_sdk::Promise<Vec<String> > {
+                ) -> near_sdk::Promise<'__ext_a, Vec<String> > {
                     let __args = {
                         #[derive(near_sdk :: borsh :: BorshSerialize)]
                         struct Input<'nearinput> {
@@ -187,13 +191,15 @@ mod tests {
                         near_sdk::borsh::BorshSerialize::try_to_vec(&__args)
                             .expect("Failed to serialize the cross contract args using Borsh.")
                     };
-                    near_sdk::Promise::new_with_return(self.account_id)
-                        .function_call_weight(
-                            "test".to_string(),
+                    near_sdk::Promise::new(self.account_id)
+                        .function_call(
+                            "test",
                             __args,
-                            self.deposit,
-                            self.static_gas,
-                            self.gas_weight,
+                            near_sdk::promise::FunctionCallOpts {
+                                deposit: Some(self.deposit),
+                                static_gas: Some(self.static_gas),
+                                gas_weight: Some(self.gas_weight),
+                            }
                         )
                 }
             }

--- a/near-sdk-macros/src/core_impl/utils/mod.rs
+++ b/near-sdk-macros/src/core_impl/utils/mod.rs
@@ -1,25 +1,21 @@
 use syn::{GenericArgument, Path, PathArguments, PathSegment, Type};
 
-pub(crate) enum PromiseVariant<'a> {
-    PromiseOrValue(&'a Type),
-    Promise(&'a Type),
-    Value(&'a Type),
+pub(crate) enum ReturnVariant {
+    PromiseOrValue,
+    Promise,
+    Value,
 }
 
-pub(crate) fn function_return_variant(ty: &Type) -> PromiseVariant {
+pub(crate) fn function_return_variant(ty: &Type) -> ReturnVariant {
     if let Some(last) = last_type_segment(ty) {
         if last.ident == "PromiseOrValue" {
-            return PromiseVariant::PromiseOrValue(
-                first_generic_type(last).expect("PromiseOrValue expects a generic type"),
-            );
+            return ReturnVariant::PromiseOrValue;
         } else if last.ident == "ScheduledFn" {
-            return PromiseVariant::Promise(
-                first_generic_type(last).expect("ScheduledFn expects a generic type"),
-            );
+            return ReturnVariant::Promise;
         }
     }
 
-    PromiseVariant::Value(ty)
+    ReturnVariant::Value
 }
 
 fn first_generic_type(segment: &PathSegment) -> Option<&Type> {

--- a/near-sdk-macros/src/core_impl/utils/mod.rs
+++ b/near-sdk-macros/src/core_impl/utils/mod.rs
@@ -10,7 +10,7 @@ pub(crate) fn function_return_variant(ty: &Type) -> ReturnVariant {
     if let Some(last) = last_type_segment(ty) {
         if last.ident == "PromiseOrValue" {
             return ReturnVariant::PromiseOrValue;
-        } else if last.ident == "ScheduledFn" {
+        } else if last.ident == "Promise" {
             return ReturnVariant::Promise;
         }
     }
@@ -39,7 +39,7 @@ pub(crate) fn remove_promise_types_recursively(mut ty: &Type) -> &Type {
     loop {
         if let Some(last) = last_type_segment(ty) {
             // TODO add others
-            if last.ident == "PromiseOrValue" || last.ident == "ScheduledFn" {
+            if last.ident == "PromiseOrValue" || last.ident == "Promise" {
                 if let Some(inner) = first_generic_type(last) {
                     ty = inner;
                     continue;
@@ -147,10 +147,10 @@ mod tests {
             String
         );
         assert_conversion!(remove_promise_types_recursively(Result<String>), Result<String>);
-        assert_conversion!(remove_promise_types_recursively(ScheduledFn<String>), String);
+        assert_conversion!(remove_promise_types_recursively(Promise<String>), String);
         assert_conversion!(remove_promise_types_recursively(u8), u8);
         assert_conversion!(
-            remove_promise_types_recursively(ScheduledFn<PromiseOrValue<String>>),
+            remove_promise_types_recursively(Promise<PromiseOrValue<String>>),
             String
         );
         // TODO do we want to skip over wrapper types?

--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -13,7 +13,7 @@ use crate::mock::MockedBlockchain;
 use crate::types::{
     AccountId, Balance, BlockHeight, Gas, PromiseIndex, PromiseResult, PublicKey, StorageUsage,
 };
-use crate::{GasWeight, PromiseError};
+use crate::{log, GasWeight, PromiseError};
 use near_sys as sys;
 
 const REGISTER_EXPECTED_ERR: &str =
@@ -455,7 +455,9 @@ pub fn promise_and(promise_indices: &[PromiseIndex]) -> PromiseIndex {
 
 pub fn promise_batch_create(account_id: &AccountId) -> PromiseIndex {
     let account_id = account_id.as_ref();
-    unsafe { sys::promise_batch_create(account_id.len() as _, account_id.as_ptr() as _) }
+    let idx = unsafe { sys::promise_batch_create(account_id.len() as _, account_id.as_ptr() as _) };
+    log!("creating promise {}", idx);
+    idx
 }
 
 pub fn promise_batch_then(promise_index: PromiseIndex, account_id: &AccountId) -> PromiseIndex {
@@ -630,6 +632,7 @@ pub(crate) fn promise_result_internal(result_idx: u64) -> Result<(), PromiseErro
 /// Consider the execution result of promise under `promise_idx` as execution result of this
 /// function.
 pub fn promise_return(promise_idx: PromiseIndex) {
+    log!("P return: {}", promise_idx);
     unsafe { sys::promise_return(promise_idx) }
 }
 
@@ -659,6 +662,7 @@ pub fn validator_total_stake() -> Balance {
 // #####################
 /// Sets the blob of data as the return value of the contract.
 pub fn value_return(value: &[u8]) {
+    log!("value return: {:?}", value);
     unsafe { sys::value_return(value.len() as _, value.as_ptr() as _) }
 }
 /// Terminates the execution of the program with the UTF-8 encoded message.

--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -13,7 +13,7 @@ use crate::mock::MockedBlockchain;
 use crate::types::{
     AccountId, Balance, BlockHeight, Gas, PromiseIndex, PromiseResult, PublicKey, StorageUsage,
 };
-use crate::{log, GasWeight, PromiseError};
+use crate::{GasWeight, PromiseError};
 use near_sys as sys;
 
 const REGISTER_EXPECTED_ERR: &str =
@@ -455,9 +455,7 @@ pub fn promise_and(promise_indices: &[PromiseIndex]) -> PromiseIndex {
 
 pub fn promise_batch_create(account_id: &AccountId) -> PromiseIndex {
     let account_id = account_id.as_ref();
-    let idx = unsafe { sys::promise_batch_create(account_id.len() as _, account_id.as_ptr() as _) };
-    log!("creating promise {}", idx);
-    idx
+    unsafe { sys::promise_batch_create(account_id.len() as _, account_id.as_ptr() as _) }
 }
 
 pub fn promise_batch_then(promise_index: PromiseIndex, account_id: &AccountId) -> PromiseIndex {
@@ -632,7 +630,6 @@ pub(crate) fn promise_result_internal(result_idx: u64) -> Result<(), PromiseErro
 /// Consider the execution result of promise under `promise_idx` as execution result of this
 /// function.
 pub fn promise_return(promise_idx: PromiseIndex) {
-    log!("P return: {}", promise_idx);
     unsafe { sys::promise_return(promise_idx) }
 }
 
@@ -662,7 +659,6 @@ pub fn validator_total_stake() -> Balance {
 // #####################
 /// Sets the blob of data as the return value of the contract.
 pub fn value_return(value: &[u8]) {
-    log!("value return: {:?}", value);
     unsafe { sys::value_return(value.len() as _, value.as_ptr() as _) }
 }
 /// Terminates the execution of the program with the UTF-8 encoded message.

--- a/near-sdk/src/lib.rs
+++ b/near-sdk/src/lib.rs
@@ -20,7 +20,7 @@ pub use environment::env;
 pub use near_sys as sys;
 
 pub mod promise;
-pub use promise::{Promise, PromiseOrValue, ScheduledFn};
+pub use promise::{Promise, PromiseBuilder, PromiseOrValue};
 
 // Private types just used within macro generation, not stable to be used.
 #[doc(hidden)]

--- a/near-sdk/src/lib.rs
+++ b/near-sdk/src/lib.rs
@@ -19,8 +19,8 @@ pub use environment::env;
 #[cfg(feature = "unstable")]
 pub use near_sys as sys;
 
-mod promise;
-pub use promise::{Promise, PromiseOrValue};
+pub mod promise;
+pub use promise::{Promise, PromiseOrValue, ScheduledFn};
 
 // Private types just used within macro generation, not stable to be used.
 #[doc(hidden)]

--- a/near-sdk/src/promise.rs
+++ b/near-sdk/src/promise.rs
@@ -106,7 +106,7 @@ impl<'a, T> PromiseBuilder<'a, T> {
     }
 
     /// Deploy a smart contract to the account on which this promise acts.
-    pub fn deploy_contract(self, code: Vec<u8>) -> Self {
+    pub fn deploy_contract(self, code: &'a [u8]) -> Self {
         self.add_action(PromiseAction::DeployContract { code })
     }
 
@@ -418,7 +418,7 @@ where
 enum PromiseAction<'a> {
     CreateAccount,
     DeployContract {
-        code: Vec<u8>,
+        code: &'a [u8],
     },
     FunctionCallWeight {
         function_name: &'a str,

--- a/near-sdk/src/promise.rs
+++ b/near-sdk/src/promise.rs
@@ -1,25 +1,390 @@
 use borsh::BorshSchema;
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::io::{Error, Write};
 use std::marker::PhantomData;
-use std::rc::Rc;
 
 use crate::{AccountId, Balance, Gas, GasWeight, PromiseIndex, PublicKey};
 
-enum PromiseAction {
+/// This type indicates that the promise will not return any bytes.
+// TODO this is likely broken. I believe JSON schema treats as any, but borsh may try to deserialize 0 bytes
+pub type NoReturn = ();
+
+mod private {
+    /// Seal `ToKey` implementations to limit usage to the builtin implementations
+    pub trait SchedulablePromise<T> {
+        fn append_to_promises(self, promises: &mut Vec<super::PromiseIndex>);
+    }
+
+    impl<T> SchedulablePromise<T> for super::Promise<'_, T> {
+        fn append_to_promises(self, promises: &mut Vec<super::PromiseIndex>) {
+            promises.push(self.schedule())
+        }
+    }
+    impl<T> SchedulablePromise<T> for super::PromiseThen<'_, T> {
+        fn append_to_promises(self, promises: &mut Vec<super::PromiseIndex>) {
+            promises.push(self.schedule())
+        }
+    }
+    impl<L, R> SchedulablePromise<super::PromiseAnd<L, R>> for super::PromiseAnd<L, R> {
+        fn append_to_promises(self, promises: &mut Vec<super::PromiseIndex>) {
+            promises.extend(self.promises)
+        }
+    }
+}
+
+/// A structure representing a result of the scheduled execution on another contract.
+///
+/// Smart contract developers will explicitly use `Promise` in two situations:
+/// * When they need to return `Promise`.
+///
+///   In the following code if someone calls method `ContractA::a` they will internally cause an
+///   execution of method `ContractB::b` of `bob_near` account, and the return value of `ContractA::a`
+///   will be what `ContractB::b` returned.
+/// ```no_run
+/// # use near_sdk::{ext_contract, near_bindgen, Promise, Gas, ScheduledFn};
+/// # use borsh::{BorshDeserialize, BorshSerialize};
+/// #[ext_contract]
+/// pub trait ContractB {
+///     fn b(&mut self);
+/// }
+///
+/// #[near_bindgen]
+/// #[derive(Default, BorshDeserialize, BorshSerialize)]
+/// struct ContractA {}
+///
+/// #[near_bindgen]
+/// impl ContractA {
+///     pub fn a(&self) -> ScheduledFn {
+///         contract_b::ext("bob_near".parse().unwrap()).b()
+///     }
+/// }
+/// ```
+///
+/// * When they need to create a transaction with one or many actions, e.g. the following code
+///   schedules a transaction that creates an account, transfers tokens, and assigns a public key:
+///
+/// ```no_run
+/// # use near_sdk::{Promise, env, test_utils::VMContextBuilder, testing_env};
+/// # testing_env!(VMContextBuilder::new().signer_account_id("bob_near".parse().unwrap())
+/// #               .account_balance(1000).prepaid_gas(1_000_000.into()).build());
+/// Promise::new(&"bob_near".parse().unwrap())
+///   .create_account()
+///   .transfer(1000)
+///   .add_full_access_key(env::signer_account_pk())
+///   .schedule();
+/// ```
+#[must_use]
+#[derive(Debug)]
+pub struct Promise<'a, T = NoReturn> {
+    account_id: &'a AccountId,
+    actions: Vec<PromiseAction<'a>>,
+    _marker: PhantomData<fn() -> T>,
+}
+
+impl<'a> Promise<'a, NoReturn> {
+    /// Create a promise that acts on the given account.
+    pub fn new(account_id: &'a AccountId) -> Self {
+        Self { account_id, actions: Vec::new(), _marker: Default::default() }
+    }
+}
+
+impl<'a, T> Promise<'a, T> {
+    fn add_action(mut self, action: PromiseAction<'a>) -> Self {
+        self.actions.push(action);
+        self
+    }
+
+    /// Create account on which this promise acts.
+    pub fn create_account(self) -> Self {
+        self.add_action(PromiseAction::CreateAccount)
+    }
+
+    /// Deploy a smart contract to the account on which this promise acts.
+    pub fn deploy_contract(self, code: Vec<u8>) -> Self {
+        self.add_action(PromiseAction::DeployContract { code })
+    }
+
+    /// A low-level interface for making a function call to the account that this promise acts on.
+    pub fn function_call<F>(
+        self,
+        function_name: &'a str,
+        // TODO should this be part of opts or have some convenience method for serialization
+        arguments: Vec<u8>,
+        opts: FunctionCallOpts,
+    ) -> Promise<'a, F> {
+        let Self { account_id, actions, _marker: _ } =
+            self.add_action(PromiseAction::FunctionCallWeight {
+                function_name,
+                arguments,
+                amount: opts.deposit.unwrap_or_default(),
+                gas: opts.static_gas.unwrap_or_default(),
+                weight: opts.gas_weight.unwrap_or(GasWeight(1)),
+            });
+        Promise { account_id, actions, _marker: Default::default() }
+    }
+
+    /// Transfer tokens to the account that this promise acts on.
+    pub fn transfer(self, amount: Balance) -> Self {
+        self.add_action(PromiseAction::Transfer { amount })
+    }
+
+    /// Stake the account for the given amount of tokens using the given public key.
+    pub fn stake(self, amount: Balance, public_key: &'a PublicKey) -> Self {
+        self.add_action(PromiseAction::Stake { amount, public_key })
+    }
+
+    /// Add full access key to the given account.
+    pub fn add_full_access_key(self, public_key: &'a PublicKey) -> Self {
+        self.add_full_access_key_with_nonce(public_key, 0)
+    }
+
+    /// Add full access key to the given account with a provided nonce.
+    pub fn add_full_access_key_with_nonce(self, public_key: &'a PublicKey, nonce: u64) -> Self {
+        self.add_action(PromiseAction::AddFullAccessKey { public_key, nonce })
+    }
+
+    /// Add an access key that is restricted to only calling a smart contract on some account using
+    /// only a restricted set of methods. Here `function_names` is a comma separated list of methods,
+    /// e.g. `"method_a,method_b".to_string()`.
+    pub fn add_access_key(
+        self,
+        public_key: &'a PublicKey,
+        allowance: Balance,
+        receiver_id: &'a AccountId,
+        function_names: &'a str,
+    ) -> Self {
+        self.add_access_key_with_nonce(public_key, allowance, receiver_id, function_names, 0)
+    }
+
+    /// Add an access key with a provided nonce.
+    pub fn add_access_key_with_nonce(
+        self,
+        public_key: &'a PublicKey,
+        allowance: Balance,
+        receiver_id: &'a AccountId,
+        function_names: &'a str,
+        nonce: u64,
+    ) -> Self {
+        self.add_action(PromiseAction::AddAccessKey {
+            public_key,
+            allowance,
+            receiver_id,
+            function_names,
+            nonce,
+        })
+    }
+
+    /// Delete access key from the given account.
+    pub fn delete_key(self, public_key: &'a PublicKey) -> Self {
+        self.add_action(PromiseAction::DeleteKey { public_key })
+    }
+
+    /// Delete the given account.
+    pub fn delete_account(self, beneficiary_id: &'a AccountId) -> Self {
+        self.add_action(PromiseAction::DeleteAccount { beneficiary_id })
+    }
+
+    /// Merge this promise with another promise, so that we can schedule execution of another
+    /// smart contract right after all merged promises finish.
+    ///
+    /// Note, once the promises are merged it is not possible to add actions to them, e.g. the
+    /// following code will panic during the execution of the smart contract:
+    ///
+    /// ```no_run
+    /// # use near_sdk::{Promise, testing_env};
+    /// let p1 = Promise::new("bob_near".parse().unwrap()).create_account();
+    /// let p2 = Promise::new("carol_near".parse().unwrap()).create_account();
+    /// let p3 = p1.and(p2);
+    /// // p3.create_account();
+    /// ```
+    pub fn and<O>(self, other: impl private::SchedulablePromise<T>) -> PromiseAnd<T, O> {
+        let mut promises = vec![self.schedule()];
+        other.append_to_promises(&mut promises);
+        PromiseAnd { promises, _marker: Default::default() }
+    }
+
+    /// Schedules execution of another promise right after the current promise finish executing.
+    ///
+    /// In the following code `bob_near` and `dave_near` will be created concurrently. `carol_near`
+    /// creation will wait for `bob_near` to be created, and `eva_near` will wait for both `carol_near`
+    /// and `dave_near` to be created first.
+    /// ```no_run
+    /// # use near_sdk::{Promise, VMContext, testing_env};
+    /// let p1 = Promise::new("bob_near".parse().unwrap()).create_account();
+    /// let p2 = Promise::new("carol_near".parse().unwrap()).create_account();
+    /// let p3 = Promise::new("dave_near".parse().unwrap()).create_account();
+    /// let p4 = Promise::new("eva_near".parse().unwrap()).create_account();
+    /// p1.then(p2).and(p3).then(p4).schedule();
+    /// ```
+    pub fn then<O>(self, other: Promise<O>) -> PromiseThen<O> {
+        PromiseThen { after: self.schedule(), inner: other }
+    }
+
+    /// A specialized, relatively low-level API method. Allows to mark the given promise as the one
+    /// that should be considered as a return value.
+    ///
+    /// In the below code `a1` and `a2` functions are equivalent.
+    /// ```
+    /// # use near_sdk::{ext_contract, Gas, near_bindgen, Promise};
+    /// # use borsh::{BorshDeserialize, BorshSerialize};
+    /// #[ext_contract]
+    /// pub trait ContractB {
+    ///     fn b(&mut self);
+    /// }
+    ///
+    /// #[near_bindgen]
+    /// #[derive(Default, BorshDeserialize, BorshSerialize)]
+    /// struct ContractA {}
+    ///
+    /// #[near_bindgen]
+    /// impl ContractA {
+    ///     pub fn a1(&self) {
+    ///        contract_b::ext("bob_near".parse().unwrap()).b().as_return();
+    ///     }
+    ///
+    ///     pub fn a2(&self) -> ScheduledFn {
+    ///        contract_b::ext("bob_near".parse().unwrap()).b().schedule_as_return()
+    ///     }
+    /// }
+    /// ```
+    pub fn schedule_as_return(self) -> ScheduledFn<T> {
+        let index = self.schedule();
+        crate::env::promise_return(index);
+        ScheduledFn { index, _marker: Default::default() }
+    }
+
+    // TODO docs
+    pub fn schedule(self) -> PromiseIndex {
+        let promise_index = crate::env::promise_batch_create(&self.account_id);
+        for action in self.actions {
+            action.add(promise_index);
+        }
+        promise_index
+    }
+}
+
+/// Until we implement strongly typed promises we serialize them as unit struct.
+impl<T> BorshSchema for Promise<'_, T>
+where
+    T: BorshSchema,
+{
+    fn add_definitions_recursively(
+        definitions: &mut HashMap<borsh::schema::Declaration, borsh::schema::Definition>,
+    ) {
+        <T>::add_definitions_recursively(definitions);
+    }
+
+    fn declaration() -> borsh::schema::Declaration {
+        <T>::declaration()
+    }
+}
+
+// TODO docs
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct FunctionCallOpts {
+    pub deposit: Option<Balance>,
+    pub static_gas: Option<Gas>,
+    pub gas_weight: Option<GasWeight>,
+}
+
+// TODO docs
+#[must_use]
+#[derive(Debug)]
+pub struct PromiseThen<'a, T = NoReturn> {
+    after: PromiseIndex,
+    inner: Promise<'a, T>,
+}
+
+impl<T> PromiseThen<'_, T> {
+    // TODO docs
+    pub fn schedule(self) -> PromiseIndex {
+        let promise_index = crate::env::promise_batch_then(self.after, self.inner.account_id);
+        for action in self.inner.actions {
+            action.add(promise_index);
+        }
+        promise_index
+    }
+
+    // TODO docs
+    pub fn schedule_as_return(self) -> ScheduledFn<T> {
+        let index = self.schedule();
+        crate::env::promise_return(index);
+        ScheduledFn { index, _marker: Default::default() }
+    }
+}
+
+#[must_use]
+#[derive(Debug)]
+pub struct PromiseAnd<L, R> {
+    promises: Vec<PromiseIndex>,
+    _marker: PhantomData<fn() -> (L, R)>,
+}
+
+impl<L, R> PromiseAnd<L, R> {
+    pub fn schedule(self) -> PromiseIndex {
+        let promise_index = crate::env::promise_and(&self.promises);
+        promise_index
+    }
+}
+
+impl<L, R> BorshSchema for PromiseAnd<L, R>
+where
+    L: BorshSchema,
+    R: BorshSchema,
+{
+    fn add_definitions_recursively(
+        definitions: &mut HashMap<borsh::schema::Declaration, borsh::schema::Definition>,
+    ) {
+        // TODO this might be able to recursively check the sub declarations, and if they are
+        // `PromiseAnd`, then the tuple elements are pulled and flattened into one definition.
+        // Currently, with nested `PromiseAnd`, the definition will look like (A, (B, (C, D)))
+        // which is usable, but not as clear as it could be.
+        Self::add_definition(
+            Self::declaration(),
+            borsh::schema::Definition::Tuple { elements: vec![L::declaration(), R::declaration()] },
+            definitions,
+        );
+        <L>::add_definitions_recursively(definitions);
+        <R>::add_definitions_recursively(definitions);
+    }
+
+    fn declaration() -> borsh::schema::Declaration {
+        format!("PromiseAnd<{}, {}>", L::declaration(), R::declaration())
+    }
+}
+
+pub struct ScheduledFn<T = NoReturn> {
+    pub index: PromiseIndex,
+    _marker: PhantomData<fn() -> T>,
+}
+
+impl<T> serde::Serialize for ScheduledFn<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // TODO not ideal that anything is serialized here. This is a workaround to allow this
+        // type to be returned from #[near_bindgen] functions.
+        serializer.serialize_unit()
+    }
+}
+
+impl<T> borsh::BorshSerialize for ScheduledFn<T> {
+    fn serialize<W: Write>(&self, _writer: &mut W) -> Result<(), Error> {
+        // Intentionally no bytes written for the promise, the return value from the promise
+        // will be considered as the return value from the contract call.
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+enum PromiseAction<'a> {
     CreateAccount,
     DeployContract {
         code: Vec<u8>,
     },
-    FunctionCall {
-        function_name: String,
-        arguments: Vec<u8>,
-        amount: Balance,
-        gas: Gas,
-    },
     FunctionCallWeight {
-        function_name: String,
+        function_name: &'a str,
         arguments: Vec<u8>,
         amount: Balance,
         gas: Gas,
@@ -30,43 +395,34 @@ enum PromiseAction {
     },
     Stake {
         amount: Balance,
-        public_key: PublicKey,
+        public_key: &'a PublicKey,
     },
     AddFullAccessKey {
-        public_key: PublicKey,
+        public_key: &'a PublicKey,
         nonce: u64,
     },
     AddAccessKey {
-        public_key: PublicKey,
+        public_key: &'a PublicKey,
         allowance: Balance,
-        receiver_id: AccountId,
-        function_names: String,
+        receiver_id: &'a AccountId,
+        function_names: &'a str,
         nonce: u64,
     },
     DeleteKey {
-        public_key: PublicKey,
+        public_key: &'a PublicKey,
     },
     DeleteAccount {
-        beneficiary_id: AccountId,
+        beneficiary_id: &'a AccountId,
     },
 }
 
-impl PromiseAction {
-    pub fn add(&self, promise_index: PromiseIndex) {
+impl PromiseAction<'_> {
+    fn add(&self, promise_index: PromiseIndex) {
         use PromiseAction::*;
         match self {
             CreateAccount => crate::env::promise_batch_action_create_account(promise_index),
             DeployContract { code } => {
                 crate::env::promise_batch_action_deploy_contract(promise_index, code)
-            }
-            FunctionCall { function_name, arguments, amount, gas } => {
-                crate::env::promise_batch_action_function_call(
-                    promise_index,
-                    function_name,
-                    arguments,
-                    *amount,
-                    *gas,
-                )
             }
             FunctionCallWeight { function_name, arguments, amount, gas, weight } => {
                 crate::env::promise_batch_action_function_call_weight(
@@ -111,393 +467,38 @@ impl PromiseAction {
     }
 }
 
-struct PromiseSingle {
-    pub account_id: AccountId,
-    pub actions: RefCell<Vec<PromiseAction>>,
-    pub after: RefCell<Option<PromiseIndex>>,
-    /// Promise index that is computed only once.
-    pub promise_index: RefCell<Option<PromiseIndex>>,
-}
+// impl<T> serde::Serialize for Promise<T> {
+//     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+//     where
+//         S: serde::Serializer,
+//     {
+//         *self.should_return.borrow_mut() = true;
+//         serializer.serialize_unit()
+//     }
+// }
 
-impl PromiseSingle {
-    pub fn construct_recursively(&self) -> PromiseIndex {
-        let mut promise_lock = self.promise_index.borrow_mut();
-        if let Some(res) = promise_lock.as_ref() {
-            return *res;
-        }
-        let promise_index = if let Some(after) = self.after.borrow().as_ref() {
-            crate::env::promise_batch_then(*after, &self.account_id)
-        } else {
-            crate::env::promise_batch_create(&self.account_id)
-        };
-        let actions_lock = self.actions.borrow();
-        for action in actions_lock.iter() {
-            action.add(promise_index);
-        }
-        *promise_lock = Some(promise_index);
-        promise_index
-    }
-}
+// impl<T> borsh::BorshSerialize for Promise<T> {
+//     fn serialize<W: Write>(&self, _writer: &mut W) -> Result<(), Error> {
+//         *self.should_return.borrow_mut() = true;
 
-pub struct PromiseJoint {
-    pub promise_a: PromiseIndex,
-    pub promise_b: PromiseIndex,
-    /// Promise index that is computed only once.
-    pub promise_index: RefCell<Option<PromiseIndex>>,
-}
+//         // Intentionally no bytes written for the promise, the return value from the promise
+//         // will be considered as the return value from the contract call.
+//         Ok(())
+//     }
+// }
 
-impl PromiseJoint {
-    pub fn construct_recursively(&self) -> PromiseIndex {
-        let mut promise_lock = self.promise_index.borrow_mut();
-        if let Some(res) = promise_lock.as_ref() {
-            return *res;
-        }
-        let res = crate::env::promise_and(&[self.promise_a, self.promise_b]);
-        *promise_lock = Some(res);
-        res
-    }
-}
+// #[cfg(feature = "abi")]
+// impl schemars::JsonSchema for Promise {
+//     fn schema_name() -> String {
+//         "Promise".to_string()
+//     }
 
-/// A structure representing a result of the scheduled execution on another contract.
-///
-/// Smart contract developers will explicitly use `Promise` in two situations:
-/// * When they need to return `Promise`.
-///
-///   In the following code if someone calls method `ContractA::a` they will internally cause an
-///   execution of method `ContractB::b` of `bob_near` account, and the return value of `ContractA::a`
-///   will be what `ContractB::b` returned.
-/// ```no_run
-/// # use near_sdk::{ext_contract, near_bindgen, Promise, Gas};
-/// # use borsh::{BorshDeserialize, BorshSerialize};
-/// #[ext_contract]
-/// pub trait ContractB {
-///     fn b(&mut self);
-/// }
-///
-/// #[near_bindgen]
-/// #[derive(Default, BorshDeserialize, BorshSerialize)]
-/// struct ContractA {}
-///
-/// #[near_bindgen]
-/// impl ContractA {
-///     pub fn a(&self) -> Promise {
-///         contract_b::ext("bob_near".parse().unwrap()).b()
-///     }
-/// }
-/// ```
-///
-/// * When they need to create a transaction with one or many actions, e.g. the following code
-///   schedules a transaction that creates an account, transfers tokens, and assigns a public key:
-///
-/// ```no_run
-/// # use near_sdk::{Promise, env, test_utils::VMContextBuilder, testing_env};
-/// # testing_env!(VMContextBuilder::new().signer_account_id("bob_near".parse().unwrap())
-/// #               .account_balance(1000).prepaid_gas(1_000_000.into()).build());
-/// Promise::new("bob_near".parse().unwrap())
-///   .create_account()
-///   .transfer(1000)
-///   .add_full_access_key(env::signer_account_pk());
-/// ```
-pub struct Promise<T = ()> {
-    subtype: PromiseSubtype,
-    should_return: RefCell<bool>,
-    _marker: PhantomData<fn() -> T>,
-}
-
-/// Until we implement strongly typed promises we serialize them as unit struct.
-impl<T> BorshSchema for Promise<T>
-where
-    T: BorshSchema,
-{
-    fn add_definitions_recursively(
-        definitions: &mut HashMap<borsh::schema::Declaration, borsh::schema::Definition>,
-    ) {
-        <T>::add_definitions_recursively(definitions);
-    }
-
-    fn declaration() -> borsh::schema::Declaration {
-        <T>::declaration()
-    }
-}
-
-#[derive(Clone)]
-enum PromiseSubtype {
-    Single(Rc<PromiseSingle>),
-    Joint(Rc<PromiseJoint>),
-}
-
-impl Promise<()> {
-    pub fn new(account_id: AccountId) -> Self {
-        Self::new_with_return(account_id)
-    }
-}
-
-impl<T> Promise<T> {
-    /// Create a promise that acts on the given account.
-    // TODO this is bad because it requires generic on a non-function call
-    pub fn new_with_return(account_id: AccountId) -> Self {
-        Self {
-            subtype: PromiseSubtype::Single(Rc::new(PromiseSingle {
-                account_id,
-                actions: RefCell::new(vec![]),
-                after: RefCell::new(None),
-                promise_index: RefCell::new(None),
-            })),
-            should_return: RefCell::new(false),
-            _marker: Default::default(),
-        }
-    }
-
-    fn add_action(self, action: PromiseAction) -> Self {
-        match &self.subtype {
-            PromiseSubtype::Single(x) => x.actions.borrow_mut().push(action),
-            PromiseSubtype::Joint(_) => {
-                crate::env::panic_str("Cannot add action to a joint promise.")
-            }
-        }
-        self
-    }
-
-    /// Create account on which this promise acts.
-    pub fn create_account(self) -> Self {
-        self.add_action(PromiseAction::CreateAccount)
-    }
-
-    /// Deploy a smart contract to the account on which this promise acts.
-    pub fn deploy_contract(self, code: Vec<u8>) -> Self {
-        self.add_action(PromiseAction::DeployContract { code })
-    }
-
-    /// A low-level interface for making a function call to the account that this promise acts on.
-    // TODO not really a way to specify generic on function call, which is how it should be
-    pub fn function_call(
-        self,
-        function_name: String,
-        arguments: Vec<u8>,
-        amount: Balance,
-        gas: Gas,
-    ) -> Self {
-        self.add_action(PromiseAction::FunctionCall { function_name, arguments, amount, gas })
-    }
-
-    /// A low-level interface for making a function call to the account that this promise acts on.
-    /// unlike [`Promise::function_call`], this function accepts a weight to use relative unused gas
-    /// on this function call at the end of the scheduling method execution.
-    pub fn function_call_weight(
-        self,
-        function_name: String,
-        arguments: Vec<u8>,
-        amount: Balance,
-        gas: Gas,
-        weight: GasWeight,
-    ) -> Self {
-        self.add_action(PromiseAction::FunctionCallWeight {
-            function_name,
-            arguments,
-            amount,
-            gas,
-            weight,
-        })
-    }
-
-    /// Transfer tokens to the account that this promise acts on.
-    pub fn transfer(self, amount: Balance) -> Self {
-        self.add_action(PromiseAction::Transfer { amount })
-    }
-
-    /// Stake the account for the given amount of tokens using the given public key.
-    pub fn stake(self, amount: Balance, public_key: PublicKey) -> Self {
-        self.add_action(PromiseAction::Stake { amount, public_key })
-    }
-
-    /// Add full access key to the given account.
-    pub fn add_full_access_key(self, public_key: PublicKey) -> Self {
-        self.add_full_access_key_with_nonce(public_key, 0)
-    }
-
-    /// Add full access key to the given account with a provided nonce.
-    pub fn add_full_access_key_with_nonce(self, public_key: PublicKey, nonce: u64) -> Self {
-        self.add_action(PromiseAction::AddFullAccessKey { public_key, nonce })
-    }
-
-    /// Add an access key that is restricted to only calling a smart contract on some account using
-    /// only a restricted set of methods. Here `function_names` is a comma separated list of methods,
-    /// e.g. `"method_a,method_b".to_string()`.
-    pub fn add_access_key(
-        self,
-        public_key: PublicKey,
-        allowance: Balance,
-        receiver_id: AccountId,
-        function_names: String,
-    ) -> Self {
-        self.add_access_key_with_nonce(public_key, allowance, receiver_id, function_names, 0)
-    }
-
-    /// Add an access key with a provided nonce.
-    pub fn add_access_key_with_nonce(
-        self,
-        public_key: PublicKey,
-        allowance: Balance,
-        receiver_id: AccountId,
-        function_names: String,
-        nonce: u64,
-    ) -> Self {
-        self.add_action(PromiseAction::AddAccessKey {
-            public_key,
-            allowance,
-            receiver_id,
-            function_names,
-            nonce,
-        })
-    }
-
-    /// Delete access key from the given account.
-    pub fn delete_key(self, public_key: PublicKey) -> Self {
-        self.add_action(PromiseAction::DeleteKey { public_key })
-    }
-
-    /// Delete the given account.
-    pub fn delete_account(self, beneficiary_id: AccountId) -> Self {
-        self.add_action(PromiseAction::DeleteAccount { beneficiary_id })
-    }
-
-    /// Merge this promise with another promise, so that we can schedule execution of another
-    /// smart contract right after all merged promises finish.
-    ///
-    /// Note, once the promises are merged it is not possible to add actions to them, e.g. the
-    /// following code will panic during the execution of the smart contract:
-    ///
-    /// ```no_run
-    /// # use near_sdk::{Promise, testing_env};
-    /// let p1 = Promise::new("bob_near".parse().unwrap()).create_account();
-    /// let p2 = Promise::new("carol_near".parse().unwrap()).create_account();
-    /// let p3 = p1.and(p2);
-    /// // p3.create_account();
-    /// ```
-    pub fn and<O>(self, other: Promise<O>) -> Promise<PromiseAnd<T, O>> {
-        Promise {
-            subtype: PromiseSubtype::Joint(Rc::new(PromiseJoint {
-                promise_a: self.construct_recursively(),
-                promise_b: other.construct_recursively(),
-                promise_index: RefCell::new(None),
-            })),
-            should_return: RefCell::new(false),
-            _marker: PhantomData::default(),
-        }
-    }
-
-    /// Schedules execution of another promise right after the current promise finish executing.
-    ///
-    /// In the following code `bob_near` and `dave_near` will be created concurrently. `carol_near`
-    /// creation will wait for `bob_near` to be created, and `eva_near` will wait for both `carol_near`
-    /// and `dave_near` to be created first.
-    /// ```no_run
-    /// # use near_sdk::{Promise, VMContext, testing_env};
-    /// let p1 = Promise::new("bob_near".parse().unwrap()).create_account();
-    /// let p2 = Promise::new("carol_near".parse().unwrap()).create_account();
-    /// let p3 = Promise::new("dave_near".parse().unwrap()).create_account();
-    /// let p4 = Promise::new("eva_near".parse().unwrap()).create_account();
-    /// p1.then(p2).and(p3).then(p4);
-    /// ```
-    pub fn then<O>(self, mut other: Promise<O>) -> Promise<O> {
-        match &mut other.subtype {
-            PromiseSubtype::Single(x) => {
-                let mut after = x.after.borrow_mut();
-                if after.is_some() {
-                    crate::env::panic_str(
-                        "Cannot callback promise which is already scheduled after another",
-                    );
-                }
-                *after = Some(self.construct_recursively())
-            }
-            PromiseSubtype::Joint(_) => crate::env::panic_str("Cannot callback joint promise."),
-        }
-        other
-    }
-
-    /// A specialized, relatively low-level API method. Allows to mark the given promise as the one
-    /// that should be considered as a return value.
-    ///
-    /// In the below code `a1` and `a2` functions are equivalent.
-    /// ```
-    /// # use near_sdk::{ext_contract, Gas, near_bindgen, Promise};
-    /// # use borsh::{BorshDeserialize, BorshSerialize};
-    /// #[ext_contract]
-    /// pub trait ContractB {
-    ///     fn b(&mut self);
-    /// }
-    ///
-    /// #[near_bindgen]
-    /// #[derive(Default, BorshDeserialize, BorshSerialize)]
-    /// struct ContractA {}
-    ///
-    /// #[near_bindgen]
-    /// impl ContractA {
-    ///     pub fn a1(&self) {
-    ///        contract_b::ext("bob_near".parse().unwrap()).b().as_return();
-    ///     }
-    ///
-    ///     pub fn a2(&self) -> Promise {
-    ///        contract_b::ext("bob_near".parse().unwrap()).b()
-    ///     }
-    /// }
-    /// ```
-    #[allow(clippy::wrong_self_convention)]
-    pub fn as_return(self) -> Self {
-        *self.should_return.borrow_mut() = true;
-        self
-    }
-
-    fn construct_recursively(&self) -> PromiseIndex {
-        let res = match &self.subtype {
-            PromiseSubtype::Single(x) => x.construct_recursively(),
-            PromiseSubtype::Joint(x) => x.construct_recursively(),
-        };
-        if *self.should_return.borrow() {
-            crate::env::promise_return(res);
-        }
-        res
-    }
-}
-
-impl<T> Drop for Promise<T> {
-    fn drop(&mut self) {
-        self.construct_recursively();
-    }
-}
-
-impl<T> serde::Serialize for Promise<T> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        *self.should_return.borrow_mut() = true;
-        serializer.serialize_unit()
-    }
-}
-
-impl<T> borsh::BorshSerialize for Promise<T> {
-    fn serialize<W: Write>(&self, _writer: &mut W) -> Result<(), Error> {
-        *self.should_return.borrow_mut() = true;
-
-        // Intentionally no bytes written for the promise, the return value from the promise
-        // will be considered as the return value from the contract call.
-        Ok(())
-    }
-}
-
-#[cfg(feature = "abi")]
-impl schemars::JsonSchema for Promise {
-    fn schema_name() -> String {
-        "Promise".to_string()
-    }
-
-    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        // Since promises are untyped, for now we represent Promise results with the schema
-        // `true` which matches everything (i.e. always passes validation)
-        schemars::schema::Schema::Bool(true)
-    }
-}
+//     fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+//         // Since promises are untyped, for now we represent Promise results with the schema
+//         // `true` which matches everything (i.e. always passes validation)
+//         schemars::schema::Schema::Bool(true)
+//     }
+// }
 
 /// When the method can return either a promise or a value, it can be called with `PromiseOrValue::Promise`
 /// or `PromiseOrValue::Value` to specify which one should be returned.
@@ -519,7 +520,7 @@ impl schemars::JsonSchema for Promise {
 #[derive(serde::Serialize)]
 #[serde(untagged)]
 pub enum PromiseOrValue<T> {
-    Promise(Promise<T>),
+    Promise(ScheduledFn<T>),
     Value(T),
 }
 
@@ -538,9 +539,9 @@ where
     }
 }
 
-impl<T> From<Promise<T>> for PromiseOrValue<T> {
-    fn from(promise: Promise<T>) -> Self {
-        PromiseOrValue::Promise(promise)
+impl<T> From<PromiseThen<'_, T>> for PromiseOrValue<T> {
+    fn from(promise: PromiseThen<'_, T>) -> Self {
+        PromiseOrValue::Promise(promise.schedule_as_return())
     }
 }
 
@@ -563,39 +564,5 @@ impl<T: schemars::JsonSchema> schemars::JsonSchema for PromiseOrValue<T> {
 
     fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
         T::json_schema(gen)
-    }
-}
-
-/// Generic type to indicate merged promises that execute in parallel.
-///
-/// The ordering of return values is in the order of L (left) -> R (right)
-/// where the generics act as a binary tree.
-pub struct PromiseAnd<L, R> {
-    _marker: PhantomData<fn() -> (L, R)>,
-}
-
-impl<L, R> BorshSchema for PromiseAnd<L, R>
-where
-    L: BorshSchema,
-    R: BorshSchema,
-{
-    fn add_definitions_recursively(
-        definitions: &mut HashMap<borsh::schema::Declaration, borsh::schema::Definition>,
-    ) {
-        // TODO this might be able to recursively check the sub declarations, and if they are
-        // `PromiseAnd`, then the tuple elements are pulled and flattened into one definition.
-        // Currently, with nested `PromiseAnd`, the definition will look like (A, (B, (C, D)))
-        // which is usable, but not as clear as it could be.
-        Self::add_definition(
-            Self::declaration(),
-            borsh::schema::Definition::Tuple { elements: vec![L::declaration(), R::declaration()] },
-            definitions,
-        );
-        <L>::add_definitions_recursively(definitions);
-        <R>::add_definitions_recursively(definitions);
-    }
-
-    fn declaration() -> borsh::schema::Declaration {
-        format!("PromiseAnd<{}, {}>", L::declaration(), R::declaration())
     }
 }


### PR DESCRIPTION
Definitely not perfect since we have to follow the drop pattern with the host functions available

- This now schedules promises when `then` or `and` is called to avoid recursive generics or unsafe code to swap the generic type
- Janky pattern because Promises should only really be typed when a function call is acted on it, but not much flexibility with this single type
- Currently, if the function call returns a promise, this is expressed in the parameters (this could be useful to know it is chained, but maybe not from an interface level?) cc @itegulov your input on what you think is useful here is important
- Takes Ok type of `Result<_, PromiseError>` from new error handling logic


Generally, it's a pretty breaking change, so seems like if we are changing this API it should come in 5.0 pre-releases to be iterated on. For cases of using ACI to have typed promises for codegen, might require using this new version or creating a fallback to handle promises as some `any` type in the schema generation (this might be necessary for other language impls anyway).

@matklad if and only if you have free time, input on how promises becoming generic could be migrated to, or if we were to start from scratch if you had any considerations