### PR TITLE
feat: allow generics for borsh storage key derive

### DIFF
--- a/near-sdk-macros/src/lib.rs
+++ b/near-sdk-macros/src/lib.rs
@@ -281,7 +281,7 @@ pub fn borsh_storage_key(item: TokenStream) -> TokenStream {
     let predicate = parse_quote!(#name #ty_generics: ::near_sdk::borsh::BorshSerialize);
     let where_clause: WhereClause = if let Some(mut w) = where_clause.cloned() {
         w.predicates.push(predicate);
-        parse_quote!(#w)
+        w
     } else {
         parse_quote!(where #predicate)
     };

--- a/near-sdk-macros/src/lib.rs
+++ b/near-sdk-macros/src/lib.rs
@@ -279,7 +279,7 @@ pub fn borsh_storage_key(item: TokenStream) -> TokenStream {
     };
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     TokenStream::from(quote! {
-        impl #impl_generics near_sdk::__private::BorshIntoStorageKey for #name #ty_generics #where_clause {}
+        impl #impl_generics near_sdk::__private::BorshIntoStorageKey for #name #ty_generics #where_clause #name #ty_generics: ::near_sdk::borsh::BorshSerialize  {}
     })
 }
 

--- a/near-sdk-macros/src/lib.rs
+++ b/near-sdk-macros/src/lib.rs
@@ -264,10 +264,10 @@ pub fn derive_no_default(item: TokenStream) -> TokenStream {
 /// The type should also implement or derive `BorshSerialize` trait.
 #[proc_macro_derive(BorshStorageKey)]
 pub fn borsh_storage_key(item: TokenStream) -> TokenStream {
-    let name = if let Ok(input) = syn::parse::<ItemEnum>(item.clone()) {
-        input.ident
+    let (name, generics) = if let Ok(input) = syn::parse::<ItemEnum>(item.clone()) {
+        (input.ident, input.generics)
     } else if let Ok(input) = syn::parse::<ItemStruct>(item) {
-        input.ident
+        (input.ident, input.generics)
     } else {
         return TokenStream::from(
             syn::Error::new(
@@ -277,8 +277,9 @@ pub fn borsh_storage_key(item: TokenStream) -> TokenStream {
             .to_compile_error(),
         );
     };
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     TokenStream::from(quote! {
-        impl near_sdk::__private::BorshIntoStorageKey for #name {}
+        impl #impl_generics near_sdk::__private::BorshIntoStorageKey for #name #ty_generics #where_clause {}
     })
 }
 

--- a/near-sdk/compilation_tests/all.rs
+++ b/near-sdk/compilation_tests/all.rs
@@ -17,6 +17,7 @@ fn compilation_tests() {
     t.pass("compilation_tests/cond_compilation.rs");
     t.compile_fail("compilation_tests/payable_view.rs");
     t.pass("compilation_tests/borsh_storage_key.rs");
+    t.pass("compilation_tests/borsh_storage_key_generics.rs");
     t.pass("compilation_tests/function_error.rs");
     t.pass("compilation_tests/enum_near_bindgen.rs");
 }

--- a/near-sdk/compilation_tests/borsh_storage_key_generics.rs
+++ b/near-sdk/compilation_tests/borsh_storage_key_generics.rs
@@ -1,0 +1,44 @@
+//! Testing BorshStorageKey macro with lifetimes and generics.
+
+use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
+use near_sdk::collections::LookupMap;
+use near_sdk::{near_bindgen, BorshStorageKey};
+
+#[derive(BorshStorageKey, BorshSerialize)]
+struct StorageKeyStruct<'a, T>
+where
+    T: BorshSerialize,
+{
+    key: &'a T,
+}
+
+#[derive(BorshStorageKey, BorshSerialize)]
+enum StorageKeyEnum<'a, T>
+where
+    T: BorshSerialize,
+{
+    Accounts,
+    SubAccounts { account_id: &'a T },
+}
+
+#[near_bindgen]
+#[derive(BorshDeserialize, BorshSerialize)]
+struct Contract {
+    map1: LookupMap<u64, u64>,
+    map2: LookupMap<String, String>,
+}
+
+impl Default for Contract {
+    fn default() -> Self {
+        let a = "test".to_string();
+        Self {
+            map1: LookupMap::new(StorageKeyStruct { key: &"bla" }),
+            map2: LookupMap::new(StorageKeyEnum::SubAccounts { account_id: &a }),
+        }
+    }
+}
+
+#[near_bindgen]
+impl Contract {}
+
+fn main() {}

--- a/near-sdk/compilation_tests/borsh_storage_key_generics.rs
+++ b/near-sdk/compilation_tests/borsh_storage_key_generics.rs
@@ -7,7 +7,7 @@ use near_sdk::{near_bindgen, BorshStorageKey};
 #[derive(BorshStorageKey, BorshSerialize)]
 struct StorageKeyStruct<'a, T>
 where
-    T: BorshSerialize,
+    T: BorshSerialize + ?Sized,
 {
     key: &'a T,
 }
@@ -15,7 +15,7 @@ where
 #[derive(BorshStorageKey, BorshSerialize)]
 enum StorageKeyEnum<'a, T>
 where
-    T: BorshSerialize,
+    T: BorshSerialize + ?Sized,
 {
     Accounts,
     SubAccounts { account_id: &'a T },
@@ -32,7 +32,7 @@ impl Default for Contract {
     fn default() -> Self {
         let a = "test".to_string();
         Self {
-            map1: LookupMap::new(StorageKeyStruct { key: &"bla" }),
+            map1: LookupMap::new(StorageKeyStruct { key: "bla" }),
             map2: LookupMap::new(StorageKeyEnum::SubAccounts { account_id: &a }),
         }
     }

--- a/near-sdk/compilation_tests/borsh_storage_key_generics.rs
+++ b/near-sdk/compilation_tests/borsh_storage_key_generics.rs
@@ -7,7 +7,7 @@ use near_sdk::{near_bindgen, BorshStorageKey};
 #[derive(BorshStorageKey, BorshSerialize)]
 struct StorageKeyStruct<'a, T>
 where
-    T: BorshSerialize + ?Sized,
+    T: ?Sized,
 {
     key: &'a T,
 }
@@ -15,7 +15,7 @@ where
 #[derive(BorshStorageKey, BorshSerialize)]
 enum StorageKeyEnum<'a, T>
 where
-    T: BorshSerialize + ?Sized,
+    T: ?Sized,
 {
     Accounts,
     SubAccounts { account_id: &'a T },


### PR DESCRIPTION
Tried to use a reference for this today, but realized this isn't supported.