### PR TITLE
fix: update test vector for optimized skip

### DIFF
--- a/near-sdk/src/collections/unordered_map/mod.rs
+++ b/near-sdk/src/collections/unordered_map/mod.rs
@@ -524,12 +524,14 @@ mod tests {
         assert_eq!(DES_COUNT.load(Ordering::SeqCst), 0);
 
         let collected: Vec<u64> = map.iter().skip(5).take(4).map(|(_, v)| v.0).collect();
-        assert_eq!(DES_COUNT.load(Ordering::SeqCst), 4);
+        // 4 or 5 is accepted because pre 1.65 Rust skip loaded an extra value.
+        assert!((4..=5).contains(&DES_COUNT.load(Ordering::SeqCst)));
         assert_eq!(&collected, &[5, 6, 7, 8]);
 
         DES_COUNT.store(0, Ordering::SeqCst);
         let collected: Vec<u64> = map.values().skip(5).take(4).map(|v| v.0).collect();
-        assert_eq!(DES_COUNT.load(Ordering::SeqCst), 4);
+        // 4 or 5 is accepted because pre 1.65 Rust skip loaded an extra value.
+        assert!((4..=5).contains(&DES_COUNT.load(Ordering::SeqCst)));
         assert_eq!(&collected, &[5, 6, 7, 8]);
     }
 

--- a/near-sdk/src/collections/unordered_map/mod.rs
+++ b/near-sdk/src/collections/unordered_map/mod.rs
@@ -524,14 +524,12 @@ mod tests {
         assert_eq!(DES_COUNT.load(Ordering::SeqCst), 0);
 
         let collected: Vec<u64> = map.iter().skip(5).take(4).map(|(_, v)| v.0).collect();
-        // 5 because skip is a bit inefficient in that it calls nth to skip.
-        assert_eq!(DES_COUNT.load(Ordering::SeqCst), 5);
+        assert_eq!(DES_COUNT.load(Ordering::SeqCst), 4);
         assert_eq!(&collected, &[5, 6, 7, 8]);
 
         DES_COUNT.store(0, Ordering::SeqCst);
         let collected: Vec<u64> = map.values().skip(5).take(4).map(|v| v.0).collect();
-        // 5 because skip is a bit inefficient in that it calls nth to skip.
-        assert_eq!(DES_COUNT.load(Ordering::SeqCst), 5);
+        assert_eq!(DES_COUNT.load(Ordering::SeqCst), 4);
         assert_eq!(&collected, &[5, 6, 7, 8]);
     }
 

--- a/near-sdk/src/json_types/vector.rs
+++ b/near-sdk/src/json_types/vector.rs
@@ -53,7 +53,7 @@ mod base64_bytes {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&base64::encode(&bytes))
+        serializer.serialize_str(&base64::encode(bytes))
     }
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>

--- a/near-sdk/tests/code_size.rs
+++ b/near-sdk/tests/code_size.rs
@@ -2,7 +2,7 @@
 fn check_example_size(example: &str) -> usize {
     let status = std::process::Command::new("cargo")
         .env("RUSTFLAGS", "-C link-arg=-s")
-        .args(&["build", "--release", "--target", "wasm32-unknown-unknown", "--manifest-path"])
+        .args(["build", "--release", "--target", "wasm32-unknown-unknown", "--manifest-path"])
         .arg(format!("../examples/{}/Cargo.toml", example))
         .status()
         .unwrap();


### PR DESCRIPTION
The [skip optimization I added to Rust](https://github.com/rust-lang/rust/pull/96350) has been released with 1.65 and broke one of our test vectors.