### PR TITLE
fix: Update generic for LookupSet hasher

### DIFF
--- a/near-sdk/src/collections/lazy_option.rs
+++ b/near-sdk/src/collections/lazy_option.rs
@@ -18,7 +18,7 @@ const ERR_VALUE_DESERIALIZATION: &str = "Cannot deserialize value with Borsh";
 pub struct LazyOption<T> {
     storage_key: Vec<u8>,
     #[borsh_skip]
-    el: PhantomData<T>,
+    el: PhantomData<fn() -> T>,
 }
 
 impl<T> LazyOption<T> {

--- a/near-sdk/src/collections/lookup_map.rs
+++ b/near-sdk/src/collections/lookup_map.rs
@@ -17,7 +17,7 @@ const ERR_VALUE_SERIALIZATION: &str = "Cannot serialize value with Borsh";
 pub struct LookupMap<K, V> {
     key_prefix: Vec<u8>,
     #[borsh_skip]
-    el: PhantomData<(K, V)>,
+    el: PhantomData<fn() -> (K, V)>,
 }
 
 impl<K, V> LookupMap<K, V> {

--- a/near-sdk/src/collections/lookup_set.rs
+++ b/near-sdk/src/collections/lookup_set.rs
@@ -15,7 +15,7 @@ const ERR_ELEMENT_SERIALIZATION: &str = "Cannot serialize element with Borsh";
 pub struct LookupSet<T> {
     element_prefix: Vec<u8>,
     #[borsh_skip]
-    el: PhantomData<T>,
+    el: PhantomData<fn() -> T>,
 }
 
 impl<T> LookupSet<T> {

--- a/near-sdk/src/collections/vector.rs
+++ b/near-sdk/src/collections/vector.rs
@@ -25,7 +25,7 @@ pub struct Vector<T> {
     len: u64,
     prefix: Vec<u8>,
     #[borsh_skip]
-    el: PhantomData<T>,
+    el: PhantomData<fn() -> T>,
 }
 
 impl<T> Vector<T> {

--- a/near-sdk/src/store/lookup_set/mod.rs
+++ b/near-sdk/src/store/lookup_set/mod.rs
@@ -21,7 +21,7 @@ where
     cache: StableMap<T, OnceCell<EntryState>>,
 
     #[borsh_skip]
-    hasher: PhantomData<H>,
+    hasher: PhantomData<fn() -> H>,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
No need for the drop check on this, the structure does not have an owned value for this, just uses the generic for a pure function.

Switched the old collection generics as well. On the one hand, they do not own the values, but having the drop check might prevent some unintended behaviour.

@matklad do you have any intuitions about this? Hard to think of a reason why this shouldn't be done, but unsure if I'm missing something