### PR TITLE
chore: remove rlib from examples

### DIFF
--- a/examples/fungible-token/ft/Cargo.toml
+++ b/examples/fungible-token/ft/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 near-sdk = { path = "../../../near-sdk", features = ["abi"] }

--- a/examples/fungible-token/test-contract-defi/Cargo.toml
+++ b/examples/fungible-token/test-contract-defi/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 near-sdk = { path = "../../../near-sdk", features = ["abi"] }


### PR DESCRIPTION
Seems like we have missed a couple of them