### PR TITLE
fix: concretize `Self` references in method signatures

### DIFF
--- a/near-sdk-macros/src/core_impl/abi/abi_generator.rs
+++ b/near-sdk-macros/src/core_impl/abi/abi_generator.rs
@@ -117,7 +117,7 @@ impl ImplItemMethodInfo {
             let arg_name = arg.ident.to_string();
             match arg.bindgen_ty {
                 BindgenArgType::Regular => {
-                    let schema = generate_schema(&typ, &arg.serializer_ty);
+                    let schema = generate_schema(typ, &arg.serializer_ty);
                     match arg.serializer_ty {
                         SerializerType::JSON => params.push(quote! {
                             near_sdk::__private::AbiJsonParameter {

--- a/near-sdk-macros/src/core_impl/abi/abi_generator.rs
+++ b/near-sdk-macros/src/core_impl/abi/abi_generator.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Span, TokenStream as TokenStream2};
-use quote::{format_ident, quote};
+use quote::{format_ident, quote, ToTokens};
 use syn::spanned::Spanned;
 use syn::{Attribute, Lit::Str, Meta::NameValue, MetaNameValue, ReturnType, Type};
 
@@ -16,7 +16,7 @@ pub fn generate(i: &ItemImplInfo) -> TokenStream2 {
         return TokenStream2::new();
     }
 
-    let functions: Vec<TokenStream2> = public_functions.iter().map(|m| m.abi_struct()).collect();
+    let functions: Vec<TokenStream2> = public_functions.iter().map(|m| m.abi_struct(i)).collect();
     let first_function_name = &public_functions[0].attr_signature_info.ident;
     let near_abi_symbol = format_ident!("__near_abi_{}", first_function_name);
     quote! {
@@ -81,7 +81,7 @@ impl ImplItemMethodInfo {
     /// }
     /// ```
     /// If args are serialized with Borsh it will not include `#[derive(borsh::BorshSchema)]`.
-    pub fn abi_struct(&self) -> TokenStream2 {
+    pub fn abi_struct(&self, i: &ItemImplInfo) -> TokenStream2 {
         let function_name_str = self.attr_signature_info.ident.to_string();
         let function_doc = match parse_rustdoc(&self.attr_signature_info.non_bindgen_attrs) {
             Some(doc) => quote! { Some(#doc.to_string()) },
@@ -117,6 +117,7 @@ impl ImplItemMethodInfo {
             let arg_name = arg.ident.to_string();
             match arg.bindgen_ty {
                 BindgenArgType::Regular => {
+                    let typ = if typ.to_token_stream().to_string() == "Self" { &i.ty } else { typ };
                     let schema = generate_schema(typ, &arg.serializer_ty);
                     match arg.serializer_ty {
                         SerializerType::JSON => params.push(quote! {
@@ -134,7 +135,7 @@ impl ImplItemMethodInfo {
                     };
                 }
                 BindgenArgType::CallbackArg => {
-                    callbacks.push(generate_abi_type(typ, &arg.serializer_ty));
+                    callbacks.push(generate_abi_type(typ, &arg.serializer_ty, &i.ty));
                 }
                 BindgenArgType::CallbackResultArg => {
                     let typ = if let Some(ok_type) = utils::extract_ok_type(typ) {
@@ -147,7 +148,7 @@ impl ImplItemMethodInfo {
                         )
                         .into_compile_error();
                     };
-                    callbacks.push(generate_abi_type(typ, &arg.serializer_ty));
+                    callbacks.push(generate_abi_type(typ, &arg.serializer_ty, &i.ty));
                 }
                 BindgenArgType::CallbackArgVec => {
                     if callback_vec.is_none() {
@@ -161,8 +162,11 @@ impl ImplItemMethodInfo {
                             .into_compile_error();
                         };
 
-                        let abi_type =
-                            generate_abi_type(typ, &self.attr_signature_info.result_serializer);
+                        let abi_type = generate_abi_type(
+                            typ,
+                            &self.attr_signature_info.result_serializer,
+                            &i.ty,
+                        );
                         callback_vec = Some(quote! { Some(#abi_type) })
                     } else {
                         return syn::Error::new(
@@ -212,7 +216,7 @@ impl ImplItemMethodInfo {
                         .into_compile_error();
                     };
                     let abi_type =
-                        generate_abi_type(ty, &self.attr_signature_info.result_serializer);
+                        generate_abi_type(ty, &self.attr_signature_info.result_serializer, &i.ty);
                     quote! { Some(#abi_type) }
                 }
                 ReturnType::Type(_, ty) if is_handles_result => {
@@ -224,7 +228,7 @@ impl ImplItemMethodInfo {
                 }
                 ReturnType::Type(_, ty) => {
                     let abi_type =
-                        generate_abi_type(ty, &self.attr_signature_info.result_serializer);
+                        generate_abi_type(ty, &self.attr_signature_info.result_serializer, &i.ty);
                     quote! { Some(#abi_type) }
                 }
             },
@@ -256,7 +260,8 @@ fn generate_schema(ty: &Type, serializer_type: &SerializerType) -> TokenStream2 
     }
 }
 
-fn generate_abi_type(ty: &Type, serializer_type: &SerializerType) -> TokenStream2 {
+fn generate_abi_type(ty: &Type, serializer_type: &SerializerType, impl_ty: &Type) -> TokenStream2 {
+    let ty = if ty.to_token_stream().to_string() == "Self" { &impl_ty } else { ty };
     let schema = generate_schema(ty, serializer_type);
     match serializer_type {
         SerializerType::JSON => quote! {

--- a/near-sdk-macros/src/core_impl/info_extractor/arg_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/arg_info.rs
@@ -58,7 +58,7 @@ impl ArgInfo {
                 ));
             }
         };
-        *original.ty.as_mut() = utils::sanitize_self(&*original.ty, &source_type)?;
+        *original.ty.as_mut() = utils::sanitize_self(&original.ty, source_type)?;
         let (reference, mutability, ty) = match original.ty.as_ref() {
             x @ (Type::Array(_) | Type::Path(_) | Type::Tuple(_) | Type::Group(_)) => {
                 (None, None, (*x).clone())

--- a/near-sdk-macros/src/core_impl/info_extractor/arg_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/arg_info.rs
@@ -1,5 +1,6 @@
-use crate::core_impl::info_extractor::serializer_attr::SerializerAttr;
-use crate::core_impl::info_extractor::SerializerType;
+use crate::core_impl::info_extractor::{SerializerAttr, SerializerType};
+use crate::core_impl::utils;
+use proc_macro2::TokenStream;
 use quote::ToTokens;
 use syn::{spanned::Spanned, Attribute, Error, Ident, Pat, PatType, Token, Type};
 
@@ -40,16 +41,15 @@ pub struct ArgInfo {
 
 impl ArgInfo {
     /// Extract near-sdk specific argument info.
-    pub fn new(original: &mut PatType) -> syn::Result<Self> {
+    pub fn new(original: &mut PatType, source_type: &TokenStream) -> syn::Result<Self> {
         let mut non_bindgen_attrs = vec![];
         let pat_reference;
         let pat_mutability;
-        let ident;
-        match original.pat.as_ref() {
+        let ident = match original.pat.as_ref() {
             Pat::Ident(pat_ident) => {
                 pat_reference = pat_ident.by_ref;
                 pat_mutability = pat_ident.mutability;
-                ident = pat_ident.ident.clone();
+                pat_ident.ident.clone()
             }
             _ => {
                 return Err(Error::new(
@@ -58,8 +58,9 @@ impl ArgInfo {
                 ));
             }
         };
+        *original.ty.as_mut() = utils::sanitize_self(&*original.ty, &source_type)?;
         let (reference, mutability, ty) = match original.ty.as_ref() {
-            x @ Type::Array(_) | x @ Type::Path(_) | x @ Type::Tuple(_) => {
+            x @ (Type::Array(_) | Type::Path(_) | Type::Tuple(_) | Type::Group(_)) => {
                 (None, None, (*x).clone())
             }
             Type::Reference(r) => (Some(r.and_token), r.mutability, (*r.elem.as_ref()).clone()),
@@ -69,7 +70,7 @@ impl ArgInfo {
         let mut bindgen_ty = BindgenArgType::Regular;
         // In the absence of serialization attributes this is a JSON serialization.
         let mut serializer_ty = SerializerType::JSON;
-        for attr in &mut original.attrs {
+        for attr in &original.attrs {
             let attr_str = attr.path.to_token_stream().to_string();
             match attr_str.as_str() {
                 "callback" | "callback_unwrap" => {

--- a/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
@@ -137,7 +137,7 @@ impl AttrSigInfo {
         let mut returns = original_sig.output.clone();
 
         if let ReturnType::Type(_, ref mut ty) = returns {
-            *ty.as_mut() = utils::sanitize_self(&*ty, &source_type)?;
+            *ty.as_mut() = utils::sanitize_self(&*ty, source_type)?;
         }
 
         let mut result = Self {

--- a/near-sdk-macros/src/core_impl/info_extractor/impl_item_method_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/impl_item_method_info.rs
@@ -1,4 +1,5 @@
 use crate::core_impl::info_extractor::AttrSigInfo;
+use quote::ToTokens;
 use syn::{ImplItemMethod, Type, Visibility};
 
 /// Information extracted from `ImplItemMethod`.
@@ -15,7 +16,7 @@ impl ImplItemMethodInfo {
     /// Process the method and extract information important for near-sdk.
     pub fn new(original: &mut ImplItemMethod, struct_type: Type) -> syn::Result<Self> {
         let ImplItemMethod { attrs, sig, .. } = original;
-        let attr_signature_info = AttrSigInfo::new(attrs, sig)?;
+        let attr_signature_info = AttrSigInfo::new(attrs, sig, &struct_type.to_token_stream())?;
         let is_public = matches!(original.vis, Visibility::Public(_));
         Ok(Self { attr_signature_info, is_public, struct_type })
     }

--- a/near-sdk-macros/src/core_impl/info_extractor/item_trait_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/item_trait_info.rs
@@ -1,5 +1,6 @@
 use super::TraitItemMethodInfo;
 use inflector::Inflector;
+use quote::ToTokens;
 use syn::spanned::Spanned;
 use syn::{Error, Ident, ItemTrait, TraitItem};
 
@@ -30,7 +31,8 @@ impl ItemTraitInfo {
                     ))
                 }
                 TraitItem::Method(method) => {
-                    methods.push(TraitItemMethodInfo::new(method)?);
+                    methods
+                        .push(TraitItemMethodInfo::new(method, &original.ident.to_token_stream())?);
                     if method.default.is_some() {
                         return Err(Error::new(
                             method.span(),

--- a/near-sdk-macros/src/core_impl/info_extractor/trait_item_method_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/trait_item_method_info.rs
@@ -1,4 +1,5 @@
 use super::AttrSigInfo;
+use proc_macro2::TokenStream as TokenStream2;
 use syn::spanned::Spanned;
 use syn::{Error, LitStr, TraitItemMethod};
 
@@ -13,7 +14,7 @@ pub struct TraitItemMethodInfo {
 }
 
 impl TraitItemMethodInfo {
-    pub fn new(original: &mut TraitItemMethod) -> syn::Result<Self> {
+    pub fn new(original: &mut TraitItemMethod, trait_name: &TokenStream2) -> syn::Result<Self> {
         if original.default.is_some() {
             return Err(Error::new(
                 original.span(),
@@ -25,7 +26,7 @@ impl TraitItemMethodInfo {
 
         let TraitItemMethod { attrs, sig, .. } = original;
 
-        let attr_sig_info = AttrSigInfo::new(attrs, sig)?;
+        let attr_sig_info = AttrSigInfo::new(attrs, sig, trait_name)?;
 
         let ident_byte_str =
             LitStr::new(&attr_sig_info.ident.to_string(), attr_sig_info.ident.span());

--- a/near-sdk-macros/src/core_impl/utils/mod.rs
+++ b/near-sdk-macros/src/core_impl/utils/mod.rs
@@ -1,4 +1,4 @@
-use proc_macro2::{Delimiter, Group, TokenStream as TokenStream2, TokenTree};
+use proc_macro2::{Group, TokenStream as TokenStream2, TokenTree};
 use quote::quote;
 use syn::{GenericArgument, Path, PathArguments, Type};
 
@@ -78,22 +78,19 @@ pub(crate) fn extract_vec_type(ty: &Type) -> Option<&Type> {
 
 fn _sanitize_self(typ: TokenStream2, replace_with: &TokenStream2) -> TokenStream2 {
     let trees = typ.into_iter().map(|t| match t {
-        TokenTree::Ident(ident) if ident == "Self" => {
-            let replace_with = replace_with
-                .clone()
-                .into_iter()
-                .map(|mut t| {
-                    t.set_span(ident.span());
-                    t
-                })
-                .collect();
-            TokenTree::Group(Group::new(Delimiter::None, replace_with))
-        }
+        TokenTree::Ident(ident) if ident == "Self" => replace_with
+            .clone()
+            .into_iter()
+            .map(|mut t| {
+                t.set_span(ident.span());
+                t
+            })
+            .collect::<TokenStream2>(),
         TokenTree::Group(group) => {
             let stream = _sanitize_self(group.stream(), replace_with);
-            TokenTree::Group(Group::new(group.delimiter(), stream))
+            TokenTree::Group(Group::new(group.delimiter(), stream)).into()
         }
-        rest => rest,
+        rest => rest.into(),
     });
     trees.collect()
 }

--- a/near-sdk-macros/src/core_impl/utils/mod.rs
+++ b/near-sdk-macros/src/core_impl/utils/mod.rs
@@ -1,3 +1,5 @@
+use proc_macro2::{Delimiter, Group, TokenStream as TokenStream2, TokenTree};
+use quote::quote;
 use syn::{GenericArgument, Path, PathArguments, Type};
 
 /// Checks whether the given path is literally "Result".
@@ -72,4 +74,32 @@ pub(crate) fn extract_vec_type(ty: &Type) -> Option<&Type> {
         }
         _ => None,
     }
+}
+
+fn _sanitize_self(typ: TokenStream2, replace_with: &TokenStream2) -> TokenStream2 {
+    let trees = typ.into_iter().map(|t| match t {
+        TokenTree::Ident(ident) if ident == "Self" => {
+            let replace_with = replace_with
+                .clone()
+                .into_iter()
+                .map(|mut t| {
+                    t.set_span(ident.span());
+                    t
+                })
+                .collect();
+            TokenTree::Group(Group::new(Delimiter::None, replace_with))
+        }
+        TokenTree::Group(group) => {
+            let stream = _sanitize_self(group.stream(), &replace_with);
+            TokenTree::Group(Group::new(group.delimiter(), stream))
+        }
+        rest => rest,
+    });
+    trees.collect()
+}
+
+pub fn sanitize_self(typ: &Type, replace_with: &TokenStream2) -> syn::Result<Type> {
+    syn::parse2(_sanitize_self(quote! { #typ }, &replace_with)).map_err(|original| {
+        syn::Error::new(original.span(), "Self sanitization failed. Please report this as a bug.")
+    })
 }

--- a/near-sdk-macros/src/core_impl/utils/mod.rs
+++ b/near-sdk-macros/src/core_impl/utils/mod.rs
@@ -90,7 +90,7 @@ fn _sanitize_self(typ: TokenStream2, replace_with: &TokenStream2) -> TokenStream
             TokenTree::Group(Group::new(Delimiter::None, replace_with))
         }
         TokenTree::Group(group) => {
-            let stream = _sanitize_self(group.stream(), &replace_with);
+            let stream = _sanitize_self(group.stream(), replace_with);
             TokenTree::Group(Group::new(group.delimiter(), stream))
         }
         rest => rest,
@@ -99,7 +99,7 @@ fn _sanitize_self(typ: TokenStream2, replace_with: &TokenStream2) -> TokenStream
 }
 
 pub fn sanitize_self(typ: &Type, replace_with: &TokenStream2) -> syn::Result<Type> {
-    syn::parse2(_sanitize_self(quote! { #typ }, &replace_with)).map_err(|original| {
+    syn::parse2(_sanitize_self(quote! { #typ }, replace_with)).map_err(|original| {
         syn::Error::new(original.span(), "Self sanitization failed. Please report this as a bug.")
     })
 }

--- a/near-sdk/compilation_tests/all.rs
+++ b/near-sdk/compilation_tests/all.rs
@@ -22,4 +22,5 @@ fn compilation_tests() {
     t.pass("compilation_tests/enum_near_bindgen.rs");
     t.pass("compilation_tests/schema_derive.rs");
     t.compile_fail("compilation_tests/schema_derive_invalids.rs");
+    t.pass("compilation_tests/self_support.rs");
 }

--- a/near-sdk/compilation_tests/self_support.rs
+++ b/near-sdk/compilation_tests/self_support.rs
@@ -1,6 +1,5 @@
 //! Method signature uses Self.
 
-use borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::near_bindgen;
 use serde::{Deserialize, Serialize};
 
@@ -12,28 +11,34 @@ pub struct Ident {
 
 #[near_bindgen]
 impl Ident {
-    pub fn plain_arg(a: Self) {}
+    pub fn plain_arg(_a: Self) {
+        unimplemented!()
+    }
     pub fn plain_ret() -> Self {
-        todo!()
+        unimplemented!()
     }
     pub fn plain_arg_ret(a: Self) -> Self {
-        todo!()
+        a
     }
-    pub fn nested_arg(a: Vec<Self>) {}
+    pub fn nested_arg(_a: Vec<Self>) {
+        unimplemented!()
+    }
     pub fn nested_ret() -> Vec<Self> {
-        todo!()
+        unimplemented!()
     }
     pub fn nested_arg_ret(a: Vec<Self>) -> Vec<Self> {
-        todo!()
+        a
     }
-    pub fn deeply_nested_arg(a: Option<[(Self, Result<Self, ()>); 2]>) {}
+    pub fn deeply_nested_arg(_a: Option<[(Self, Result<Self, ()>); 2]>) {
+        unimplemented!()
+    }
     pub fn deeply_nested_ret() -> Option<[(Self, Result<Self, ()>); 2]> {
-        todo!()
+        unimplemented!()
     }
     pub fn deeply_nested_arg_ret(
         a: Option<[(Self, Result<Self, ()>); 2]>,
     ) -> Option<[(Self, Result<Self, ()>); 2]> {
-        todo!()
+        a
     }
 }
 

--- a/near-sdk/compilation_tests/self_support.rs
+++ b/near-sdk/compilation_tests/self_support.rs
@@ -1,0 +1,40 @@
+//! Method signature uses Self.
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use near_sdk::near_bindgen;
+use serde::{Deserialize, Serialize};
+
+#[near_bindgen]
+#[derive(Default, Serialize, Deserialize)]
+pub struct Ident {
+    value: u32,
+}
+
+#[near_bindgen]
+impl Ident {
+    pub fn plain_arg(a: Self) {}
+    pub fn plain_ret() -> Self {
+        todo!()
+    }
+    pub fn plain_arg_ret(a: Self) -> Self {
+        todo!()
+    }
+    pub fn nested_arg(a: Vec<Self>) {}
+    pub fn nested_ret() -> Vec<Self> {
+        todo!()
+    }
+    pub fn nested_arg_ret(a: Vec<Self>) -> Vec<Self> {
+        todo!()
+    }
+    pub fn deeply_nested_arg(a: Option<[(Self, Result<Self, ()>); 2]>) {}
+    pub fn deeply_nested_ret() -> Option<[(Self, Result<Self, ()>); 2]> {
+        todo!()
+    }
+    pub fn deeply_nested_arg_ret(
+        a: Option<[(Self, Result<Self, ()>); 2]>,
+    ) -> Option<[(Self, Result<Self, ()>); 2]> {
+        todo!()
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Resolves: #972, #1000.

This patch replaces any `Self` references in method signatures with the concrete type of the `impl` block itself.

Example:

```rust
#[near_bindgen]
#[derive(Serialize, Deserialize)]
struct MyType {
    data: u8,
}

#[near_bindgen]
impl MyType {
    fn set_state(&mut self, new_state: Self) -> Self {
        std::mem::replace(self, new_state)
    }
}
```

the impl block is transformed into:

```rust
impl MyType {
    fn set_state(&mut self, new_state: MyType) -> MyType {
        std::mem::replace(self, new_state)
    }
}
```

this transformation is maintained regardless of type complexity or nesting level.

Worth noting, this does not transform `Self` references in generic bounds. But they're going to be prohibited following https://github.com/near/near-sdk-rs/pull/980 anyway. So I left it out.