### PR TITLE
chore: bump workspaces version to new patch

### DIFF
--- a/examples/callback-results/Cargo.lock
+++ b/examples/callback-results/Cargo.lock
@@ -3047,9 +3047,9 @@ dependencies = [
 
 [[package]]
 name = "workspaces"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58a9b9b6d29ca216ce56e738450ac32016466fe626e1a10732e0f01092ce2f66"
+checksum = "d1bcb8cee0423b071bbbf0699cee998e48012d499c474780903de8233ae63fce"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/callback-results/Cargo.toml
+++ b/examples/callback-results/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 near-sdk = { path = "../../near-sdk" }
 
 [dev-dependencies]
-workspaces = "0.3"
+workspaces = "0.3.1"
 serde_json = "1.0"
 tokio = { version = "1.14", features = ["full"] }
 anyhow = "1.0"

--- a/examples/cross-contract-calls/Cargo.lock
+++ b/examples/cross-contract-calls/Cargo.lock
@@ -3162,9 +3162,9 @@ dependencies = [
 
 [[package]]
 name = "workspaces"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58a9b9b6d29ca216ce56e738450ac32016466fe626e1a10732e0f01092ce2f66"
+checksum = "d1bcb8cee0423b071bbbf0699cee998e48012d499c474780903de8233ae63fce"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/cross-contract-calls/Cargo.toml
+++ b/examples/cross-contract-calls/Cargo.toml
@@ -11,7 +11,7 @@ near-units = "0.2.0"
 serde_json = "1.0"
 test-case = "2.0"
 tokio = { version = "1.14", features = ["full"] }
-workspaces = "0.3"
+workspaces = "0.3.1"
 
 cross-contract-high-level = { path = "./high-level" }
 cross-contract-low-level = { path = "./low-level" }

--- a/examples/factory-contract/Cargo.lock
+++ b/examples/factory-contract/Cargo.lock
@@ -3162,9 +3162,9 @@ dependencies = [
 
 [[package]]
 name = "workspaces"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58a9b9b6d29ca216ce56e738450ac32016466fe626e1a10732e0f01092ce2f66"
+checksum = "d1bcb8cee0423b071bbbf0699cee998e48012d499c474780903de8233ae63fce"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/factory-contract/Cargo.toml
+++ b/examples/factory-contract/Cargo.toml
@@ -11,7 +11,7 @@ near-units = "0.2.0"
 serde_json = "1.0"
 test-case = "2.0"
 tokio = { version = "1.14", features = ["full"] }
-workspaces = "0.3"
+workspaces = "0.3.1"
 
 factory-contract-high-level = { path = "./high-level" }
 factory-contract-low-level = { path = "./low-level" }

--- a/examples/fungible-token/Cargo.lock
+++ b/examples/fungible-token/Cargo.lock
@@ -3333,9 +3333,9 @@ dependencies = [
 
 [[package]]
 name = "workspaces"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58a9b9b6d29ca216ce56e738450ac32016466fe626e1a10732e0f01092ce2f66"
+checksum = "d1bcb8cee0423b071bbbf0699cee998e48012d499c474780903de8233ae63fce"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/fungible-token/Cargo.toml
+++ b/examples/fungible-token/Cargo.toml
@@ -11,7 +11,7 @@ near-sdk = { path = "../../near-sdk" }
 near-units = "0.2.0"
 serde_json = "1.0"
 tokio = { version = "1.14", features = ["full"] }
-workspaces = "0.3"
+workspaces = "0.3.1"
 
 # remember to include a line for each contract
 fungible-token = { path = "./ft" }

--- a/examples/lockable-fungible-token/Cargo.lock
+++ b/examples/lockable-fungible-token/Cargo.lock
@@ -3261,9 +3261,9 @@ dependencies = [
 
 [[package]]
 name = "workspaces"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58a9b9b6d29ca216ce56e738450ac32016466fe626e1a10732e0f01092ce2f66"
+checksum = "d1bcb8cee0423b071bbbf0699cee998e48012d499c474780903de8233ae63fce"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/lockable-fungible-token/Cargo.toml
+++ b/examples/lockable-fungible-token/Cargo.toml
@@ -17,7 +17,7 @@ near-sdk = { path = "../../near-sdk" }
 near-units = "0.2.0"
 serde_json = "1.0"
 tokio = { version = "1.14", features = ["full"] }
-workspaces = "0.3"
+workspaces = "0.3.1"
 
 [profile.release]
 codegen-units = 1

--- a/examples/non-fungible-token/Cargo.lock
+++ b/examples/non-fungible-token/Cargo.lock
@@ -3337,9 +3337,9 @@ dependencies = [
 
 [[package]]
 name = "workspaces"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58a9b9b6d29ca216ce56e738450ac32016466fe626e1a10732e0f01092ce2f66"
+checksum = "d1bcb8cee0423b071bbbf0699cee998e48012d499c474780903de8233ae63fce"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/non-fungible-token/Cargo.toml
+++ b/examples/non-fungible-token/Cargo.toml
@@ -12,7 +12,7 @@ near-sdk = { path = "../../near-sdk" }
 near-units = "0.2.0"
 serde_json = "1.0"
 tokio = { version = "1.14", features = ["full"] }
-workspaces = "0.3"
+workspaces = "0.3.1"
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
This patch version fixes the non-determinism in our CI failures (which is starting to get annoying)