### PR TITLE
fix: strip return types of lifetimes

### DIFF
--- a/near-sdk-macros/src/core_impl/info_extractor/arg_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/arg_info.rs
@@ -58,7 +58,8 @@ impl ArgInfo {
                 ));
             }
         };
-        let (reference, mutability, ty) = utils::extract_ref_mut(original.ty.as_ref())?;
+        let (reference, mutability, ty) =
+            utils::extract_ref_mut(original.ty.as_ref(), original.span())?;
         // In the absence of callback attributes this is a regular argument.
         let mut bindgen_ty = BindgenArgType::Regular;
         // In the absence of serialization attributes this is a JSON serialization.

--- a/near-sdk-macros/src/core_impl/info_extractor/arg_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/arg_info.rs
@@ -1,5 +1,5 @@
-use crate::core_impl::info_extractor::serializer_attr::SerializerAttr;
 use crate::core_impl::info_extractor::SerializerType;
+use crate::core_impl::{info_extractor::serializer_attr::SerializerAttr, utils};
 use quote::ToTokens;
 use syn::{spanned::Spanned, Attribute, Error, Ident, Pat, PatType, Token, Type};
 
@@ -58,13 +58,7 @@ impl ArgInfo {
                 ));
             }
         };
-        let (reference, mutability, ty) = match original.ty.as_ref() {
-            x @ Type::Array(_) | x @ Type::Path(_) | x @ Type::Tuple(_) => {
-                (None, None, (*x).clone())
-            }
-            Type::Reference(r) => (Some(r.and_token), r.mutability, (*r.elem.as_ref()).clone()),
-            _ => return Err(Error::new(original.span(), "Unsupported argument type.")),
-        };
+        let (reference, mutability, ty) = utils::extract_ref_mut(original.ty.as_ref())?;
         // In the absence of callback attributes this is a regular argument.
         let mut bindgen_ty = BindgenArgType::Regular;
         // In the absence of serialization attributes this is a JSON serialization.

--- a/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
@@ -1,4 +1,5 @@
 use super::{ArgInfo, BindgenArgType, InitAttr, MethodType, SerializerAttr, SerializerType};
+use crate::core_impl::utils;
 use proc_macro2::Span;
 use quote::ToTokens;
 use syn::spanned::Spanned;
@@ -132,7 +133,13 @@ impl AttrSigInfo {
         }
 
         *original_attrs = non_bindgen_attrs.clone();
-        let returns = original_sig.output.clone();
+        let returns = match &original_sig.output {
+            ReturnType::Default => ReturnType::Default,
+            ReturnType::Type(arrow, ty) => {
+                let (_, _, ty) = utils::extract_ref_mut(&ty)?;
+                ReturnType::Type(arrow.clone(), ty.into())
+            }
+        };
 
         let mut result = Self {
             ident,

--- a/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
@@ -136,8 +136,8 @@ impl AttrSigInfo {
         let returns = match &original_sig.output {
             ReturnType::Default => ReturnType::Default,
             ReturnType::Type(arrow, ty) => {
-                let (_, _, ty) = utils::extract_ref_mut(&ty)?;
-                ReturnType::Type(arrow.clone(), ty.into())
+                let (_, _, ty) = utils::extract_ref_mut(ty)?;
+                ReturnType::Type(*arrow, ty.into())
             }
         };
 

--- a/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
@@ -136,7 +136,7 @@ impl AttrSigInfo {
         let returns = match &original_sig.output {
             ReturnType::Default => ReturnType::Default,
             ReturnType::Type(arrow, ty) => {
-                let (_, _, ty) = utils::extract_ref_mut(ty)?;
+                let (_, _, ty) = utils::extract_ref_mut(ty, ty.span())?;
                 ReturnType::Type(*arrow, ty.into())
             }
         };

--- a/near-sdk-macros/src/core_impl/utils/mod.rs
+++ b/near-sdk-macros/src/core_impl/utils/mod.rs
@@ -1,5 +1,5 @@
+use proc_macro2::Span;
 use syn::{
-    spanned::Spanned,
     token::{And, Mut},
     GenericArgument, Path, PathArguments, Type,
 };
@@ -79,12 +79,15 @@ pub(crate) fn extract_vec_type(ty: &Type) -> Option<&Type> {
 }
 
 /// Extracts reference and mutability tokens from a `Type` object. Also, strips top-level lifetime binding if present.
-pub(crate) fn extract_ref_mut(ty: &Type) -> syn::Result<(Option<And>, Option<Mut>, Type)> {
+pub(crate) fn extract_ref_mut(
+    ty: &Type,
+    span: Span,
+) -> syn::Result<(Option<And>, Option<Mut>, Type)> {
     match ty {
         x @ Type::Array(_) | x @ Type::Path(_) | x @ Type::Tuple(_) => {
             Ok((None, None, (*x).clone()))
         }
         Type::Reference(r) => Ok((Some(r.and_token), r.mutability, (*r.elem.as_ref()).clone())),
-        _ => Err(syn::Error::new(ty.span(), "Unsupported contract API type.")),
+        _ => Err(syn::Error::new(span, "Unsupported contract API type.")),
     }
 }

--- a/near-sdk/compilation_tests/bad_argument.stderr
+++ b/near-sdk/compilation_tests/bad_argument.stderr
@@ -1,4 +1,4 @@
-error: Unsupported argument type.
+error: Unsupported contract API type.
   --> compilation_tests/bad_argument.rs:30:56
    |
 30 |     pub fn insert(&mut self, key: TypeA, value: TypeB, t: impl MyTrait) -> Option<TypeB> {


### PR DESCRIPTION
Closes #974 

We are already stripping function params of their lifetimes, seems reasonable to also do this for the return type.