### PR TITLE
Add documentation to collection cache types

### DIFF
--- a/near-sdk/src/utils/cache_entry.rs
+++ b/near-sdk/src/utils/cache_entry.rs
@@ -1,3 +1,10 @@
+/// This type acts as a guard pattern for a lazily loaded element.
+///
+/// The value type is represented as an [`Option`] where [`None`] represents the element not being
+/// present in storage.
+///
+/// This entry is marked as modified when the inner value is accessed mutably or replaced, which
+/// indicates if there needs to be state modified for that entry.
 #[derive(Clone, Debug)]
 pub(crate) struct CacheEntry<T> {
     value: Option<T>,
@@ -26,11 +33,6 @@ impl<T> CacheEntry<T> {
         &mut self.value
     }
 
-    #[allow(dead_code)]
-    pub fn into_value(self) -> Option<T> {
-        self.value
-    }
-
     /// Replaces the current value with a new one. This changes the state of the cell to mutated
     /// if either the old or new value is [`Some<T>`].
     pub fn replace(&mut self, value: Option<T>) -> Option<T> {
@@ -52,12 +54,6 @@ impl<T> CacheEntry<T> {
     /// Returns true if the entry has been modified
     pub fn is_modified(&self) -> bool {
         matches!(self.state, EntryState::Modified)
-    }
-
-    #[allow(dead_code)]
-    /// Returns true if the entry state has not been changed.
-    pub fn is_cached(&self) -> bool {
-        !self.is_modified()
     }
 }
 

--- a/near-sdk/src/utils/stable_map.rs
+++ b/near-sdk/src/utils/stable_map.rs
@@ -2,6 +2,9 @@ use std::borrow::Borrow;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 
+/// This map is used as an append-only cache of keys to values. Insertions in the map can be done
+/// with only an immutable reference because the values are boxed and any insertion will not create
+/// dangling pointers for existing references.
 pub(crate) struct StableMap<K, V> {
     map: RefCell<BTreeMap<K, Box<V>>>,
 }


### PR DESCRIPTION
It also removes some unused types. I can't remember why those were kept in if it was a prediction of what would be needed, but they shouldn't be needed.