### PR TITLE
fix: Make Lazy and LazyOption debug impls match

### DIFF
--- a/near-sdk/src/store/lazy/impls.rs
+++ b/near-sdk/src/store/lazy/impls.rs
@@ -100,7 +100,7 @@ where
         } else {
             f.debug_struct("Lazy")
                 .field("storage_key", &self.storage_key)
-                .field("cached_value", &self.cache.get().and_then(|v| v.value().as_ref()))
+                .field("cache", &self.cache.get())
                 .finish()
         }
     }

--- a/near-sdk/src/store/lazy/impls.rs
+++ b/near-sdk/src/store/lazy/impls.rs
@@ -89,3 +89,19 @@ where
         Self::get_mut(self)
     }
 }
+
+impl<T> std::fmt::Debug for Lazy<T>
+where
+    T: std::fmt::Debug + BorshSerialize + BorshDeserialize,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if cfg!(feature = "expensive-debug") {
+            self.get().fmt(f)
+        } else {
+            f.debug_struct("Lazy")
+                .field("storage_key", &self.storage_key)
+                .field("cached_value", &self.cache.get().and_then(|v| v.value().as_ref()))
+                .finish()
+        }
+    }
+}

--- a/near-sdk/src/store/lazy/mod.rs
+++ b/near-sdk/src/store/lazy/mod.rs
@@ -181,11 +181,16 @@ mod tests {
 
     #[test]
     pub fn test_debug() {
-        let lazy = Lazy::new(b"m", 8u8);
+        let mut lazy = Lazy::new(b"m", 8u8);
         if cfg!(feature = "expensive-debug") {
             assert_eq!(format!("{:?}", lazy), "8");
         } else {
-            assert_eq!(format!("{:?}", lazy), "Lazy { storage_key: [109], cached_value: Some(8) }");
+            assert_eq!(format!("{:?}", lazy), "Lazy { storage_key: [109], cache: Some(CacheEntry { value: Some(8), state: Modified }) }");
+        }
+
+        lazy.flush();
+        if !cfg!(feature = "expensive-debug") {
+            assert_eq!(format!("{:?}", lazy), "Lazy { storage_key: [109], cache: Some(CacheEntry { value: Some(8), state: Cached }) }");
         }
 
         // Serialize and deserialize to simulate storing and loading.
@@ -195,7 +200,7 @@ mod tests {
         if cfg!(feature = "expensive-debug") {
             assert_eq!(format!("{:?}", lazy), "8");
         } else {
-            assert_eq!(format!("{:?}", lazy), "Lazy { storage_key: [109], cached_value: None }");
+            assert_eq!(format!("{:?}", lazy), "Lazy { storage_key: [109], cache: None }");
         }
     }
 }

--- a/near-sdk/src/store/lazy_option/impls.rs
+++ b/near-sdk/src/store/lazy_option/impls.rs
@@ -40,7 +40,7 @@ where
             self.get().fmt(f)
         } else {
             f.debug_struct("LazyOption")
-                .field("storage_key", &self.storage_key)
+                .field("storage_key", &self.prefix)
                 .field("cache", &self.cache.get())
                 .finish()
         }

--- a/near-sdk/src/store/lazy_option/impls.rs
+++ b/near-sdk/src/store/lazy_option/impls.rs
@@ -41,7 +41,7 @@ where
         } else {
             f.debug_struct("LazyOption")
                 .field("storage_key", &self.storage_key)
-                .field("cached_value", &self.cache.get().map(|v| v.value()))
+                .field("cache", &self.cache.get())
                 .finish()
         }
     }

--- a/near-sdk/src/store/lazy_option/impls.rs
+++ b/near-sdk/src/store/lazy_option/impls.rs
@@ -39,7 +39,10 @@ where
         if cfg!(feature = "expensive-debug") {
             self.get().fmt(f)
         } else {
-            f.debug_struct("LazyOption").field("storage_key", &self.storage_key).finish()
+            f.debug_struct("LazyOption")
+                .field("storage_key", &self.storage_key)
+                .field("cached_value", &self.cache.get().map(|v| v.value()))
+                .finish()
         }
     }
 }

--- a/near-sdk/src/store/lazy_option/mod.rs
+++ b/near-sdk/src/store/lazy_option/mod.rs
@@ -169,7 +169,7 @@ mod tests {
         } else {
             assert_eq!(
                 format!("{:?}", lazy_option),
-                "LazyOption { storage_key: [109], cached_value: Some(None) }"
+                "LazyOption { storage_key: [109], cache: Some(CacheEntry { value: None, state: Cached }) }"
             );
         }
 
@@ -179,7 +179,7 @@ mod tests {
         } else {
             assert_eq!(
                 format!("{:?}", lazy_option),
-                "LazyOption { storage_key: [109], cached_value: Some(Some(1)) }"
+                "LazyOption { storage_key: [109], cache: Some(CacheEntry { value: Some(1), state: Modified }) }"
             );
         }
 
@@ -192,7 +192,7 @@ mod tests {
         } else {
             assert_eq!(
                 format!("{:?}", lazy_option),
-                "LazyOption { storage_key: [109], cached_value: None }"
+                "LazyOption { storage_key: [109], cache: None }"
             );
         }
     }

--- a/near-sdk/src/store/lazy_option/mod.rs
+++ b/near-sdk/src/store/lazy_option/mod.rs
@@ -167,14 +167,33 @@ mod tests {
         if cfg!(feature = "expensive-debug") {
             assert_eq!(format!("{:?}", lazy_option), "None");
         } else {
-            assert_eq!(format!("{:?}", lazy_option), "LazyOption { storage_key: [109] }");
+            assert_eq!(
+                format!("{:?}", lazy_option),
+                "LazyOption { storage_key: [109], cached_value: Some(None) }"
+            );
         }
 
-        lazy_option.set(Some(1u64));
+        *lazy_option = Some(1u8);
         if cfg!(feature = "expensive-debug") {
             assert_eq!(format!("{:?}", lazy_option), "Some(1)");
         } else {
-            assert_eq!(format!("{:?}", lazy_option), "LazyOption { storage_key: [109] }");
+            assert_eq!(
+                format!("{:?}", lazy_option),
+                "LazyOption { storage_key: [109], cached_value: Some(Some(1)) }"
+            );
+        }
+
+        // Serialize and deserialize to simulate storing and loading.
+        let serialized = borsh::to_vec(&lazy_option).unwrap();
+        drop(lazy_option);
+        let lazy_option = LazyOption::<u8>::try_from_slice(&serialized).unwrap();
+        if cfg!(feature = "expensive-debug") {
+            assert_eq!(format!("{:?}", lazy_option), "Some(1)");
+        } else {
+            assert_eq!(
+                format!("{:?}", lazy_option),
+                "LazyOption { storage_key: [109], cached_value: None }"
+            );
         }
     }
 }


### PR DESCRIPTION
Noticed when working on related things that these were not matching. This should be resolved before #888 comes in, but is a separate issue

What this proposes is including the cached value in debug output but keeping the type as an `Option` so that we can change the implementation without breaking this format. Can alternatively just keep the default debug derive or ignore cache, but the cache seems important for debug purposes. (Maybe not obfuscating the cache entry type is valuable to see if a value has been flushed to storage)?