### PR TITLE
fix: approved account ids

### DIFF
--- a/near-contract-standards/src/non_fungible_token/core/core_impl.rs
+++ b/near-contract-standards/src/non_fungible_token/core/core_impl.rs
@@ -206,7 +206,7 @@ impl NonFungibleToken {
 
         // clear approvals, if using Approval Management extension
         // this will be rolled back by a panic if sending fails
-        let approved_account_ids = 
+        let approved_account_ids =
             self.approvals_by_id.as_mut().map(|by_id| by_id.remove(token_id).unwrap_or_default());
 
         // check if authorized

--- a/near-contract-standards/src/non_fungible_token/core/core_impl.rs
+++ b/near-contract-standards/src/non_fungible_token/core/core_impl.rs
@@ -209,13 +209,13 @@ impl NonFungibleToken {
         let approved_account_ids = self
             .approvals_by_id
             .as_mut()
-            .and_then(|by_id| by_id.remove(token_id).or_else(|| Some(HashMap::new())));
+            .map(|by_id| by_id.remove(token_id).unwrap_or_default());
 
         // check if authorized
         let sender_id = if sender_id != &owner_id {
-            // if approval extension is NOT being used, or if token has no approved accounts
+            // Panic if approval extension is NOT being used
             let app_acc_ids =
-                approved_account_ids.as_ref().unwrap_or_else(|| env::panic_str("Unauthorized"));
+                approved_account_ids.as_ref().unwrap_or_else(|| env::panic_str("Approval extension is disabled"));
 
             // Approval extension is being used; get approval_id for sender.
             let actual_approval_id = app_acc_ids.get(sender_id);

--- a/near-contract-standards/src/non_fungible_token/core/core_impl.rs
+++ b/near-contract-standards/src/non_fungible_token/core/core_impl.rs
@@ -206,8 +206,10 @@ impl NonFungibleToken {
 
         // clear approvals, if using Approval Management extension
         // this will be rolled back by a panic if sending fails
-        let approved_account_ids =
-            self.approvals_by_id.as_mut().and_then(|by_id| by_id.remove(token_id));
+        let approved_account_ids = self
+            .approvals_by_id
+            .as_mut()
+            .and_then(|by_id| by_id.remove(token_id).or_else(|| Some(HashMap::new())));
 
         // check if authorized
         let sender_id = if sender_id != &owner_id {

--- a/near-contract-standards/src/non_fungible_token/core/core_impl.rs
+++ b/near-contract-standards/src/non_fungible_token/core/core_impl.rs
@@ -206,16 +206,15 @@ impl NonFungibleToken {
 
         // clear approvals, if using Approval Management extension
         // this will be rolled back by a panic if sending fails
-        let approved_account_ids = self
-            .approvals_by_id
-            .as_mut()
-            .map(|by_id| by_id.remove(token_id).unwrap_or_default());
+        let approved_account_ids = 
+            self.approvals_by_id.as_mut().map(|by_id| by_id.remove(token_id).unwrap_or_default());
 
         // check if authorized
         let sender_id = if sender_id != &owner_id {
             // Panic if approval extension is NOT being used
-            let app_acc_ids =
-                approved_account_ids.as_ref().unwrap_or_else(|| env::panic_str("Approval extension is disabled"));
+            let app_acc_ids = approved_account_ids
+                .as_ref()
+                .unwrap_or_else(|| env::panic_str("Approval extension is disabled"));
 
             // Approval extension is being used; get approval_id for sender.
             let actual_approval_id = app_acc_ids.get(sender_id);


### PR DESCRIPTION
According to the [comments](https://github.com/near/near-sdk-rs/blob/master/near-contract-standards/src/non_fungible_token/core/resolver.rs#L29) and [`nft_token` implementation](https://github.com/near/near-sdk-rs/blob/master/near-contract-standards/src/non_fungible_token/core/core_impl.rs#L412:L415), I think 'Extension Not Exists' vs 'Extension Exist But Value Not Exists' is different. i.e. If a contract doesn't have Approval Extension,  when we get `approved_account_ids`, it should be `None`, but if a contract does have Approval Extension, then we get `approved_account_ids`, it should be at least empty map, NEVER be `None`.