### PR TITLE
chore: tweak error messages and remove duplicate codes

### DIFF
--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -781,12 +781,15 @@ pub fn storage_has_key(key: &[u8]) -> bool {
 // ############################################
 /// Load the state of the given object.
 pub fn state_read<T: borsh::BorshDeserialize>() -> Option<T> {
-    storage_read(STATE_KEY)
-        .map(|data| T::try_from_slice(&data).expect("cannot deserialize the contract state"))
+    storage_read(STATE_KEY).map(|data| {
+        T::try_from_slice(&data)
+            .unwrap_or_else(|_| panic_str("cannot deserialize the contract state"))
+    })
 }
 
 pub fn state_write<T: borsh::BorshSerialize>(state: &T) {
-    let data = state.try_to_vec().expect("cannot serialize the contract state");
+    let data =
+        state.try_to_vec().unwrap_or_else(|_| panic_str("cannot serialize the contract state"));
     storage_write(STATE_KEY, &data);
 }
 

--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -782,11 +782,11 @@ pub fn storage_has_key(key: &[u8]) -> bool {
 /// Load the state of the given object.
 pub fn state_read<T: borsh::BorshDeserialize>() -> Option<T> {
     storage_read(STATE_KEY)
-        .map(|data| T::try_from_slice(&data).expect("Cannot deserialize the contract state."))
+        .map(|data| T::try_from_slice(&data).expect("cannot deserialize the contract state"))
 }
 
 pub fn state_write<T: borsh::BorshSerialize>(state: &T) {
-    let data = state.try_to_vec().expect("Cannot serialize the contract state.");
+    let data = state.try_to_vec().expect("cannot serialize the contract state");
     storage_write(STATE_KEY, &data);
 }
 

--- a/near-sdk/src/store/index_map.rs
+++ b/near-sdk/src/store/index_map.rs
@@ -3,11 +3,9 @@ use std::fmt;
 use borsh::{BorshDeserialize, BorshSerialize};
 use once_cell::unsync::OnceCell;
 
+use super::{ERR_ELEMENT_DESERIALIZATION, ERR_ELEMENT_SERIALIZATION};
 use crate::utils::StableMap;
 use crate::{env, CacheEntry, EntryState, IntoStorageKey};
-
-const ERR_ELEMENT_DESERIALIZATION: &str = "Cannot deserialize element";
-const ERR_ELEMENT_SERIALIZATION: &str = "Cannot serialize element";
 
 #[derive(BorshSerialize, BorshDeserialize)]
 pub(crate) struct IndexMap<T>

--- a/near-sdk/src/store/lazy/mod.rs
+++ b/near-sdk/src/store/lazy/mod.rs
@@ -9,13 +9,11 @@ mod impls;
 use borsh::{BorshDeserialize, BorshSerialize};
 use once_cell::unsync::OnceCell;
 
-use crate::collections::ERR_INCONSISTENT_STATE;
+use super::{ERR_ELEMENT_DESERIALIZATION, ERR_ELEMENT_SERIALIZATION, ERR_INCONSISTENT_STATE};
 use crate::env;
 use crate::utils::{CacheEntry, EntryState};
 use crate::IntoStorageKey;
 
-const ERR_VALUE_SERIALIZATION: &str = "Cannot serialize value with Borsh";
-const ERR_VALUE_DESERIALIZATION: &str = "Cannot deserialize value with Borsh";
 const ERR_NOT_FOUND: &str = "No value found for the given key";
 
 fn expect_key_exists<T>(val: Option<T>) -> T {
@@ -32,7 +30,7 @@ where
 {
     let bytes = expect_key_exists(env::storage_read(key));
     let val =
-        T::try_from_slice(&bytes).unwrap_or_else(|_| env::panic_str(ERR_VALUE_DESERIALIZATION));
+        T::try_from_slice(&bytes).unwrap_or_else(|_| env::panic_str(ERR_ELEMENT_DESERIALIZATION));
     CacheEntry::new_cached(Some(val))
 }
 
@@ -40,7 +38,8 @@ pub(crate) fn serialize_and_store<T>(key: &[u8], value: &T)
 where
     T: BorshSerialize,
 {
-    let serialized = value.try_to_vec().unwrap_or_else(|_| env::panic_str(ERR_VALUE_SERIALIZATION));
+    let serialized =
+        value.try_to_vec().unwrap_or_else(|_| env::panic_str(ERR_ELEMENT_SERIALIZATION));
     env::storage_write(key, &serialized);
 }
 

--- a/near-sdk/src/store/lookup_map/mod.rs
+++ b/near-sdk/src/store/lookup_map/mod.rs
@@ -7,15 +7,12 @@ use std::fmt;
 use borsh::{BorshDeserialize, BorshSerialize};
 use once_cell::unsync::OnceCell;
 
-use super::ERR_NOT_EXIST;
+use super::{ERR_ELEMENT_DESERIALIZATION, ERR_ELEMENT_SERIALIZATION, ERR_NOT_EXIST};
 use crate::store::key::{Identity, ToKey};
 use crate::utils::{EntryState, StableMap};
 use crate::{env, CacheEntry, IntoStorageKey};
 
 pub use entry::{Entry, OccupiedEntry, VacantEntry};
-
-const ERR_ELEMENT_DESERIALIZATION: &str = "Cannot deserialize element";
-const ERR_ELEMENT_SERIALIZATION: &str = "Cannot serialize element";
 
 /// A non-iterable, lazily loaded storage map that stores its content directly on the storage trie.
 ///

--- a/near-sdk/src/store/mod.rs
+++ b/near-sdk/src/store/mod.rs
@@ -100,5 +100,6 @@ pub mod key;
 pub(crate) const ERR_INCONSISTENT_STATE: &str =
     "The collection is an inconsistent state. Did previous smart \
         contract execution terminate unexpectedly?";
-
+pub(crate) const ERR_ELEMENT_DESERIALIZATION: &str = "Cannot deserialize element";
+pub(crate) const ERR_ELEMENT_SERIALIZATION: &str = "Cannot serialize element";
 pub(crate) const ERR_NOT_EXIST: &str = "Key does not exist in map";


### PR DESCRIPTION
Noticed this when checking something unrelated. Ideally, the error messages are included in each panic message, and hopefully, the formatting machinery gets optimized away by a minifier. I don't know why, but it seems like it was decided to include the error message in state read/write but not the collections.

The difference is ~10% for each (state read 4K, collections errors 4K on a 44K contract), so maybe we should come up with a plan if we want minimal code or better error reporting.

Defaulted to just removing error messages from state serialization/deserialization because that one seems much less important than collections.

Opening PR to compare code size across examples, Results:
before:
```
  | Size contract adder
  | 96K	res/adder.wasm
  | Size contract callback-results
  | 100K	res/callback_results.wasm
  | Size contract cross-contract-calls
  | 100K	res/cross_contract_high_level.wasm
  | 92K	res/cross_contract_low_level.wasm
  | Size contract factory-contract
  | 208K	res/factory_contract_high_level.wasm
  | 204K	res/factory_contract_low_level.wasm
  | Size contract fungible-token
  | 112K	res/defi.wasm
  | 180K	res/fungible_token.wasm
  | Size contract lockable-fungible-token
  | 140K	res/lockable_fungible_token.wasm
  | Size contract mission-control
  | 128K	res/mission_control.wasm
  | Size contract non-fungible-token
  | 108K	res/approval_receiver.wasm
  | 248K	res/non_fungible_token.wasm
  | 108K	res/token_receiver.wasm
  | Size contract status-message
  | 104K	res/status_message.wasm
  | Size contract status-message-collections
  | 92K	res/status_message_collections.wasm
  | Size contract test-contract
  | 32K	res/test_contract.wasm
  | Size contract versioned
  | 116K	res/versioned.wasm
```

after:
```
  | Size contract adder
  | 96K	res/adder.wasm
  | Size contract callback-results
  | 100K	res/callback_results.wasm
  | Size contract cross-contract-calls
  | 92K	res/cross_contract_high_level.wasm
  | 84K	res/cross_contract_low_level.wasm
  | Size contract factory-contract
  | 196K	res/factory_contract_high_level.wasm
  | 192K	res/factory_contract_low_level.wasm
  | Size contract fungible-token
  | 108K	res/defi.wasm
  | 176K	res/fungible_token.wasm
  | Size contract lockable-fungible-token
  | 132K	res/lockable_fungible_token.wasm
  | Size contract mission-control
  | 124K	res/mission_control.wasm
  | Size contract non-fungible-token
  | 104K	res/approval_receiver.wasm
  | 248K	res/non_fungible_token.wasm
  | 104K	res/token_receiver.wasm
  | Size contract status-message
  | 96K	res/status_message.wasm
  | Size contract status-message-collections
  | 88K	res/status_message_collections.wasm
  | Size contract test-contract
  | 24K	res/test_contract.wasm
  | Size contract versioned
  | 108K	res/versioned.wasm


```