### PR TITLE
feat: Default optional input fields of (N)FT metadata

### DIFF
--- a/near-contract-standards/src/fungible_token/metadata.rs
+++ b/near-contract-standards/src/fungible_token/metadata.rs
@@ -12,8 +12,11 @@ pub struct FungibleTokenMetadata {
     pub spec: String,
     pub name: String,
     pub symbol: String,
+    #[serde(default)]
     pub icon: Option<String>,
+    #[serde(default)]
     pub reference: Option<String>,
+    #[serde(default)]
     pub reference_hash: Option<Base64VecU8>,
     pub decimals: u8,
 }

--- a/near-contract-standards/src/non_fungible_token/metadata.rs
+++ b/near-contract-standards/src/non_fungible_token/metadata.rs
@@ -14,9 +14,13 @@ pub struct NFTContractMetadata {
     pub spec: String,              // required, essentially a version like "nft-1.0.0"
     pub name: String,              // required, ex. "Mosaics"
     pub symbol: String,            // required, ex. "MOSIAC"
+    #[serde(default)]
     pub icon: Option<String>,      // Data URL
+    #[serde(default)]
     pub base_uri: Option<String>, // Centralized gateway known to have reliable access to decentralized storage assets referenced by `reference` or `media` URLs
+    #[serde(default)]
     pub reference: Option<String>, // URL to a JSON file with more info
+    #[serde(default)]
     pub reference_hash: Option<Base64VecU8>, // Base64-encoded sha256 hash of JSON from reference field. Required if `reference` is included.
 }
 
@@ -25,17 +29,29 @@ pub struct NFTContractMetadata {
 #[cfg_attr(feature = "abi", derive(schemars::JsonSchema))]
 #[serde(crate = "near_sdk::serde")]
 pub struct TokenMetadata {
+    #[serde(default)]
     pub title: Option<String>, // ex. "Arch Nemesis: Mail Carrier" or "Parcel #5055"
+    #[serde(default)]
     pub description: Option<String>, // free-form description
+    #[serde(default)]
     pub media: Option<String>, // URL to associated media, preferably to decentralized, content-addressed storage
+    #[serde(default)]
     pub media_hash: Option<Base64VecU8>, // Base64-encoded sha256 hash of content referenced by the `media` field. Required if `media` is included.
+    #[serde(default)]
     pub copies: Option<u64>, // number of copies of this set of metadata in existence when token was minted.
+    #[serde(default)]
     pub issued_at: Option<String>, // ISO 8601 datetime when token was issued or minted
+    #[serde(default)]
     pub expires_at: Option<String>, // ISO 8601 datetime when token expires
+    #[serde(default)]
     pub starts_at: Option<String>, // ISO 8601 datetime when token starts being valid
+    #[serde(default)]
     pub updated_at: Option<String>, // ISO 8601 datetime when token was last updated
+    #[serde(default)]
     pub extra: Option<String>, // anything extra the NFT wants to store on-chain. Can be stringified JSON.
+    #[serde(default)]
     pub reference: Option<String>, // URL to an off-chain JSON file with more info.
+    #[serde(default)]
     pub reference_hash: Option<Base64VecU8>, // Base64-encoded sha256 hash of JSON from reference field. Required if `reference` is included.
 }
 

--- a/near-contract-standards/src/non_fungible_token/metadata.rs
+++ b/near-contract-standards/src/non_fungible_token/metadata.rs
@@ -11,11 +11,11 @@ pub const NFT_METADATA_SPEC: &str = "nft-1.0.0";
 #[cfg_attr(feature = "abi", derive(schemars::JsonSchema))]
 #[serde(crate = "near_sdk::serde")]
 pub struct NFTContractMetadata {
-    pub spec: String,              // required, essentially a version like "nft-1.0.0"
-    pub name: String,              // required, ex. "Mosaics"
-    pub symbol: String,            // required, ex. "MOSIAC"
+    pub spec: String,   // required, essentially a version like "nft-1.0.0"
+    pub name: String,   // required, ex. "Mosaics"
+    pub symbol: String, // required, ex. "MOSIAC"
     #[serde(default)]
-    pub icon: Option<String>,      // Data URL
+    pub icon: Option<String>, // Data URL
     #[serde(default)]
     pub base_uri: Option<String>, // Centralized gateway known to have reliable access to decentralized storage assets referenced by `reference` or `media` URLs
     #[serde(default)]


### PR DESCRIPTION
Not a breaking change, just doesn't require all fields with `null` added in the JSON. Simplifies the devX and reduces input size necessary.

Unsure why this would be intended, JSON is already not canonical so shouldn't matter the ambiguity here afaik

@mattlockyer maybe you might have some context or reason why this shouldn't be done, though