### PR TITLE
feat: adds Default implementation for PromiseOrValue

### DIFF
--- a/near-sdk/src/promise.rs
+++ b/near-sdk/src/promise.rs
@@ -569,6 +569,15 @@ pub enum PromiseOrValue<T> {
     Value(T),
 }
 
+impl<T> Default for PromiseOrValue<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        PromiseOrValue::Value(T::default())
+    }
+}
+
 impl<T> BorshSchema for PromiseOrValue<T>
 where
     T: BorshSchema,


### PR DESCRIPTION
- Only implements for `PromiseOrValue<T>` where `T: Default`.
- Returns the `Value(..)` variant.