### PR TITLE
Fix empty owner tokens `start_index` error

### DIFF
--- a/near-contract-standards/src/non_fungible_token/enumeration/enumeration_impl.rs
+++ b/near-contract-standards/src/non_fungible_token/enumeration/enumeration_impl.rs
@@ -76,7 +76,7 @@ impl NonFungibleTokenEnumeration for NonFungibleToken {
             return vec![];
         };
 
-        if token_set.len() == 0 {
+        if token_set.is_empty() {
             return vec![];
         }
 

--- a/near-contract-standards/src/non_fungible_token/enumeration/enumeration_impl.rs
+++ b/near-contract-standards/src/non_fungible_token/enumeration/enumeration_impl.rs
@@ -75,6 +75,11 @@ impl NonFungibleTokenEnumeration for NonFungibleToken {
         } else {
             return vec![];
         };
+        
+        if token_set.len() == 0 {
+            return vec![]
+        }
+        
         let limit = limit.map(|v| v as usize).unwrap_or(usize::MAX);
         require!(limit != 0, "Cannot provide limit of 0.");
         let start_index: u128 = from_index.map(From::from).unwrap_or_default();

--- a/near-contract-standards/src/non_fungible_token/enumeration/enumeration_impl.rs
+++ b/near-contract-standards/src/non_fungible_token/enumeration/enumeration_impl.rs
@@ -75,11 +75,11 @@ impl NonFungibleTokenEnumeration for NonFungibleToken {
         } else {
             return vec![];
         };
-        
+
         if token_set.len() == 0 {
-            return vec![]
+            return vec![];
         }
-        
+
         let limit = limit.map(|v| v as usize).unwrap_or(usize::MAX);
         require!(limit != 0, "Cannot provide limit of 0.");
         let start_index: u128 = from_index.map(From::from).unwrap_or_default();


### PR DESCRIPTION
When the user's `token_set` is empty this method panics now in case of use
```
{
        ...
        from_index: None,
        limit: None,
}
```
But i propose for an empty list returned in this situation