### PR TITLE
chore: restrict arbitrary version

### DIFF
--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -47,7 +47,7 @@ trybuild = "1.0"
 rustversion = "1.0"
 rand_xorshift = "0.3"
 quickcheck = "1.0"
-arbitrary = { version = "1.0", features = ["derive"] }
+arbitrary = { version = ">=1.0, <1.1.4", features = ["derive"] }
 hex = { version = "0.4.3", features = ["serde"] }
 
 [features]


### PR DESCRIPTION
a patch release was made that breaks with 1.61 so our buildkite CI was broken. Temporary workaround