### PR TITLE
Add ext_contract macro to FungibleTokenMetadataProvider trait

### DIFF
--- a/near-contract-standards/src/fungible_token/metadata.rs
+++ b/near-contract-standards/src/fungible_token/metadata.rs
@@ -1,7 +1,7 @@
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::json_types::Base64VecU8;
-use near_sdk::require;
 use near_sdk::serde::{Deserialize, Serialize};
+use near_sdk::{ext_contract, require};
 
 pub const FT_METADATA_SPEC: &str = "ft-1.0.0";
 
@@ -17,6 +17,7 @@ pub struct FungibleTokenMetadata {
     pub decimals: u8,
 }
 
+#[ext_contract(ext_ft_metadata)]
 pub trait FungibleTokenMetadataProvider {
     fn ft_metadata(&self) -> FungibleTokenMetadata;
 }


### PR DESCRIPTION
Currently, users building smart contracts can use  `ext_ft_core` to make cross-contract calls to Fungible token methods enumerated in NEP-141. However, to make a call to the `ft_metadata` method, they have to define their own trait in their smart contract because `FungibleTokenMetadataProvider` does not have a `ext_contract` macro. This PR adds the `ext_contract` macro to the `FungibleTokenMetadataProvider` trait so that users do not have to copy/paste this trait into their code.