### PR TITLE
fix: extract #[callback_vec] vec type for abi

### DIFF
--- a/near-sdk-macros/src/core_impl/abi/abi_generator.rs
+++ b/near-sdk-macros/src/core_impl/abi/abi_generator.rs
@@ -93,6 +93,15 @@ impl ImplItemMethodInfo {
                 }
                 BindgenArgType::CallbackArgVec => {
                     if callback_vec.is_none() {
+                        let typ = if let Some(vec_type) = utils::extract_vec_type(typ) {
+                            vec_type
+                        } else {
+                            return syn::Error::new_spanned(
+                                &arg.ty,
+                                "Function parameters marked with  #[callback_vec] should have type Vec<T>",
+                            )
+                            .into_compile_error();
+                        };
                         callback_vec = Some(quote! {
                             Some(
                                 near_sdk::__private::AbiType {

--- a/near-sdk-macros/src/core_impl/utils/mod.rs
+++ b/near-sdk-macros/src/core_impl/utils/mod.rs
@@ -9,15 +9,6 @@ pub(crate) fn path_is_result(path: &Path) -> bool {
         && path.segments.iter().next().unwrap().ident == "Result"
 }
 
-/// Checks whether the given path is literally "Vec".
-/// Note that it won't match a fully qualified name `std::vec::Vec` or a type alias like
-/// `type MyVec = Vec<String>`.
-pub(crate) fn path_is_vec(path: &Path) -> bool {
-    path.leading_colon.is_none()
-        && path.segments.len() == 1
-        && path.segments.iter().next().unwrap().ident == "Vec"
-}
-
 /// Equivalent to `path_is_result` except that it works on `Type` values.
 pub(crate) fn type_is_result(ty: &Type) -> bool {
     match ty {
@@ -49,9 +40,19 @@ pub(crate) fn extract_ok_type(ty: &Type) -> Option<&Type> {
     }
 }
 
+/// Checks whether the given path is literally "Vec".
+/// Note that it won't match a fully qualified name `std::vec::Vec` or a type alias like
+/// `type MyVec = Vec<String>`.
+fn path_is_vec(path: &Path) -> bool {
+    path.leading_colon.is_none()
+        && path.segments.len() == 1
+        && path.segments.iter().next().unwrap().ident == "Vec"
+}
+
 /// Extracts the inner generic type from a `Vec<_>` type.
 ///
 /// For example, given `Vec<String>` this function will return `String`.
+#[allow(dead_code)]
 pub(crate) fn extract_vec_type(ty: &Type) -> Option<&Type> {
     match ty {
         Type::Path(type_path) if type_path.qself.is_none() && path_is_vec(&type_path.path) => {

--- a/near-sdk-macros/src/core_impl/utils/mod.rs
+++ b/near-sdk-macros/src/core_impl/utils/mod.rs
@@ -43,6 +43,7 @@ pub(crate) fn extract_ok_type(ty: &Type) -> Option<&Type> {
 /// Checks whether the given path is literally "Vec".
 /// Note that it won't match a fully qualified name `std::vec::Vec` or a type alias like
 /// `type MyVec = Vec<String>`.
+#[cfg(feature = "abi")]
 fn path_is_vec(path: &Path) -> bool {
     path.leading_colon.is_none()
         && path.segments.len() == 1
@@ -52,7 +53,7 @@ fn path_is_vec(path: &Path) -> bool {
 /// Extracts the inner generic type from a `Vec<_>` type.
 ///
 /// For example, given `Vec<String>` this function will return `String`.
-#[allow(dead_code)]
+#[cfg(feature = "abi")]
 pub(crate) fn extract_vec_type(ty: &Type) -> Option<&Type> {
     match ty {
         Type::Path(type_path) if type_path.qself.is_none() && path_is_vec(&type_path.path) => {

--- a/near-sdk-macros/src/core_impl/utils/mod.rs
+++ b/near-sdk-macros/src/core_impl/utils/mod.rs
@@ -9,6 +9,15 @@ pub(crate) fn path_is_result(path: &Path) -> bool {
         && path.segments.iter().next().unwrap().ident == "Result"
 }
 
+/// Checks whether the given path is literally "Vec".
+/// Note that it won't match a fully qualified name `std::vec::Vec` or a type alias like
+/// `type MyVec = Vec<String>`.
+pub(crate) fn path_is_vec(path: &Path) -> bool {
+    path.leading_colon.is_none()
+        && path.segments.len() == 1
+        && path.segments.iter().next().unwrap().ident == "Vec"
+}
+
 /// Equivalent to `path_is_result` except that it works on `Type` values.
 pub(crate) fn type_is_result(ty: &Type) -> bool {
     match ty {
@@ -31,6 +40,29 @@ pub(crate) fn extract_ok_type(ty: &Type) -> Option<&Type> {
                 _ => None,
             }?;
             // This argument must be a type:
+            match generic_arg {
+                GenericArgument::Type(ty) => Some(ty),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Extracts the inner generic type from a `Vec<_>` type.
+///
+/// For example, given `Vec<String>` this function will return `String`.
+pub(crate) fn extract_vec_type(ty: &Type) -> Option<&Type> {
+    match ty {
+        Type::Path(type_path) if type_path.qself.is_none() && path_is_vec(&type_path.path) => {
+            let type_params = &type_path.path.segments.first()?.arguments;
+            let generic_arg = match type_params {
+                // We are interested in the first (and only) angle-bracketed param:
+                PathArguments::AngleBracketed(params) if params.args.len() == 1 => {
+                    Some(params.args.first()?)
+                }
+                _ => None,
+            }?;
             match generic_arg {
                 GenericArgument::Type(ty) => Some(ty),
                 _ => None,


### PR DESCRIPTION
Forgot to extract the underlying type from `Vec<_>` for ABI