### PR TITLE
<WIP> feat: `defrag` function for `FreeList`

### DIFF
--- a/near-sdk/src/store/vec/mod.rs
+++ b/near-sdk/src/store/vec/mod.rs
@@ -349,7 +349,7 @@ where
         self.values.get_mut(index)
     }
 
-    fn swap(&mut self, a: u32, b: u32) {
+    pub fn swap(&mut self, a: u32, b: u32) {
         if a >= self.len() || b >= self.len() {
             env::panic_str(ERR_INDEX_OUT_OF_BOUNDS);
         }


### PR DESCRIPTION
Closes #990 

`defrag` function for `FreeList` will replace `Solt::Empty` entries in front of the list with ``Slot::Occupied` entries from back of the list. Please see the issue for detailed description.