### PR TITLE
chore: put legacy collections under feature flag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - run: rustup target add wasm32-unknown-unknown
       - name: Test
-        run: cargo test --all --features unstable --features legacy
+        run: cargo test --all --features unstable,legacy
   lint:
     name: Clippy and fmt
     runs-on: ubuntu-latest
@@ -39,7 +39,7 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - name: Test Format
         run: cargo fmt -- --check
-      - run: cargo clippy --features unstable --features legacy --tests -- -Dclippy::all
+      - run: cargo clippy --features unstable,legacy --tests -- -Dclippy::all
   windows:
     name: Windows
     runs-on: windows-latest
@@ -51,7 +51,7 @@ jobs:
           profile: minimal
           toolchain: stable
       - uses: Swatinem/rust-cache@v1
-      - run: cargo check -p near-sdk --features unstable --features legacy
+      - run: cargo check -p near-sdk --features unstable,legacy
       - run: cargo check -p near-contract-standards
   audit:
     name: Audit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - run: rustup target add wasm32-unknown-unknown
       - name: Test
-        run: cargo test --all --features unstable
+        run: cargo test --all --features unstable --features legacy
   lint:
     name: Clippy and fmt
     runs-on: ubuntu-latest
@@ -39,7 +39,7 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - name: Test Format
         run: cargo fmt -- --check
-      - run: cargo clippy --features unstable --tests -- -Dclippy::all
+      - run: cargo clippy --features unstable --features legacy --tests -- -Dclippy::all
   windows:
     name: Windows
     runs-on: windows-latest
@@ -51,7 +51,7 @@ jobs:
           profile: minimal
           toolchain: stable
       - uses: Swatinem/rust-cache@v1
-      - run: cargo check -p near-sdk --features unstable
+      - run: cargo check -p near-sdk --features unstable --features legacy
       - run: cargo check -p near-contract-standards
   audit:
     name: Audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Added new `legacy` feature flag and put `near_sdk::collections` under it. `near_sdk::store` will be replacing them. [PR 923](https://github.com/near/near-sdk-rs/pull/923).
+
 ### Removed
 - Deleted `metadata` macro. Use https://github.com/near/abi instead. [PR 920](https://github.com/near/near-sdk-rs/pull/920)
 

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "=4.1.0-pre.3", default-features = false }
+near-sdk = { path = "../near-sdk", version = "=4.1.0-pre.3", default-features = false, features = ["legacy"] }
 serde = "1"
 serde_json = "1"
 schemars = "0.8"

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -51,9 +51,10 @@ arbitrary = { version = ">=1.0, <1.1.4", features = ["derive"] }
 hex = { version = "0.4.3", features = ["serde"] }
 
 [features]
-default = ["wee_alloc", "unit-testing"]
+default = ["wee_alloc", "unit-testing", "legacy"]
 expensive-debug = []
 unstable = []
+legacy = []
 abi = ["near-abi", "schemars"]
 unit-testing = ["near-vm-logic", "near-primitives-core", "near-primitives", "near-crypto"]
 
@@ -61,4 +62,4 @@ __abi-embed = ["near-sdk-macros/__abi-embed"]
 __abi-generate = ["abi", "near-sdk-macros/__abi-generate"]
 
 [package.metadata.docs.rs]
-features = ["unstable"]
+features = ["unstable", "legacy"]

--- a/near-sdk/src/lib.rs
+++ b/near-sdk/src/lib.rs
@@ -11,6 +11,7 @@ pub use near_sdk_macros::{
 
 pub mod store;
 
+#[cfg(feature = "legacy")]
 pub mod collections;
 mod environment;
 pub use environment::env;


### PR DESCRIPTION
closes #869

This doesn't functionally change anything because it's enabled by default, but allows devs to remove this section, and this will be deprecated in the next major version