### PR TITLE
fix: remove default features from SDK dependency on standards

### DIFF
--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "=4.1.0-pre.3" }
+near-sdk = { path = "../near-sdk", version = "=4.1.0-pre.3", default-features = false }
 serde = "1"
 serde_json = "1"
 schemars = "0.8"


### PR DESCRIPTION
I noticed through https://github.com/near/near-sdk-rs/issues/910#issuecomment-1232939216 that these optional features aren't disabled by default by contract-standards, so someone could not disable these default features AND use `near-contract-standards`. oops!