### PR TITLE
fix: wrap `$ty` in angle brackets for ABI macro

### DIFF
--- a/near-sdk-macros/src/core_impl/abi/abi_generator.rs
+++ b/near-sdk-macros/src/core_impl/abi/abi_generator.rs
@@ -175,7 +175,7 @@ fn generate_abi_type(ty: &Type, serializer_type: &SerializerType) -> TokenStream
         },
         SerializerType::Borsh => quote! {
             near_sdk::__private::AbiType::Borsh {
-                type_schema: #ty::schema_container(),
+                type_schema: <#ty>::schema_container(),
             }
         },
     }


### PR DESCRIPTION
The current code does not work for some types e.g. `()::schema_container()` vs `<()>::schema_container()`