### PR TITLE
refactor: make PromiseIndex a newtype

### DIFF
--- a/near-sdk/src/types/vm_types.rs
+++ b/near-sdk/src/types/vm_types.rs
@@ -3,7 +3,10 @@ pub use near_vm_logic::types::{PromiseResult as VmPromiseResult, ReturnData};
 
 //* Types from near_vm_logic
 /// Promise index that is computed only once.
-pub type PromiseIndex = u64;
+/// This is contructed and used through the [`Promise`](crate::Promise) API and promise functions
+/// in [`near_sdk::env`](crate::env).
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct PromiseIndex(pub u64);
 /// An index of Receipt to append an action
 pub type ReceiptIndex = u64;
 pub type IteratorIndex = u64;


### PR DESCRIPTION
I thought this was done with a previous major version bump.

This shouldn't be breaking in practical cases because promise indices should never be manually constructed, but is technically breaking and should come in with a major version bump. (I'll probably keep this as a draft until we are ready to start pulling in breaking changes)

closes #945 

