### PR TITLE
fix: cargo check with all features

### DIFF
--- a/near-sdk-macros/src/core_impl/abi/abi_embed.rs
+++ b/near-sdk-macros/src/core_impl/abi/abi_embed.rs
@@ -1,15 +1,17 @@
-use proc_macro2::{Span, TokenStream as TokenStream2};
+use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 
 pub fn embed() -> TokenStream2 {
     let abi_path = match option_env!("CARGO_NEAR_ABI_PATH") {
         Some(path) => path,
         None => {
-            return syn::Error::new(
-                Span::call_site(),
-                "CARGO_NEAR_ABI_PATH environment variable is not set",
-            )
-            .to_compile_error()
+            return quote! {
+                compile_error!(
+                    "the `__abi-embed` feature flag is private and should not be activated manually\n\
+                    \n\
+                    help\x1b[0m: consider installing https://github.com/near/cargo-near"
+                );
+            };
         }
     };
     quote! {

--- a/near-sdk-macros/src/core_impl/abi/abi_embed.rs
+++ b/near-sdk-macros/src/core_impl/abi/abi_embed.rs
@@ -1,8 +1,17 @@
-use proc_macro2::TokenStream as TokenStream2;
+use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
 
 pub fn embed() -> TokenStream2 {
-    let abi_path = env!("CARGO_NEAR_ABI_PATH");
+    let abi_path = match option_env!("CARGO_NEAR_ABI_PATH") {
+        Some(path) => path,
+        None => {
+            return syn::Error::new(
+                Span::call_site(),
+                "CARGO_NEAR_ABI_PATH environment variable is not set",
+            )
+            .to_compile_error()
+        }
+    };
     quote! {
         const _: () = {
             const __CONTRACT_ABI: &'static [u8] = include_bytes!(#abi_path);

--- a/near-sdk-macros/src/core_impl/abi/abi_embed.rs
+++ b/near-sdk-macros/src/core_impl/abi/abi_embed.rs
@@ -9,7 +9,7 @@ pub fn embed() -> TokenStream2 {
                 compile_error!(
                     "the `__abi-embed` feature flag is private and should not be activated manually\n\
                     \n\
-                    help\x1b[0m: consider installing https://github.com/near/cargo-near"
+                    help\x1b[0m: consider using https://github.com/near/cargo-near"
                 );
             };
         }


### PR DESCRIPTION
Before

```console
$ cargo check --all-features
error: environment variable `CARGO_NEAR_ABI_PATH` not defined
 --> near-sdk-macros/src/core_impl/abi/abi_embed.rs:5:20
  |
5 |     let abi_path = env!("CARGO_NEAR_ABI_PATH");
  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)

error: could not compile `near-sdk-macros` due to previous error
```

Now, the only time this error comes up is when all three of these conditions are true:

1. You're building something that invokes the `#[near_bindgen]` attribute.
2. You have the `near-sdk/__abi-embed` feature flag activated.
3. The `CARGO_NEAR_ABI_PATH` env is unset.

And as far as the flow with `cargo near` is well-defined, this should never happen.

So, you really have to go looking to find this error. Or, here:

```console
$ cd near-sdk/examples/abi
$ cargo build --features near-sdk/__abi-embed
error: the `__abi-embed` feature flag is private and should not be activated manually

       help: consider using https://github.com/near/cargo-near
  --> src/lib.rs:15:1
   |
15 | #[near_bindgen]
   | ^^^^^^^^^^^^^^^
   |
   = note: this error originates in the attribute macro `near_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)

error: could not compile `abi` due to previous error
```