### PR TITLE
chore: make examples use the root target folder

### DIFF
--- a/examples/adder/.cargo/config.toml
+++ b/examples/adder/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.wasm32-unknown-unknown]
 rustflags = ["-C", "link-arg=-s"]
+
+[build]
+target-dir = "../../target"

--- a/examples/adder/build.sh
+++ b/examples/adder/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-TARGET="${CARGO_TARGET_DIR:-target}"
+TARGET="${CARGO_TARGET_DIR:-../../target}"
 set -e
 cd "$(dirname $0)"
 

--- a/examples/callback-results/.cargo/config.toml
+++ b/examples/callback-results/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.wasm32-unknown-unknown]
 rustflags = ["-C", "link-arg=-s"]
+
+[build]
+target-dir = "../../target"

--- a/examples/callback-results/build.sh
+++ b/examples/callback-results/build.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
-TARGET="${CARGO_TARGET_DIR:-target}"
+TARGET="${CARGO_TARGET_DIR:-../../target}"
 set -e
-cd "`dirname $0`"
+cd "$(dirname $0)"
 cargo build --target wasm32-unknown-unknown --release
 cp $TARGET/wasm32-unknown-unknown/release/callback_results.wasm ./res/
-

--- a/examples/cross-contract-calls/.cargo/config.toml
+++ b/examples/cross-contract-calls/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.wasm32-unknown-unknown]
 rustflags = ["-C", "link-arg=-s"]
+
+[build]
+target-dir = "../../target"

--- a/examples/cross-contract-calls/build.sh
+++ b/examples/cross-contract-calls/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-TARGET="${CARGO_TARGET_DIR:-target}"
+TARGET="${CARGO_TARGET_DIR:-../../target}"
 set -e
 cd "$(dirname $0)"
 

--- a/examples/factory-contract/.cargo/config.toml
+++ b/examples/factory-contract/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.wasm32-unknown-unknown]
 rustflags = ["-C", "link-arg=-s"]
+
+[build]
+target-dir = "../../target"

--- a/examples/factory-contract/build.sh
+++ b/examples/factory-contract/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-TARGET="${CARGO_TARGET_DIR:-target}"
+TARGET="${CARGO_TARGET_DIR:-../../target}"
 set -e
 cd "$(dirname $0)"
 

--- a/examples/fungible-token/.cargo/config.toml
+++ b/examples/fungible-token/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.wasm32-unknown-unknown]
 rustflags = ["-C", "link-arg=-s"]
+
+[build]
+target-dir = "../../target"

--- a/examples/fungible-token/build.sh
+++ b/examples/fungible-token/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-TARGET="${CARGO_TARGET_DIR:-target}"
+TARGET="${CARGO_TARGET_DIR:-../../target}"
 set -e
-cd "`dirname $0`"
+cd "$(dirname $0)"
 
 cargo build --all --target wasm32-unknown-unknown --release
 cp $TARGET/wasm32-unknown-unknown/release/defi.wasm ./res/

--- a/examples/lockable-fungible-token/.cargo/config.toml
+++ b/examples/lockable-fungible-token/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.wasm32-unknown-unknown]
 rustflags = ["-C", "link-arg=-s"]
+
+[build]
+target-dir = "../../target"

--- a/examples/lockable-fungible-token/build.sh
+++ b/examples/lockable-fungible-token/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-TARGET="${CARGO_TARGET_DIR:-target}"
+TARGET="${CARGO_TARGET_DIR:-../../target}"
 set -e
-cd "`dirname $0`"
+cd "$(dirname $0)"
 cargo build --target wasm32-unknown-unknown --release
 cp $TARGET/wasm32-unknown-unknown/release/lockable_fungible_token.wasm ./res/

--- a/examples/mission-control/.cargo/config.toml
+++ b/examples/mission-control/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.wasm32-unknown-unknown]
 rustflags = ["-C", "link-arg=-s"]
+
+[build]
+target-dir = "../../target"

--- a/examples/mission-control/build.sh
+++ b/examples/mission-control/build.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-TARGET="${CARGO_TARGET_DIR:-target}"
+TARGET="${CARGO_TARGET_DIR:-../../target}"
 set -e
-cd "`dirname $0`"
+cd "$(dirname $0)"
 cargo build --target wasm32-unknown-unknown --release
 cp $TARGET/wasm32-unknown-unknown/release/mission_control.wasm ./res/
 #wasm-opt -Oz --output ./res/mission_control.wasm ./res/mission_control.wasm
-

--- a/examples/non-fungible-token/.cargo/config.toml
+++ b/examples/non-fungible-token/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.wasm32-unknown-unknown]
 rustflags = ["-C", "link-arg=-s"]
+
+[build]
+target-dir = "../../target"

--- a/examples/non-fungible-token/build.sh
+++ b/examples/non-fungible-token/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-TARGET="${CARGO_TARGET_DIR:-target}"
+TARGET="${CARGO_TARGET_DIR:-../../target}"
 set -e
-cd "`dirname $0`"
+cd "$(dirname $0)"
 cargo build --all --target wasm32-unknown-unknown --release
 cp $TARGET/wasm32-unknown-unknown/release/approval_receiver.wasm ./res/
 cp $TARGET/wasm32-unknown-unknown/release/non_fungible_token.wasm ./res/

--- a/examples/status-message-collections/.cargo/config.toml
+++ b/examples/status-message-collections/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.wasm32-unknown-unknown]
 rustflags = ["-C", "link-arg=-s"]
+
+[build]
+target-dir = "../../target"

--- a/examples/status-message-collections/build.sh
+++ b/examples/status-message-collections/build.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-TARGET="${CARGO_TARGET_DIR:-target}"
+TARGET="${CARGO_TARGET_DIR:-../../target}"
 set -e
-cd "`dirname $0`"
+cd "$(dirname $0)"
 cargo build --target wasm32-unknown-unknown --release
 cp $TARGET/wasm32-unknown-unknown/release/status_message_collections.wasm ./res/
 #wasm-opt -Oz --output ./res/status_message_collections.wasm ./res/status_message_collections.wasm
-

--- a/examples/status-message/.cargo/config.toml
+++ b/examples/status-message/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.wasm32-unknown-unknown]
 rustflags = ["-C", "link-arg=-s"]
+
+[build]
+target-dir = "../../target"

--- a/examples/status-message/build.sh
+++ b/examples/status-message/build.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-TARGET="${CARGO_TARGET_DIR:-target}"
+TARGET="${CARGO_TARGET_DIR:-../../target}"
 set -e
-cd "`dirname $0`"
+cd "$(dirname $0)"
 cargo build --target wasm32-unknown-unknown --release
 cp $TARGET/wasm32-unknown-unknown/release/status_message.wasm ./res/
 #wasm-opt -Oz --output ./res/status_message.wasm ./res/status_message.wasm
-

--- a/examples/test-contract/.cargo/config.toml
+++ b/examples/test-contract/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.wasm32-unknown-unknown]
 rustflags = ["-C", "link-arg=-s"]
+
+[build]
+target-dir = "../../target"

--- a/examples/test-contract/build.sh
+++ b/examples/test-contract/build.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-TARGET="${CARGO_TARGET_DIR:-target}"
+TARGET="${CARGO_TARGET_DIR:-../../target}"
 set -e
-cd "`dirname $0`"
+cd "$(dirname $0)"
 cargo build --target wasm32-unknown-unknown --release
 cp $TARGET/wasm32-unknown-unknown/release/test_contract.wasm ./res/
 #wasm-opt -Oz --output ./res/test_contract.wasm ./res/test_contract.wasm
-

--- a/examples/versioned/.cargo/config.toml
+++ b/examples/versioned/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.wasm32-unknown-unknown]
 rustflags = ["-C", "link-arg=-s"]
+
+[build]
+target-dir = "../../target"

--- a/examples/versioned/build.sh
+++ b/examples/versioned/build.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
-TARGET="${CARGO_TARGET_DIR:-target}"
+TARGET="${CARGO_TARGET_DIR:-../../target}"
 set -e
-cd "`dirname $0`"
+cd "$(dirname $0)"
 cargo build --target wasm32-unknown-unknown --release
 cp $TARGET/wasm32-unknown-unknown/release/versioned.wasm ./res/
-


### PR DESCRIPTION
Not sure if there is a reason not to share the target directory across all examples. This saves ~35% of disk space on a clean build (1.7GB vs 2.6GB).