### PR TITLE
Remove unused tokens in compilation test

### DIFF
--- a/near-sdk/compilation_tests/cond_compilation.rs
+++ b/near-sdk/compilation_tests/cond_compilation.rs
@@ -9,7 +9,7 @@ struct Incrementer {
     value: u32,
 }
 
-#[near_bindgen(init => new)]
+#[near_bindgen]
 impl Incrementer {
     #[cfg(feature = "myfeature")]
     pub fn new() -> Self {


### PR DESCRIPTION
The `#[near_bindgen]` macro currently ignores tokens after the attribute name, for example `#[near_bindgen(this_is_ignored)]`. This is due to `_attr` (which [contains these tokens](https://doc.rust-lang.org/reference/procedural-macros.html#attribute-macros)) being ignored:

https://github.com/near/near-sdk-rs/blob/039cc110c9c01907b95250a50d9ff8ccbad99cbf/near-sdk-macros/src/lib.rs#L46-L47

There's a contract used in compilation test which has tokens after the attribute name: `#[near_bindgen(init => new)]`. They are removed in this PR.

## Context

For [`near-plugins`](https://github.com/aurora-is-near/near-plugins) we're experimenting with passing extra tokens like `#[near_bindgen(some_config(value_a, value_b))]`. When adding logic to parse these tokens via [`darling`](https://docs.rs/darling/latest/darling/index.html) the compilation of the contract with `#[near_bindgen(init => new)]` fails.