### PR TITLE
fix: `__abi-embed` compilation error

### DIFF
--- a/near-sdk-macros/Cargo.toml
+++ b/near-sdk-macros/Cargo.toml
@@ -16,11 +16,11 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "1.0"
-syn = {version = "1", features = ["full", "fold", "extra-traits", "visit"] }
+syn = { version = "1", features = ["full", "fold", "extra-traits", "visit"] }
 quote = "1.0"
 Inflector = { version = "0.11.4", default-features = false, features = [] }
 
 [features]
 abi = []
-__abi-embed = []
-__abi-generate = []
+__abi-embed = ["abi"]
+__abi-generate = ["abi"]

--- a/near-sdk-macros/build.rs
+++ b/near-sdk-macros/build.rs
@@ -1,0 +1,10 @@
+fn main() {
+    if cfg!(feature = "__abi-embed") {
+        if option_env!("CARGO_NEAR_ABI_PATH").is_some() {
+            println!("cargo:rustc-cfg=feature=\"__abi-embed-checked\"");
+        } else {
+            println!("cargo:warning=the `__abi-embed` feature flag is private and should not be activated manually, ignoring");
+            println!("cargo:warning=\x1b[1mhelp\x1b[0m: consider using https://github.com/near/cargo-near");
+        }
+    }
+}

--- a/near-sdk-macros/src/core_impl/abi/abi_embed.rs
+++ b/near-sdk-macros/src/core_impl/abi/abi_embed.rs
@@ -2,18 +2,7 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 
 pub fn embed() -> TokenStream2 {
-    let abi_path = match option_env!("CARGO_NEAR_ABI_PATH") {
-        Some(path) => path,
-        None => {
-            return quote! {
-                compile_error!(
-                    "the `__abi-embed` feature flag is private and should not be activated manually\n\
-                    \n\
-                    help\x1b[0m: consider using https://github.com/near/cargo-near"
-                );
-            };
-        }
-    };
+    let abi_path = env!("CARGO_NEAR_ABI_PATH");
     quote! {
         const _: () = {
             const __CONTRACT_ABI: &'static [u8] = include_bytes!(#abi_path);

--- a/near-sdk-macros/src/core_impl/abi/mod.rs
+++ b/near-sdk-macros/src/core_impl/abi/mod.rs
@@ -1,6 +1,6 @@
-#[cfg(feature = "__abi-embed")]
+#[cfg(feature = "__abi-embed-checked")]
 mod abi_embed;
-#[cfg(feature = "__abi-embed")]
+#[cfg(feature = "__abi-embed-checked")]
 pub use abi_embed::embed;
 
 #[cfg(feature = "__abi-generate")]

--- a/near-sdk-macros/src/core_impl/mod.rs
+++ b/near-sdk-macros/src/core_impl/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(any(feature = "__abi-embed", feature = "__abi-generate"))]
+#[cfg(feature = "abi")]
 pub(crate) mod abi;
 mod code_generator;
 mod event;

--- a/near-sdk-macros/src/lib.rs
+++ b/near-sdk-macros/src/lib.rs
@@ -90,9 +90,9 @@ pub fn near_bindgen(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     if let Ok(input) = syn::parse::<ItemStruct>(item.clone()) {
         let ext_gen = generate_ext_structs(&input.ident, Some(&input.generics));
-        #[cfg(feature = "__abi-embed")]
+        #[cfg(feature = "__abi-embed-checked")]
         let abi_embedded = abi::embed();
-        #[cfg(not(feature = "__abi-embed"))]
+        #[cfg(not(feature = "__abi-embed-checked"))]
         let abi_embedded = quote! {};
         TokenStream::from(quote! {
             #input
@@ -101,9 +101,9 @@ pub fn near_bindgen(attr: TokenStream, item: TokenStream) -> TokenStream {
         })
     } else if let Ok(input) = syn::parse::<ItemEnum>(item.clone()) {
         let ext_gen = generate_ext_structs(&input.ident, Some(&input.generics));
-        #[cfg(feature = "__abi-embed")]
+        #[cfg(feature = "__abi-embed-checked")]
         let abi_embedded = abi::embed();
-        #[cfg(not(feature = "__abi-embed"))]
+        #[cfg(not(feature = "__abi-embed-checked"))]
         let abi_embedded = quote! {};
         TokenStream::from(quote! {
             #input


### PR DESCRIPTION
`--all-features` causes cargo to activate all features in the `Cargo.toml` file.

This patch introduces an intermediary flag. Unknown to cargo, but injected with a build script if;

- The `__abi-embed` feature flag is activated.
- The `CARGO_NEAR_ABI_PATH` env is defined.

This way, it's never implicitly activated. Resolving the compilation error in #970.

This also means, we gravitate from this compilation error:

<img width="525" alt="CleanShot 2022-11-24 at 03 34 06@2x" src="https://user-images.githubusercontent.com/16881812/203663576-674da9be-abba-4cd0-8284-23fc465af47b.png">

.. to this compilation warning ..

<img width="599" alt="CleanShot 2022-11-24 at 03 31 04@2x" src="https://user-images.githubusercontent.com/16881812/203663312-6b40bee3-d556-43a6-bea3-3273fcb0f8aa.png">