### PR TITLE
chore: stabilize `store::LookupMap` and `store::UnorderedMap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changes
+- Stabilize `store::LookupMap` and `store::UnorderedMap` collections. [PR 922](https://github.com/near/near-sdk-rs/pull/922).
+
 ### Removed
 - Deleted `metadata` macro. Use https://github.com/near/abi instead. [PR 920](https://github.com/near/near-sdk-rs/pull/920)
 

--- a/near-sdk/src/store/index_map.rs
+++ b/near-sdk/src/store/index_map.rs
@@ -143,13 +143,11 @@ where
     }
 
     /// Inserts a element at `index`, returns the evicted element.
-    #[cfg(feature = "unstable")]
     pub fn insert(&mut self, index: u32, element: T) -> Option<T> {
         self.get_mut_inner(index).replace(Some(element))
     }
 
     /// Removes value at index and returns existing value.
-    #[allow(dead_code)]
     pub fn remove(&mut self, index: u32) -> Option<T> {
         self.get_mut_inner(index).replace(None)
     }

--- a/near-sdk/src/store/lookup_map/mod.rs
+++ b/near-sdk/src/store/lookup_map/mod.rs
@@ -32,7 +32,7 @@ const ERR_ELEMENT_SERIALIZATION: &str = "Cannot serialize element";
 /// ```
 /// use near_sdk::store::LookupMap;
 ///
-/// // Initializes a map, the generic types can be inferred to `LookupMap<String, u8, Sha256>`
+/// // Initializes a map, the generic types can be inferred to `LookupMap<String, u8, Identity>`
 /// // The `b"a"` parameter is a prefix for the storage keys of this data structure.
 /// let mut map = LookupMap::new(b"a");
 ///

--- a/near-sdk/src/store/mod.rs
+++ b/near-sdk/src/store/mod.rs
@@ -32,11 +32,11 @@
 //!
 //! Maps:
 //!
-//! - [`LookupMap`] (`unstable`): Wrapper around key-value storage interactions, similar to
+//! - [`LookupMap`]: Wrapper around key-value storage interactions, similar to
 //! [`UnorderedMap`]/[`std::collections::HashMap`] except that keys are not persisted and cannot be
 //! iterated over.
 //!
-//! - [`UnorderedMap`] (`unstable`): Storage version of [`std::collections::HashMap`]. No ordering
+//! - [`UnorderedMap`]: Storage version of [`std::collections::HashMap`]. No ordering
 //! guarantees.
 //!
 //! - [`TreeMap`] (`unstable`): Storage version of [`std::collections::BTreeMap`]. Ordered by key,

--- a/near-sdk/src/store/mod.rs
+++ b/near-sdk/src/store/mod.rs
@@ -71,9 +71,7 @@ pub use lazy_option::LazyOption;
 pub mod vec;
 pub use vec::Vector;
 
-#[cfg(feature = "unstable")]
 pub mod lookup_map;
-#[cfg(feature = "unstable")]
 pub use self::lookup_map::LookupMap;
 
 #[cfg(feature = "unstable")]
@@ -81,9 +79,7 @@ mod lookup_set;
 #[cfg(feature = "unstable")]
 pub use self::lookup_set::LookupSet;
 
-#[cfg(feature = "unstable")]
 pub mod unordered_map;
-#[cfg(feature = "unstable")]
 pub use self::unordered_map::UnorderedMap;
 
 #[cfg(feature = "unstable")]
@@ -99,18 +95,14 @@ pub use self::tree_map::TreeMap;
 mod index_map;
 pub(crate) use self::index_map::IndexMap;
 
-#[cfg(feature = "unstable")]
 pub(crate) mod free_list;
-#[cfg(feature = "unstable")]
 pub(crate) use self::free_list::FreeList;
 
 /// Storage key hash function types and trait to override map hash functions.
-#[cfg(feature = "unstable")]
 pub mod key;
 
 pub(crate) const ERR_INCONSISTENT_STATE: &str =
     "The collection is an inconsistent state. Did previous smart \
         contract execution terminate unexpectedly?";
 
-#[cfg(feature = "unstable")]
 pub(crate) const ERR_NOT_EXIST: &str = "Key does not exist in map";

--- a/near-sdk/src/store/vec/mod.rs
+++ b/near-sdk/src/store/vec/mod.rs
@@ -403,7 +403,7 @@ where
     /// ```
     pub fn pop(&mut self) -> Option<T> {
         let new_idx = self.len.checked_sub(1)?;
-        let prev = self.values.get_mut_inner(new_idx).replace(None);
+        let prev = self.values.remove(new_idx);
         self.len = new_idx;
         prev
     }
@@ -426,8 +426,6 @@ where
     ///
     /// assert_eq!(vec.get(0), Some(&"replaced".to_string()));
     /// ```
-    // TODO determine if this should be stabilized, included for backwards compat with old version
-    #[cfg(feature = "unstable")]
     pub fn replace(&mut self, index: u32, element: T) -> T {
         if index >= self.len {
             env::panic_str(ERR_INDEX_OUT_OF_BOUNDS);

--- a/near-sdk/src/utils/stable_map.rs
+++ b/near-sdk/src/utils/stable_map.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "unstable")]
 use std::borrow::Borrow;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
@@ -42,7 +41,6 @@ impl<K, V> StableMap<K, V> {
     pub(crate) fn inner(&mut self) -> &mut BTreeMap<K, Box<V>> {
         self.map.get_mut()
     }
-    #[cfg(feature = "unstable")]
     pub(crate) fn map_value_ref<Q: ?Sized, F, T>(&self, k: &Q, f: F) -> Option<T>
     where
         K: Borrow<Q> + Ord,


### PR DESCRIPTION
Part of #818 

These two are already documented thoroughly and have been tested a lot