### PR TITLE
chore: pin version of derive_arbitrary

### DIFF
--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -48,6 +48,7 @@ rustversion = "1.0"
 rand_xorshift = "0.3"
 quickcheck = "1.0"
 arbitrary = { version = ">=1.0, <1.1.4", features = ["derive"] }
+derive_arbitrary = ">=1.0, <=1.1.6"
 hex = { version = "0.4.3", features = ["serde"] }
 
 [features]


### PR DESCRIPTION
A minor release was cut that requires a MSRV of `1.63` so our buildkite CI was broken. Temporary workaround.

Associated CI: https://buildkite.com/nearprotocol/near-sdk-rs/builds/4465#0183f87e-2f41-4fec-ad5b-e068e8f67205