### PR TITLE
fix(standards): Update enum_get_token to not expect metadata and approval standard

### DIFF
--- a/near-contract-standards/src/non_fungible_token/enumeration/enumeration_impl.rs
+++ b/near-contract-standards/src/non_fungible_token/enumeration/enumeration_impl.rs
@@ -10,9 +10,9 @@ impl NonFungibleToken {
     /// Helper function used by a enumerations methods
     /// Note: this method is not exposed publicly to end users
     fn enum_get_token(&self, owner_id: AccountId, token_id: TokenId) -> Token {
-        let metadata = self.token_metadata_by_id.as_ref().unwrap().get(&token_id);
+        let metadata = self.token_metadata_by_id.as_ref().and_then(|m| m.get(&token_id));
         let approved_account_ids =
-            Some(self.approvals_by_id.as_ref().unwrap().get(&token_id).unwrap_or_default());
+            self.approvals_by_id.as_ref().map(|a| a.get(&token_id).unwrap_or_default());
 
         Token { token_id, owner_id, metadata, approved_account_ids }
     }


### PR DESCRIPTION
@hanakannzashi is this what you expected the code to be?

@BenKurrek do you mind reviewing this to make sure it makes sense? I don't have context on this

closes #842 