### PR TITLE
refactor: switch all arithmetic in standards to explicitly checked

### DIFF
--- a/near-contract-standards/src/lib.rs
+++ b/near-contract-standards/src/lib.rs
@@ -13,3 +13,5 @@ pub mod storage_management;
 pub mod upgrade;
 
 pub(crate) mod event;
+
+pub(crate) const ERR_ARITHMETIC_OVERFLOW: &str = "arithmetic overflow in contract standards";

--- a/near-contract-standards/src/non_fungible_token/core/core_impl.rs
+++ b/near-contract-standards/src/non_fungible_token/core/core_impl.rs
@@ -136,6 +136,7 @@ impl NonFungibleToken {
         }
 
         // 2. see how much space it took
+        // Note: This should not overflow because no storage items were removed above.
         self.extra_storage_in_bytes_per_token = env::storage_usage() - initial_storage_usage;
 
         // 3. roll it all back
@@ -359,7 +360,7 @@ impl NonFungibleToken {
             if self.approvals_by_id.is_some() { Some(HashMap::new()) } else { None };
 
         if let Some((id, storage_usage)) = initial_storage_usage {
-            refund_deposit_to_account(env::storage_usage() - storage_usage, id)
+            refund_deposit_to_account(env::storage_usage().saturating_sub(storage_usage), id)
         }
 
         // Return any extra attached deposit not used for storage

--- a/near-contract-standards/src/upgrade/mod.rs
+++ b/near-contract-standards/src/upgrade/mod.rs
@@ -57,7 +57,7 @@ impl Upgradable for Upgrade {
     fn stage_code(&mut self, code: Vec<u8>, timestamp: Timestamp) {
         self.assert_owner();
         require!(
-            env::block_timestamp() + self.staging_duration < timestamp,
+            env::block_timestamp().saturating_add(self.staging_duration) < timestamp,
             "Timestamp must be later than staging duration"
         );
         // Writes directly into storage to avoid serialization penalty by using default struct.
@@ -68,11 +68,8 @@ impl Upgradable for Upgrade {
     fn deploy_code(&mut self) -> Promise {
         if self.staging_timestamp < env::block_timestamp() {
             env::panic_str(
-                format!(
-                    "Deploy code too early: staging ends on {}",
-                    self.staging_timestamp + self.staging_duration
-                )
-                .as_str(),
+                format!("Deploy code too early: staging ends on {}", self.staging_timestamp)
+                    .as_str(),
             );
         }
         let code = env::storage_read(b"upgrade")


### PR DESCRIPTION
I made the statement today that we do checked arithmetic for everything, so this PR intends to be extra careful.

Ideally and in most cases, overflow checks should be done through Rust (and recommended https://docs.near.org/sdk/rust/best-practices#enable-overflow-checks and https://docs.near.org/sdk/rust/introduction#create-a-new-project), but this is done as an extra-safety measure

Would be great to get another set of eyes to see if I switched one unnecessarily or something like this