### PR TITLE
feat: Support newly stabilized alt_bn128 host functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Support newly stabilized `alt_bn128` host functions that were recently stabilized. [PR 885](https://github.com/near/near-sdk-rs/pull/885)
+
 ## [4.1.0-pre.1] - 2022-08-05
 
 ### Added

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -33,7 +33,8 @@ wee_alloc = { version = "0.4.5", default-features = false, optional = true }
 once_cell = { version = "1.8", optional = true, default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-near-vm-logic = { version = "0.14", optional = true }
+# alt_bn128 feature will need to be removed on the next version update (now stabilized)
+near-vm-logic = { version = "0.14", optional = true, features = ["protocol_feature_alt_bn128"] }
 near-primitives-core = { version = "0.14", optional = true }
 near-primitives = { version = "0.14", optional = true }
 near-crypto = { version = "0.14", optional = true }

--- a/near-sdk/src/environment/mock/mocked_blockchain.rs
+++ b/near-sdk/src/environment/mock/mocked_blockchain.rs
@@ -565,4 +565,16 @@ mod mock_chain {
     extern "C" fn validator_total_stake(stake_ptr: u64) {
         with_mock_interface(|b| b.validator_total_stake(stake_ptr))
     }
+    #[no_mangle]
+    extern "C" fn alt_bn128_g1_multiexp(value_len: u64, value_ptr: u64, register_id: u64) {
+        with_mock_interface(|b| b.alt_bn128_g1_multiexp(value_len, value_ptr, register_id))
+    }
+    #[no_mangle]
+    extern "C" fn alt_bn128_g1_sum(value_len: u64, value_ptr: u64, register_id: u64) {
+        with_mock_interface(|b| b.alt_bn128_g1_sum(value_len, value_ptr, register_id))
+    }
+    #[no_mangle]
+    extern "C" fn alt_bn128_pairing_check(value_len: u64, value_ptr: u64) -> u64 {
+        with_mock_interface(|b| b.alt_bn128_pairing_check(value_len, value_ptr))
+    }
 }


### PR DESCRIPTION
It's been stabilized, so devs will need this to test