### PR TITLE
Fix: Replace Tautology Expressions

### DIFF
--- a/examples/callback-results/src/lib.rs
+++ b/examples/callback-results/src/lib.rs
@@ -35,14 +35,14 @@ impl Callback {
     /// Panics if value is 0, returns the value passed in otherwise.
     #[private]
     pub fn c(value: u8) -> u8 {
-        require!(value > 0, "Value must be positive");
+        require!(value != 0, "Value should not be equal to 0");
         value
     }
 
     /// Panics if value is 0.
     #[private]
     pub fn d(value: u8) {
-        require!(value > 0, "Value must be positive");
+        require!(value != 0, "Value should not be equal to 0");
     }
 
     /// Receives the callbacks from the other promises called.

--- a/near-contract-standards/src/fungible_token/core_impl.rs
+++ b/near-contract-standards/src/fungible_token/core_impl.rs
@@ -98,7 +98,7 @@ impl FungibleToken {
         memo: Option<String>,
     ) {
         require!(sender_id != receiver_id, "Sender and receiver should be different");
-        require!(amount > 0, "The amount should be a positive number");
+        require!(amount != 0, "The amount should not be equal to 0");
         self.internal_withdraw(sender_id, amount);
         self.internal_deposit(receiver_id, amount);
         FtTransfer {


### PR DESCRIPTION
This PR replaces tautology expressions related to unsigned integers. 

In **internal_transfer**, the **require** statement is used to check whether the amount is greater than 0([Source](https://github.com/near/near-sdk-rs/blob/master/near-contract-standards/src/fungible_token/core_impl.rs#L101)).

` require!(amount > 0, "The amount should be a positive number");`

The amount has a **Balance** type which is u128 behind the scenes. Hence, it is always positive. 

To ensure whether the amount is not 0, a more logical way would be to do simply:

`require!(amount != 0, "The amount should not be 0");`

The same case exists in examples/callback-results
- https://github.com/near/near-sdk-rs/blob/master/examples/callback-results/src/lib.rs#L38
- https://github.com/near/near-sdk-rs/blob/master/examples/callback-results/src/lib.rs#L45