### PR TITLE
Freelist defrag

### DIFF
--- a/near-sdk/src/store/free_list/mod.rs
+++ b/near-sdk/src/store/free_list/mod.rs
@@ -233,6 +233,8 @@ where
     }
 }
 
+///Defrag struct has helper functions to perform defragmentation of `FreeList`. See the 
+/// documentation of function `FreeList->defrag` for more details.
 struct Defrag<'a, T>
 where
     T: BorshSerialize + BorshDeserialize,
@@ -247,7 +249,7 @@ impl<'a, T> Defrag<'a, T>
 where
     T: BorshSerialize + BorshDeserialize,
 {
-    /// Creates a new iterator for the given storage vector.
+    /// Create a new struct for defragmenting `FreeList`.
     fn new(list: &'a mut FreeList<T>) -> Self {
         Self {
             elements: &mut list.elements,
@@ -264,6 +266,8 @@ where
         while let Some(curr_free_index) = self.next_free_slot() {
             if let Some((value, occupied_index)) = self.next_occupied() {
                 callback(value, curr_free_index.0);
+                //The entry at curr_free_index.0 should have `None` by now.
+                //Moving it to `occupied_index` will make that entry empty.
                 self.elements.swap(curr_free_index.0, occupied_index);
             } else {
                 //Could not find an occupied slot to fill the free slot

--- a/near-sdk/src/store/free_list/mod.rs
+++ b/near-sdk/src/store/free_list/mod.rs
@@ -343,7 +343,7 @@ mod tests {
         let i8 = bucket.insert(8u8);
         assert_eq!(bucket.occupied_count, 8);
 
-        //Empty, Empty, Empty, Empty, Occupied, Occupied, Empty, Empty
+        //Empty, Empty, Empty, Empty, Occupied, Empty, Occupied, Empty
         bucket.remove(i2);
         bucket.remove(i4);
         bucket.remove(i1);

--- a/near-sdk/src/store/free_list/mod.rs
+++ b/near-sdk/src/store/free_list/mod.rs
@@ -227,7 +227,7 @@ where
     /// Empty slots in the front of the list is swapped with occupied slots in back of the list.
     /// Defrag helps reduce gas cost in certain scenarios where lot of elements in front of the list are
     /// removed without getting replaced. Please see https://github.com/near/near-sdk-rs/issues/990
-    pub fn defrag<F>(&mut self, callback: F)
+    pub(crate) fn defrag<F>(&mut self, callback: F)
     where
         F: FnMut(&T, u32),
     {

--- a/near-sdk/src/store/free_list/mod.rs
+++ b/near-sdk/src/store/free_list/mod.rs
@@ -277,14 +277,16 @@ where
                 env::panic_str(ERR_INCONSISTENT_STATE)
             }
         }
-        self.elements.len = self.occupied_count;
+
+        // After defragmenting, these should all be `Slot::Empty`.
+        self.elements.remove_tail(self.elements.len() - self.occupied_count);
     }
 
     fn next_free_slot(&mut self) -> Option<FreeListIndex> {
         while let Some(curr_free_index) = self.curr_free_slot {
-            let curr_slot = self.elements.values.remove(curr_free_index.0);
+            let curr_slot = self.elements.get(curr_free_index.0);
             self.curr_free_slot = match curr_slot {
-                Some(Slot::Empty { next_free }) => next_free,
+                Some(Slot::Empty { next_free }) => *next_free,
                 Some(Slot::Occupied(_)) => {
                     //The free list chain should not have an occupied slot
                     env::panic_str(ERR_INCONSISTENT_STATE)

--- a/near-sdk/src/store/free_list/mod.rs
+++ b/near-sdk/src/store/free_list/mod.rs
@@ -233,8 +233,8 @@ where
     }
 }
 
-///Defrag struct has helper functions to perform defragmentation of `FreeList`. See the
-/// documentation of function `FreeList->defrag` for more details.
+/// Defrag struct has helper functions to perform defragmentation of `FreeList`. See the
+/// documentation of function [`FreeList::defrag`] for more details.
 struct Defrag<'a, T>
 where
     T: BorshSerialize + BorshDeserialize,
@@ -282,6 +282,10 @@ where
             let curr_slot = self.elements.values.remove(curr_free_index.0);
             self.curr_free_slot = match curr_slot {
                 Some(Slot::Empty { next_free }) => next_free,
+                Some(Slot::Occupied(_)) => {
+                    //The free list chain should not have an occupied slot
+                    env::panic_str(ERR_INCONSISTENT_STATE)
+                }
                 _ => None,
             };
             if curr_free_index.0 < self.occupied_count {

--- a/near-sdk/src/store/free_list/mod.rs
+++ b/near-sdk/src/store/free_list/mod.rs
@@ -233,7 +233,7 @@ where
     }
 }
 
-///Defrag struct has helper functions to perform defragmentation of `FreeList`. See the 
+///Defrag struct has helper functions to perform defragmentation of `FreeList`. See the
 /// documentation of function `FreeList->defrag` for more details.
 struct Defrag<'a, T>
 where

--- a/near-sdk/src/store/free_list/mod.rs
+++ b/near-sdk/src/store/free_list/mod.rs
@@ -279,7 +279,7 @@ where
         }
 
         // After defragmenting, these should all be `Slot::Empty`.
-        self.elements.remove_tail(self.elements.len() - self.occupied_count);
+        self.elements.drain(self.occupied_count..);
     }
 
     fn next_free_slot(&mut self) -> Option<FreeListIndex> {

--- a/near-sdk/src/store/mod.rs
+++ b/near-sdk/src/store/mod.rs
@@ -39,7 +39,7 @@
 //! - [`UnorderedMap`]: Storage version of [`std::collections::HashMap`]. No ordering
 //! guarantees.
 //!
-//! - [`TreeMap`] (`unstable`): Storage version of [`std::collections::BTreeMap`]. Ordered by key,
+//! - [`TreeMap`](TreeMap) (`unstable`): Storage version of [`std::collections::BTreeMap`]. Ordered by key,
 //! which comes at the cost of more expensive lookups and iteration.
 //!
 //! Sets:

--- a/near-sdk/src/store/unordered_map/mod.rs
+++ b/near-sdk/src/store/unordered_map/mod.rs
@@ -636,6 +636,32 @@ where
     V: BorshSerialize + BorshDeserialize,
     H: ToKey,
 {
+    /// Remove empty placeholders leftover from calling [`remove`](Self::remove).
+    ///
+    /// When elements are removed using [`remove`](Self::remove), the underlying vector isn't
+    /// rearranged; instead, the removed element is replaced with a placeholder value. These
+    /// empty slots are reused on subsequent [`insert`](Self::insert) operations.
+    ///
+    /// In cases where there are a lot of removals and not a lot of insertions, these leftover
+    /// placeholders might make iteration more costly, driving higher gas costs. This method is meant
+    /// to remedy that by removing all empty slots from the underlying vector and compacting it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use near_sdk::store::UnorderedMap;
+    ///
+    /// let mut map = UnorderedMap::new(b"b");
+    ///
+    /// for i in 0..4 {
+    ///     map.insert(i, i);
+    /// }
+    ///
+    /// map.remove(&1);
+    /// map.remove(&3);
+    ///
+    /// map.defrag();
+    /// ```
     pub fn defrag(&mut self) {
         self.keys.defrag(|key, new_index| {
             // Check if value is in map to replace first

--- a/near-sdk/src/store/unordered_map/mod.rs
+++ b/near-sdk/src/store/unordered_map/mod.rs
@@ -664,9 +664,7 @@ where
     /// ```
     pub fn defrag(&mut self) {
         self.keys.defrag(|key, new_index| {
-            // Check if value is in map to replace first
-            let entry = self.values.get_mut_inner(key);
-            if let Some(existing) = entry.value_mut() {
+            if let Some(existing) = self.values.get_mut(key) {
                 existing.key_index = FreeListIndex(new_index);
             }
         });

--- a/near-sdk/src/store/unordered_map/mod.rs
+++ b/near-sdk/src/store/unordered_map/mod.rs
@@ -535,6 +535,16 @@ where
     /// [`BorshSerialize`] and [`ToOwned<Owned = K>`](ToOwned) on the borrowed form *must* match
     /// those for the key type.
     ///
+    /// # Performance
+    ///
+    /// When elements are removed, the underlying vector of keys isn't
+    /// rearranged; instead, the removed key is replaced with a placeholder value. These
+    /// empty slots are reused on subsequent [`insert`](Self::insert) operations.
+    ///
+    /// In cases where there are a lot of removals and not a lot of insertions, these leftover
+    /// placeholders might make iteration more costly, driving higher gas costs. If you need to
+    /// remedy this, take a look at [`defrag`](Self::defrag).
+    ///
     /// # Examples
     ///
     /// ```
@@ -562,6 +572,16 @@ where
     /// The key may be any borrowed form of the map's key type, but
     /// [`BorshSerialize`] and [`ToOwned<Owned = K>`](ToOwned) on the borrowed form *must* match
     /// those for the key type.
+    ///
+    /// # Performance
+    ///
+    /// When elements are removed, the underlying vector of keys isn't
+    /// rearranged; instead, the removed key is replaced with a placeholder value. These
+    /// empty slots are reused on subsequent [`insert`](Self::insert) operations.
+    ///
+    /// In cases where there are a lot of removals and not a lot of insertions, these leftover
+    /// placeholders might make iteration more costly, driving higher gas costs. If you need to
+    /// remedy this, take a look at [`defrag`](Self::defrag).
     ///
     /// # Examples
     ///

--- a/near-sdk/src/store/unordered_map/mod.rs
+++ b/near-sdk/src/store/unordered_map/mod.rs
@@ -641,7 +641,7 @@ where
             // Check if value is in map to replace first
             let entry = self.values.get_mut_inner(key);
             if let Some(existing) = entry.value_mut() {
-                _ = mem::replace(&mut existing.key_index, FreeListIndex(new_index));
+                existing.key_index = FreeListIndex(new_index);
             }
         });
     }

--- a/near-sdk/src/store/unordered_map/mod.rs
+++ b/near-sdk/src/store/unordered_map/mod.rs
@@ -777,35 +777,33 @@ mod tests {
     #[test]
     fn defrag() {
         let mut map = UnorderedMap::new(b"b");
-        map.insert(0u8, 0u8);
-        map.insert(1, 1);
-        map.insert(2, 2);
-        map.insert(3, 3);
-        map.insert(4, 4);
-        map.insert(5, 5);
-        map.insert(6, 6);
-        map.insert(7, 7);
-        map.insert(8, 8);
 
-        for id in 1..4u8 {
-            map.remove(&(id * 2));
+        let all_indices = 0..=8;
+
+        for i in all_indices {
+            map.insert(i, i);
+        }
+
+        let removed = [2, 4, 6];
+        let existing = [0, 1, 3, 5, 7, 8];
+
+        for id in removed {
+            map.remove(&id);
         }
 
         map.defrag();
 
-        assert!(map.get(&2u8).is_none());
-        assert!(map.get(&4u8).is_none());
-        assert!(map.get(&6u8).is_none());
-        assert_eq!(*map.get(&1u8).unwrap(), 1u8);
-        assert_eq!(*map.get(&3u8).unwrap(), 3u8);
-        assert_eq!(*map.get(&5u8).unwrap(), 5u8);
-        assert_eq!(*map.get(&7u8).unwrap(), 7u8);
-        assert_eq!(*map.get(&8u8).unwrap(), 8u8);
+        for i in removed {
+            assert_eq!(map.get(&i), None);
+        }
+        for i in existing {
+            assert_eq!(map.get(&i), Some(&i));
+        }
 
         //Check the elements moved during defragmentation
-        assert_eq!(map.remove_entry(&7u8).unwrap(), (7, 7));
-        assert_eq!(map.remove_entry(&8u8).unwrap(), (8, 8));
-        assert_eq!(map.remove_entry(&1u8).unwrap(), (1, 1));
-        assert_eq!(map.remove_entry(&3u8).unwrap(), (3, 3));
+        assert_eq!(map.remove_entry(&7).unwrap(), (7, 7));
+        assert_eq!(map.remove_entry(&8).unwrap(), (8, 8));
+        assert_eq!(map.remove_entry(&1).unwrap(), (1, 1));
+        assert_eq!(map.remove_entry(&3).unwrap(), (3, 3));
     }
 }

--- a/near-sdk/src/store/unordered_map/mod.rs
+++ b/near-sdk/src/store/unordered_map/mod.rs
@@ -805,5 +805,7 @@ mod tests {
         //Check the elements moved during defragmentation
         assert_eq!(map.remove_entry(&7u8).unwrap(), (7, 7));
         assert_eq!(map.remove_entry(&8u8).unwrap(), (8, 8));
+        assert_eq!(map.remove_entry(&1u8).unwrap(), (1, 1));
+        assert_eq!(map.remove_entry(&3u8).unwrap(), (3, 3));
     }
 }

--- a/near-sdk/src/store/unordered_set/iter.rs
+++ b/near-sdk/src/store/unordered_set/iter.rs
@@ -190,12 +190,12 @@ where
 {
 }
 
-/// A lazy iterator producing elements in the symmetrical difference of `UnorderedSet`s.
+/// A lazy iterator producing elements in the symmetrical difference of [`UnorderedSet`]s.
 ///
-/// This `struct` is created by the [`symmetrical_difference`] method on [`UnorderedSet`].
+/// This `struct` is created by the [`symmetric_difference`] method on [`UnorderedSet`].
 /// See its documentation for more.
 ///
-/// [`symmetrical_difference`]: UnorderedSet::symmetrical_difference
+/// [`symmetric_difference`]: UnorderedSet::symmetric_difference
 pub struct SymmetricDifference<'a, T, H>
 where
     T: BorshSerialize + Ord + BorshDeserialize,
@@ -284,7 +284,7 @@ where
 {
 }
 
-/// A draining iterator for [`UnorderedMap<K, V, H>`].
+/// A draining iterator for [`UnorderedSet`].
 ///
 /// This `struct` is created by the [`drain`] method on [`UnorderedSet`].
 /// See its documentation for more.

--- a/near-sdk/src/store/vec/mod.rs
+++ b/near-sdk/src/store/vec/mod.rs
@@ -349,7 +349,7 @@ where
         self.values.get_mut(index)
     }
 
-    pub fn swap(&mut self, a: u32, b: u32) {
+    pub(crate) fn swap(&mut self, a: u32, b: u32) {
         if a >= self.len() || b >= self.len() {
             env::panic_str(ERR_INDEX_OUT_OF_BOUNDS);
         }

--- a/near-sdk/src/store/vec/mod.rs
+++ b/near-sdk/src/store/vec/mod.rs
@@ -349,7 +349,7 @@ where
         self.values.get_mut(index)
     }
 
-    fn swap(&mut self, a: u32, b: u32) {
+    pub fn swap(&mut self, a: u32, b: u32) {
         if a >= self.len() || b >= self.len() {
             env::panic_str(ERR_INDEX_OUT_OF_BOUNDS);
         }

--- a/near-sdk/src/store/vec/mod.rs
+++ b/near-sdk/src/store/vec/mod.rs
@@ -408,6 +408,23 @@ where
         prev
     }
 
+    /// Removes the last n elements from a vector. Returns `true` on success.
+    /// If the vector is shorter than n, returns `false` without committing any changes.
+    pub(crate) fn remove_tail(&mut self, n: u32) -> bool {
+        let new_idx = match self.len.checked_sub(n) {
+            Some(new_idx) => new_idx,
+            None => return false,
+        };
+
+        for ix in new_idx..self.len {
+            self.values.remove(ix);
+        }
+
+        self.len = new_idx;
+
+        true
+    }
+
     /// Inserts a element at `index`, returns an evicted element.
     ///
     /// # Panics
@@ -567,6 +584,23 @@ mod tests {
         for _ in 0..501 {
             assert_eq!(baseline.pop(), vec.pop());
         }
+    }
+
+    #[test]
+    fn test_remove_tail() {
+        let mut vec = Vector::new(b"v".to_vec());
+
+        vec.push(5);
+        vec.push(2);
+        vec.push(3);
+        vec.remove_tail(2);
+
+        assert_eq!(vec.len(), 1);
+        assert_eq!(vec.get(0), Some(&5));
+        assert_eq!(vec.get(1), None);
+        assert_eq!(vec.values.get(1), None);
+        assert_eq!(vec.get(2), None);
+        assert_eq!(vec.values.get(2), None);
     }
 
     #[test]

--- a/near-sdk/src/store/vec/mod.rs
+++ b/near-sdk/src/store/vec/mod.rs
@@ -408,23 +408,6 @@ where
         prev
     }
 
-    /// Removes the last n elements from a vector. Returns `true` on success.
-    /// If the vector is shorter than n, returns `false` without committing any changes.
-    pub(crate) fn remove_tail(&mut self, n: u32) -> bool {
-        let new_idx = match self.len.checked_sub(n) {
-            Some(new_idx) => new_idx,
-            None => return false,
-        };
-
-        for ix in new_idx..self.len {
-            self.values.remove(ix);
-        }
-
-        self.len = new_idx;
-
-        true
-    }
-
     /// Inserts a element at `index`, returns an evicted element.
     ///
     /// # Panics
@@ -584,23 +567,6 @@ mod tests {
         for _ in 0..501 {
             assert_eq!(baseline.pop(), vec.pop());
         }
-    }
-
-    #[test]
-    fn test_remove_tail() {
-        let mut vec = Vector::new(b"v".to_vec());
-
-        vec.push(5);
-        vec.push(2);
-        vec.push(3);
-        vec.remove_tail(2);
-
-        assert_eq!(vec.len(), 1);
-        assert_eq!(vec.get(0), Some(&5));
-        assert_eq!(vec.get(1), None);
-        assert_eq!(vec.values.get(1), None);
-        assert_eq!(vec.get(2), None);
-        assert_eq!(vec.values.get(2), None);
     }
 
     #[test]


### PR DESCRIPTION
Closes #990 

This PR picks up where #992 left off (thanks @askoa!). The implementation is mostly the same except:

- `FreeList::defrag` does not interact with `Vector` internals (see comments in #992)
- `Vector` gets the new `remove_tail` method to support the above in a slightly more efficient fashion
- the `defrag` test does not assert stuff irrelevant to the feature - those assertions are instead pulled into new, more atomic tests (`new_bucket_is_empty`, `occupied_count_gets_updated`)