### PR TITLE
fix: rename param `approvals` to `approved_account_ids`

### DIFF
--- a/near-contract-standards/src/non_fungible_token/core/resolver.rs
+++ b/near-contract-standards/src/non_fungible_token/core/resolver.rs
@@ -26,7 +26,7 @@ pub trait NonFungibleTokenResolver {
     /// * `previous_owner_id`: the owner prior to the call to `nft_transfer_call`
     /// * `receiver_id`: the `receiver_id` argument given to `nft_transfer_call`
     /// * `token_id`: the `token_id` argument given to `ft_transfer_call`
-    /// * `approvals`: if using Approval Management, contract MUST provide
+    /// * `approved_account_ids`: if using Approval Management, contract MUST provide
     ///   set of original approved accounts in this argument, and restore these
     ///   approved accounts in case of revert.
     ///
@@ -36,6 +36,6 @@ pub trait NonFungibleTokenResolver {
         previous_owner_id: AccountId,
         receiver_id: AccountId,
         token_id: TokenId,
-        approvals: Option<HashMap<AccountId, u64>>,
+        approved_account_ids: Option<HashMap<AccountId, u64>>,
     ) -> bool;
 }


### PR DESCRIPTION
According to [NEP171](https://github.com/near/NEPs/blob/master/neps/nep-0171.md), the last param of `nft_resolve_transfer ` is `approved_account_ids`, and the [macro implementation](https://github.com/near/near-sdk-rs/blob/master/near-contract-standards/src/non_fungible_token/macros.rs#L47) is also `approved_account_ids`, but in trait definition, it named `approvals`, it will cause unexpected JSON serialization result when cross call `nft_resolve_transfer` because the trait use `#[ext_contract]` macro. Currently, approval ids can not be revoked when `nft_transfer_call` failed.