### PR TITLE
chore: deprecate upgrade standards implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Removed
+- Deprecated `near_contract_standards::upgrade`. [PR 856](https://github.com/near/near-sdk-rs/pull/856)
+  - Implementation did not match any NEAR standard and was not correct
+
 
 ## [4.0.0] - 2022-05-25
 

--- a/near-contract-standards/src/lib.rs
+++ b/near-contract-standards/src/lib.rs
@@ -6,6 +6,10 @@ pub mod non_fungible_token;
 pub mod storage_management;
 /// This upgrade standard is a use case where a staging area exists for a WASM
 /// blob, allowing it to be stored for a period of time before deployed.
+#[deprecated(
+    since = "4.1.0",
+    note = "This was removed because there is no standard (NEP) for upgradable contracts."
+)]
 pub mod upgrade;
 
 pub(crate) mod event;


### PR DESCRIPTION
Not quite sure why this was added, somewhat broken as per #855 and the interface doesn't make much sense and is inefficient.

Deprecating for now and can optimize/update if there are real use cases or the standard is actually added to NEPs