### PR TITLE
chore: deprecate vm logic types

### DIFF
--- a/near-sdk/src/types/vm_types.rs
+++ b/near-sdk/src/types/vm_types.rs
@@ -5,7 +5,9 @@ pub use near_vm_logic::types::{PromiseResult as VmPromiseResult, ReturnData};
 /// Promise index that is computed only once.
 pub type PromiseIndex = u64;
 /// An index of Receipt to append an action
+#[deprecated(since = "4.1.0", note = "type not used within SDK, use u64 directly or another alias")]
 pub type ReceiptIndex = u64;
+#[deprecated(since = "4.1.0", note = "type not used within SDK, use u64 directly or another alias")]
 pub type IteratorIndex = u64;
 
 /// When there is a callback attached to one or more contract calls the execution results of these


### PR DESCRIPTION
noticed this when doing #948 but separated from those changes because this isn't as breaking and can come in 4.1

I think these aliases might have been used previously, otherwise, I don't know why these weren't removed before.