### PR TITLE
fix: support `#[handle_result]` in ABI macro

### DIFF
--- a/near-sdk-macros/src/core_impl/abi/abi_generator.rs
+++ b/near-sdk-macros/src/core_impl/abi/abi_generator.rs
@@ -127,13 +127,13 @@ impl ImplItemMethodInfo {
                         None
                     }
                 }
-                ReturnType::Type(_, ty) if utils::type_is_result(ty) && is_handles_result => {
+                ReturnType::Type(_, ty) if is_handles_result && utils::type_is_result(ty) => {
                     let ty = if let Some(ty) = utils::extract_ok_type(ty) {
                         ty
                     } else {
                         return syn::Error::new_spanned(
                             ty,
-                            "Function marked with #[handle_result] should have return type Result<T, PromiseError>",
+                            "Function marked with #[handle_result] should have return type Result<T, E>",
                         )
                         .into_compile_error();
                     };

--- a/near-sdk-macros/src/core_impl/abi/abi_generator.rs
+++ b/near-sdk-macros/src/core_impl/abi/abi_generator.rs
@@ -133,7 +133,7 @@ impl ImplItemMethodInfo {
                     } else {
                         return syn::Error::new_spanned(
                             ty,
-                            "Function marked with #[handle_result] should have return type Result<T, E>",
+                            "Function marked with #[handle_result] should have return type Result<T, E> (where E implements FunctionError).",
                         )
                         .into_compile_error();
                     };
@@ -151,7 +151,7 @@ impl ImplItemMethodInfo {
                 ReturnType::Type(_, ty) if is_handles_result => {
                     return syn::Error::new(
                         ty.span(),
-                        "Method marked with #[handle_result] should return Result<T, E>.",
+                        "Method marked with #[handle_result] should return Result<T, E> (where E implements FunctionError).",
                     )
                     .to_compile_error();
                 }

--- a/near-sdk-macros/src/core_impl/code_generator/impl_item_method_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/impl_item_method_info.rs
@@ -149,7 +149,7 @@ impl ImplItemMethodInfo {
                 ReturnType::Type(_, return_type) if *is_handles_result => {
                     return syn::Error::new(
                         return_type.span(),
-                        "Method marked with #[handle_result] should return Result<T, E>.",
+                        "Method marked with #[handle_result] should return Result<T, E> (where E implements FunctionError).",
                     )
                     .to_compile_error();
                 }
@@ -241,7 +241,7 @@ fn init_method_wrapper(
         }
         ReturnType::Type(_, return_type) if *is_handles_result => Err(syn::Error::new(
             return_type.span(),
-            "Method marked with #[handle_result] should return Result<T, E>",
+            "Method marked with #[handle_result] should return Result<T, E> (where E implements FunctionError).",
         )),
         ReturnType::Type(_, _) => Ok(quote! {
             #state_check

--- a/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
@@ -832,7 +832,7 @@ mod tests {
         let actual = method_info.method_wrapper();
         let expected = quote!(
             compile_error! {
-                "Method marked with #[handle_result] should return Result<T, E>."
+                "Method marked with #[handle_result] should return Result<T, E> (where E implements FunctionError)."
             }
         );
         assert_eq!(expected.to_string(), actual.to_string());


### PR DESCRIPTION
Fixes https://github.com/near/near-sdk-rs/issues/853