### PR TITLE
fix: update Base58 parsing error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixes
+- Updated the associated error type for `Base58CryptoHash` parsing through `TryFrom` to concrete type. [PR 919](https://github.com/near/near-sdk-rs/pull/919)
+
 ## [4.1.0-pre.3] - 2022-08-30
 
 ### Added

--- a/near-sdk/src/json_types/hash.rs
+++ b/near-sdk/src/json_types/hash.rs
@@ -65,7 +65,7 @@ impl TryFrom<String> for Base58CryptoHash {
     type Error = ParseCryptoHashError;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        Self::try_from(value.as_str())
+        value.parse()
     }
 }
 
@@ -73,7 +73,7 @@ impl TryFrom<&str> for Base58CryptoHash {
     type Error = ParseCryptoHashError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        Ok(value.parse()?)
+        value.parse()
     }
 }
 

--- a/near-sdk/src/json_types/hash.rs
+++ b/near-sdk/src/json_types/hash.rs
@@ -62,7 +62,7 @@ impl From<&Base58CryptoHash> for String {
 }
 
 impl TryFrom<String> for Base58CryptoHash {
-    type Error = Box<dyn std::error::Error>;
+    type Error = ParseCryptoHashError;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
         Self::try_from(value.as_str())
@@ -70,7 +70,7 @@ impl TryFrom<String> for Base58CryptoHash {
 }
 
 impl TryFrom<&str> for Base58CryptoHash {
-    type Error = Box<dyn std::error::Error>;
+    type Error = ParseCryptoHashError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         Ok(value.parse()?)


### PR DESCRIPTION
Noticed when looking at https://github.com/near/near-sdk-rs/issues/399 that the error type hadn't been updated for the other parsing methods, only `FromStr`. Yes, this is a breaking change, but it should not affect any usages of this type in practice and it will be coming with a minor version bump.

closes #399