### PR TITLE
chore: impl `JsonSchema` for newtypes

### DIFF
--- a/near-sdk/src/json_types/hash.rs
+++ b/near-sdk/src/json_types/hash.rs
@@ -40,6 +40,17 @@ impl<'de> de::Deserialize<'de> for Base58CryptoHash {
     }
 }
 
+#[cfg(feature = "abi")]
+impl schemars::JsonSchema for Base58CryptoHash {
+    fn schema_name() -> String {
+        String::schema_name()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(gen)
+    }
+}
+
 impl From<&Base58CryptoHash> for String {
     fn from(hash: &Base58CryptoHash) -> Self {
         bs58::encode(&hash.0).into_string()

--- a/near-sdk/src/json_types/hash.rs
+++ b/near-sdk/src/json_types/hash.rs
@@ -42,6 +42,10 @@ impl<'de> de::Deserialize<'de> for Base58CryptoHash {
 
 #[cfg(feature = "abi")]
 impl schemars::JsonSchema for Base58CryptoHash {
+    fn is_referenceable() -> bool {
+        false
+    }
+
     fn schema_name() -> String {
         String::schema_name()
     }

--- a/near-sdk/src/json_types/integers.rs
+++ b/near-sdk/src/json_types/integers.rs
@@ -11,7 +11,6 @@ macro_rules! impl_str_type {
         #[derive(
             Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, BorshDeserialize, BorshSerialize,
         )]
-        #[cfg_attr(feature = "abi", derive(schemars::JsonSchema))]
         pub struct $iden(pub $ty);
 
         impl From<$ty> for $iden {
@@ -48,6 +47,17 @@ macro_rules! impl_str_type {
                     str::parse::<$ty>(&s)
                         .map_err(|err| serde::de::Error::custom(err.to_string()))?,
                 ))
+            }
+        }
+
+        #[cfg(feature = "abi")]
+        impl schemars::JsonSchema for $iden {
+            fn schema_name() -> String {
+                String::schema_name()
+            }
+
+            fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+                String::json_schema(gen)
             }
         }
     };

--- a/near-sdk/src/json_types/integers.rs
+++ b/near-sdk/src/json_types/integers.rs
@@ -52,6 +52,10 @@ macro_rules! impl_str_type {
 
         #[cfg(feature = "abi")]
         impl schemars::JsonSchema for $iden {
+            fn is_referenceable() -> bool {
+                false
+            }
+
             fn schema_name() -> String {
                 String::schema_name()
             }

--- a/near-sdk/src/json_types/vector.rs
+++ b/near-sdk/src/json_types/vector.rs
@@ -20,7 +20,7 @@ impl From<Base64VecU8> for Vec<u8> {
 #[cfg(feature = "abi")]
 impl schemars::JsonSchema for Base64VecU8 {
     fn schema_name() -> String {
-        "Base64VecU8".to_string()
+        String::schema_name()
     }
 
     fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {

--- a/near-sdk/src/json_types/vector.rs
+++ b/near-sdk/src/json_types/vector.rs
@@ -19,6 +19,10 @@ impl From<Base64VecU8> for Vec<u8> {
 
 #[cfg(feature = "abi")]
 impl schemars::JsonSchema for Base64VecU8 {
+    fn is_referenceable() -> bool {
+        false
+    }
+
     fn schema_name() -> String {
         String::schema_name()
     }

--- a/near-sdk/src/types/gas.rs
+++ b/near-sdk/src/types/gas.rs
@@ -55,6 +55,17 @@ impl<'de> Deserialize<'de> for Gas {
     }
 }
 
+#[cfg(feature = "abi")]
+impl schemars::JsonSchema for Gas {
+    fn schema_name() -> String {
+        String::schema_name()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(gen)
+    }
+}
+
 impl From<u64> for Gas {
     fn from(amount: u64) -> Self {
         Self(amount)

--- a/near-sdk/src/types/gas.rs
+++ b/near-sdk/src/types/gas.rs
@@ -57,6 +57,10 @@ impl<'de> Deserialize<'de> for Gas {
 
 #[cfg(feature = "abi")]
 impl schemars::JsonSchema for Gas {
+    fn is_referenceable() -> bool {
+        false
+    }
+
     fn schema_name() -> String {
         String::schema_name()
     }

--- a/near-sdk/src/types/public_key.rs
+++ b/near-sdk/src/types/public_key.rs
@@ -161,6 +161,10 @@ impl<'de> serde::Deserialize<'de> for PublicKey {
 
 #[cfg(feature = "abi")]
 impl schemars::JsonSchema for PublicKey {
+    fn is_referenceable() -> bool {
+        false
+    }
+
     fn schema_name() -> String {
         String::schema_name()
     }

--- a/near-sdk/src/types/public_key.rs
+++ b/near-sdk/src/types/public_key.rs
@@ -159,6 +159,17 @@ impl<'de> serde::Deserialize<'de> for PublicKey {
     }
 }
 
+#[cfg(feature = "abi")]
+impl schemars::JsonSchema for PublicKey {
+    fn schema_name() -> String {
+        String::schema_name()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(gen)
+    }
+}
+
 impl From<&PublicKey> for String {
     fn from(str_public_key: &PublicKey) -> Self {
         match str_public_key.curve_type() {


### PR DESCRIPTION
Tested ABI flow on a few external contracts and one of them was exposing `PublicKey`, so I think it makes sense to implement `JsonSchema` for all newtypes that already derive `(De)serialize`.

Also fixed a bug with large integer schemas - they are serialized as strings, but the automatic `JsonSchema` derivation makes them look as if they are numbers.