### PR TITLE
feat: return raw bytes from ABI chunk generators

### DIFF
--- a/near-sdk-macros/src/core_impl/abi/abi_generator.rs
+++ b/near-sdk-macros/src/core_impl/abi/abi_generator.rs
@@ -23,13 +23,15 @@ pub fn generate(i: &ItemImplInfo) -> TokenStream2 {
         #[cfg(not(target_arch = "wasm32"))]
         const _: () = {
             #[no_mangle]
-            pub fn #near_abi_symbol() -> near_sdk::__private::ChunkedAbiEntry {
+            pub fn #near_abi_symbol() -> String {
                 let mut gen = near_sdk::__private::schemars::gen::SchemaGenerator::default();
                 let functions = vec![#(#functions),*];
-                near_sdk::__private::ChunkedAbiEntry::new(
-                    functions,
-                    gen.into_root_schema_for::<String>()
-                )
+                near_sdk::serde_json::to_string(
+                    &near_sdk::__private::ChunkedAbiEntry::new(
+                        functions,
+                        gen.into_root_schema_for::<String>()
+                    )
+                ).unwrap()
             }
         };
     }

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -48,6 +48,7 @@ rustversion = "1.0"
 rand_xorshift = "0.3"
 quickcheck = "1.0"
 arbitrary = { version = ">=1.0, <1.1.4", features = ["derive"] }
+derive_arbitrary = ">=1.0, <=1.1.6"
 hex = { version = "0.4.3", features = ["serde"] }
 
 [features]


### PR DESCRIPTION
`cargo-near` + `near-sdk`, at any point in time, could use versions of `near-abi` with conflicting in-memory representations of `ChunkedAbiEntry`, making it impossible to simply cast one as the other.

Since `near-abi` already hosts a deserialization implementation for `ChunkedAbiEntry`, with `schema_version` validation, it makes sense to just use that.

This means the ABI chunk generator has to return a JSON string directly, which `cargo-near` can then parse, returning a neat error if an error occurred.

This is linked to https://github.com/near/cargo-near/pull/74.