### PR TITLE
chore: add audit to SDK CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+          toolchain: stable
       - uses: Swatinem/rust-cache@v1
       - name: Install Audit
         run: cargo install cargo-audit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,3 +50,21 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - run: cargo check -p near-sdk --features unstable
       - run: cargo check -p near-contract-standards
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v2
+      - name: Install Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+      - uses: Swatinem/rust-cache@v1
+      - name: Install Audit
+        run: cargo install cargo-audit
+      - name: Run Audit
+        uses: actions-rs/cargo@v1
+        with:
+          command: audit
+          args: --ignore RUSTSEC-2020-0071


### PR DESCRIPTION
Ignoring time audit vulnerability because it isn't exposed through chrono, which is what `nearcore` crates pull this in through

https://github.com/chronotope/chrono/issues/602