### PR TITLE
`owner_by_id` updated from TreeMap to UnorderedMap

### DIFF
--- a/examples/non-fungible-token/nft/src/lib.rs
+++ b/examples/non-fungible-token/nft/src/lib.rs
@@ -119,7 +119,7 @@ mod tests {
 
     use super::*;
 
-    const MINT_STORAGE_COST: u128 = 5870000000000000000000;
+    const MINT_STORAGE_COST: u128 = 6270000000000000000000;
 
     fn get_context(predecessor_account_id: AccountId) -> VMContextBuilder {
         let mut builder = VMContextBuilder::new();

--- a/examples/non-fungible-token/tests/workspaces/test_core.rs
+++ b/examples/non-fungible-token/tests/workspaces/test_core.rs
@@ -1,6 +1,7 @@
-use crate::utils::{init, TOKEN_ID};
+use crate::utils::{init, helper_mint, TOKEN_ID};
 use near_contract_standards::non_fungible_token::Token;
 use near_primitives::views::FinalExecutionStatus;
+use near_sdk::json_types::U128;
 use near_sdk::ONE_YOCTO;
 
 #[tokio::test]
@@ -270,6 +271,47 @@ async fn simulate_simple_transfer_no_logs_on_failure() -> anyhow::Result<()> {
         .await?
         .json::<Token>()?;
     assert_eq!(token.owner_id.to_string(), nft_contract.id().to_string());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn simulate_mass_mint() -> anyhow::Result<()> {
+    let worker = workspaces::sandbox();
+    let (nft_contract, _, _, _) = init(&worker).await?;
+
+    pub const TOTAL_NFT_TO_MINT: u128 = 750;
+
+    for n in 1..TOTAL_NFT_TO_MINT {
+        helper_mint(
+            &nft_contract,
+            &worker,
+            n.to_string(),
+            "Name".to_string(),
+            "Description".to_string(),
+        ).await?;
+    }
+
+    let token = nft_contract
+        .call(&worker, "nft_token")
+        .args_json(((TOTAL_NFT_TO_MINT - 1).to_string(), ))?
+        .view()
+        .await?
+        .json::<Token>()?;
+    assert_eq!(token.owner_id.to_string(), nft_contract.id().to_string());
+
+    let total_supply: U128 = nft_contract.call(&worker, "nft_total_supply").view().await?.json()?;
+    assert_eq!(total_supply, U128::from(TOTAL_NFT_TO_MINT));
+
+    // read 3 tokens somewhere from the end
+    let tokens: Vec<Token> = nft_contract.call(&worker, "nft_tokens")
+        .args_json((Some(U128::from(700)), Some(3u64)))?
+        .view().await?.json()?;
+
+    assert_eq!(tokens.len(), 3);
+    assert_eq!(tokens.get(0).unwrap().token_id, "700".to_string());
+    assert_eq!(tokens.get(1).unwrap().token_id, "701".to_string());
+    assert_eq!(tokens.get(2).unwrap().token_id, "702".to_string());
 
     Ok(())
 }

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-contract-standards"
-version = "4.0.0-pre.8"
+version = "4.0.1"
 authors = ["Near Inc <hello@near.org>"]
 edition = "2018"
 license = "GPL-3.0"

--- a/near-contract-standards/src/non_fungible_token/core/core_impl.rs
+++ b/near-contract-standards/src/non_fungible_token/core/core_impl.rs
@@ -7,7 +7,7 @@ use crate::non_fungible_token::utils::{
     hash_account_id, refund_approved_account_ids, refund_deposit_to_account,
 };
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
-use near_sdk::collections::{LookupMap, TreeMap, UnorderedSet};
+use near_sdk::collections::{LookupMap, UnorderedMap, UnorderedSet};
 use near_sdk::json_types::Base64VecU8;
 use near_sdk::{
     assert_one_yocto, env, ext_contract, require, AccountId, Balance, BorshStorageKey, CryptoHash,
@@ -61,7 +61,7 @@ pub struct NonFungibleToken {
     pub extra_storage_in_bytes_per_token: StorageUsage,
 
     // always required
-    pub owner_by_id: TreeMap<TokenId, AccountId>,
+    pub owner_by_id: UnorderedMap<TokenId, AccountId>,
 
     // required by metadata extension
     pub token_metadata_by_id: Option<LookupMap<TokenId, TokenMetadata>>,
@@ -107,7 +107,7 @@ impl NonFungibleToken {
         let mut this = Self {
             owner_id,
             extra_storage_in_bytes_per_token: 0,
-            owner_by_id: TreeMap::new(owner_by_id_prefix),
+            owner_by_id: UnorderedMap::new(owner_by_id_prefix),
             token_metadata_by_id: token_metadata_prefix.map(LookupMap::new),
             tokens_per_owner: enumeration_prefix.map(LookupMap::new),
             approvals_by_id,


### PR DESCRIPTION
`owner_by_id` updated from TreeMap to Unordered map due to https://github.com/near/near-sdk-rs/issues/800. `simulate_mass_mint` test introduced.

Please review if my version upgrade was correct.