### PR TITLE
fix: Expose missing UnorderedSet iter types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Exposed missing iterator types used in `near_sdk::store::UnorderedSet`. [PR 961](https://github.com/near/near-sdk-rs/pull/961)
+
 ## [4.1.1] - 2022-11-10
 
 ### Fixed

--- a/near-sdk/src/store/unordered_set/mod.rs
+++ b/near-sdk/src/store/unordered_set/mod.rs
@@ -1,12 +1,10 @@
 mod impls;
 mod iter;
 
+pub use self::iter::{Difference, Drain, Intersection, Iter, SymmetricDifference, Union};
 use super::{FreeList, LookupMap, ERR_INCONSISTENT_STATE};
 use crate::store::free_list::FreeListIndex;
 use crate::store::key::{Sha256, ToKey};
-pub use crate::store::unordered_set::iter::{
-    Difference, Drain, Intersection, Iter, SymmetricDifference, Union,
-};
 use crate::{env, IntoStorageKey};
 use borsh::{BorshDeserialize, BorshSerialize};
 use std::borrow::Borrow;


### PR DESCRIPTION
It was reported that these types weren't available.