### PR TITLE
Depreciated legacy tree map  #868

### DIFF
--- a/near-sdk/src/collections/legacy_tree_map.rs
+++ b/near-sdk/src/collections/legacy_tree_map.rs
@@ -1,6 +1,8 @@
 //! Legacy `TreeMap` implementation that is using `UnorderedMap`.
 //! DEPRECATED. This implementation is deprecated and may be removed in the future.
 #![allow(clippy::all)]
+// This suppresses the depreciation warnings for uses of LegacyTreeMap in this module
+#![allow(deprecated)]
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use std::ops::Bound;
@@ -18,6 +20,7 @@ use crate::IntoStorageKey;
 /// - `above`/`below`:          O(log(N))
 /// - `range` of K elements:    O(Klog(N))
 ///
+#[deprecated(since = "4.1.0", note = "Use tree_map::TreeMap instead")]
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct LegacyTreeMap<K, V> {
     root: u64,

--- a/near-sdk/src/collections/mod.rs
+++ b/near-sdk/src/collections/mod.rs
@@ -39,6 +39,7 @@
 //! that seemlessly integrated with the rest of the Rust standard library.
 
 mod legacy_tree_map;
+#[allow(deprecated)]
 pub use legacy_tree_map::LegacyTreeMap;
 
 mod lookup_map;


### PR DESCRIPTION
I have the alternative of marking each individual use of legacy tree map in `legacy_tree_map.rs` as depreciated rather than the whole module, but since the whole source file is depreciated I figured it wasn't worth the effort