### PR TITLE
feat: make #[hanlde_result] work with fully qualified paths

### DIFF
--- a/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
@@ -853,4 +853,33 @@ mod tests {
         );
         assert_eq!(expected.to_string(), actual.to_string());
     }
+
+    #[test]
+    fn handle_result_anyhow() {
+        let impl_type: Type = syn::parse_str("Hello").unwrap();
+        let mut method: ImplItemMethod = parse_quote! {
+            #[handle_result]
+            pub fn method(&self) -> anyhow::Result<u64> { }
+        };
+        let method_info = ImplItemMethodInfo::new(&mut method, impl_type).unwrap();
+        let actual = method_info.method_wrapper();
+        let expected = quote!(
+            #[cfg(target_arch = "wasm32")]
+            #[no_mangle]
+            pub extern "C" fn method() {
+                near_sdk::env::setup_panic_hook();
+                let contract: Hello = near_sdk::env::state_read().unwrap_or_default();
+                let result = contract.method();
+                match result {
+                    Ok(result) => {
+                        let result =
+                            near_sdk::serde_json::to_vec(&result).expect("Failed to serialize the return value using JSON.");
+                        near_sdk::env::value_return(&result);
+                    }
+                    Err(err) => near_sdk::FunctionError::panic(&err)
+                }
+            }
+        );
+        assert_eq!(expected.to_string(), actual.to_string());
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/near/near-sdk-rs/issues/852

Opening this as a draft for now since there is one unresolved thing with `FunctionError` impl for `anyhow::Error`. There is no `AsRef<str>` implementation for `anyhow::Error` and we can't implement it ourselves (or `FunctionError` itself) due to conflicting implementations (life is hard without specialization...).