### PR TITLE
chore: bump contract builder to version 1.61

### DIFF
--- a/contract-builder/Dockerfile
+++ b/contract-builder/Dockerfile
@@ -1,8 +1,8 @@
-FROM rust:1.56.0
+FROM rust:1.60.0
 
 LABEL description="Container for builds"
 
-RUN rustup default 1.56.0
+RUN rustup default 1.60.0
 RUN rustup target add wasm32-unknown-unknown
 
 RUN apt-get -y update && apt-get install -y \

--- a/contract-builder/Dockerfile
+++ b/contract-builder/Dockerfile
@@ -1,8 +1,8 @@
-FROM rust:1.60.0
+FROM rust:1.61.0
 
 LABEL description="Container for builds"
 
-RUN rustup default 1.60.0
+RUN rustup default 1.61.0
 RUN rustup target add wasm32-unknown-unknown
 
 RUN apt-get -y update && apt-get install -y \


### PR DESCRIPTION
1.60 is needed to be able to build the nearcore crates used for unit testing after #820 as can be seen from this failed buildkite https://buildkite.com/nearprotocol/near-sdk-rs/builds/4076#090f7030-7abe-48bf-80a0-95fbce8f323f

This adds more value to https://github.com/near/near-ops/issues/839 since using `latest` and bumping people's images based on this for updates like this isn't a good pattern. cc @anshal-savla 

Also noting that changes like this would break old CI runs on this repo since the toolchain is different and would produce different binaries -- there should be a way to specify the Rust toolchain version on the image tag