### PR TITLE
fix: add compiler error for using Result with init

### DIFF
--- a/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
@@ -787,6 +787,23 @@ mod tests {
     }
 
     #[test]
+    fn init_result_without_handle_result() {
+        let impl_type: Type = syn::parse_str("Hello").unwrap();
+        let mut method: ImplItemMethod = parse_quote! {
+            #[init]
+            pub fn new() -> Result<Self, &'static str> { }
+        };
+        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let actual = method_info.method_wrapper();
+        let expected = quote!(
+            compile_error! {
+                "Serializing Result<T, E> has been deprecated. Consider marking your method with #[handle_result] if the second generic represents a panicable error or replacing Result with another two type sum enum otherwise. If you really want to keep the legacy behavior, mark the method with #[handle_result] and make it return Result<Result<T, E>, near_sdk::Abort>."
+            }
+        );
+        assert_eq!(expected.to_string(), actual.to_string());
+    }
+
+    #[test]
     fn handle_result_init_ignore_state() {
         let impl_type: Type = syn::parse_str("Hello").unwrap();
         let mut method: ImplItemMethod = parse_quote! {


### PR DESCRIPTION
As reported in #926, currently an `#[init]` method that returns a `Result`, but misses a `#[handle_result]` annotation compiles successfully, but causes problems at runtime.

This PR fixes that, so writing

```rust
#[init]
pub fn new() -> Result<Self, &'static str> { }
```

Now fails to compile with the 

```
Serializing Result<T, E> has been deprecated. Consider marking your method with #[handle_result]...
```

message, but writing

```rust
#[init]
#[handle_result]
pub fn new() -> Result<Self, &'static str> { }
```

compiles successfully as before.