### PR TITLE
Deprecate `Self` in non-init function's return type

### DIFF
--- a/near-sdk-macros/src/core_impl/info_extractor/arg_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/arg_info.rs
@@ -58,7 +58,7 @@ impl ArgInfo {
                 ));
             }
         };
-        *original.ty.as_mut() = utils::sanitize_self(&original.ty, source_type)?;
+        *original.ty.as_mut() = utils::sanitize_self(&original.ty, source_type)?.into();
         let (reference, mutability, ty) =
             utils::extract_ref_mut(original.ty.as_ref(), original.span())?;
         // In the absence of callback attributes this is a regular argument.

--- a/near-sdk-macros/src/core_impl/info_extractor/arg_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/arg_info.rs
@@ -58,7 +58,7 @@ impl ArgInfo {
                 ));
             }
         };
-        *original.ty.as_mut() = utils::sanitize_self(&original.ty, source_type)?.into();
+        *original.ty.as_mut() = utils::sanitize_self(&original.ty, source_type)?.ty;
         let (reference, mutability, ty) =
             utils::extract_ref_mut(original.ty.as_ref(), original.span())?;
         // In the absence of callback attributes this is a regular argument.

--- a/near-sdk-macros/src/core_impl/info_extractor/arg_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/arg_info.rs
@@ -1,6 +1,6 @@
 use crate::core_impl::info_extractor::{SerializerAttr, SerializerType};
 use crate::core_impl::utils;
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::ToTokens;
 use syn::{spanned::Spanned, Attribute, Error, Ident, Pat, PatType, Token, Type};
 
@@ -35,6 +35,8 @@ pub struct ArgInfo {
     pub bindgen_ty: BindgenArgType,
     /// Type of serializer that we use for this argument.
     pub serializer_ty: SerializerType,
+    /// Spans of all occurences of the `Self` token, if any.
+    pub self_occurrences: Vec<Span>,
     /// The original `PatType` of the argument.
     pub original: PatType,
 }
@@ -58,7 +60,8 @@ impl ArgInfo {
                 ));
             }
         };
-        *original.ty.as_mut() = utils::sanitize_self(&original.ty, source_type)?.ty;
+        let sanitize_self = utils::sanitize_self(&original.ty, source_type)?;
+        *original.ty.as_mut() = sanitize_self.ty;
         let (reference, mutability, ty) =
             utils::extract_ref_mut(original.ty.as_ref(), original.span())?;
         // In the absence of callback attributes this is a regular argument.
@@ -106,6 +109,7 @@ impl ArgInfo {
             ty,
             bindgen_ty,
             serializer_ty,
+            self_occurrences: sanitize_self.self_occurrences,
             original: original.clone(),
         })
     }

--- a/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
@@ -146,7 +146,7 @@ impl AttrSigInfo {
         original_sig: &mut Signature,
         source_type: &TokenStream2,
     ) -> syn::Result<Self> {
-        let self_occurrences = Self::sanitize_self(original_sig, source_type)?;
+        let mut self_occurrences = Self::sanitize_self(original_sig, source_type)?;
 
         let mut errors = vec![];
         for generic in &original_sig.generics.params {
@@ -214,6 +214,8 @@ impl AttrSigInfo {
             }
         }
 
+        self_occurrences.extend(args.iter().map(|arg| arg.self_occurrences.clone()).flatten());
+
         let method_kind = visitor.build()?;
 
         *original_attrs = non_bindgen_attrs.clone();
@@ -224,7 +226,7 @@ impl AttrSigInfo {
             // TODO: return an error instead in 5.0
             // see https://github.com/near/near-sdk-rs/issues/1005
             println!(
-                "near_bindgen: references to `Self` in non-init method return types will be forbidden in 5.0"
+                "near_bindgen: references to `Self` in non-init methods will be forbidden in 5.0"
             );
 
             // Once proc_macro::Diagnostic is stabilized, we could start getting rid of the `println` and
@@ -236,6 +238,7 @@ impl AttrSigInfo {
             //     "references to `Self` in non-init methods will be forbidden in 5.0",
             // )
             // .emit();
+            //
         }
 
         let mut result: AttrSigInfo = AttrSigInfoV2 {

--- a/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
@@ -214,7 +214,7 @@ impl AttrSigInfo {
             }
         }
 
-        self_occurrences.extend(args.iter().map(|arg| arg.self_occurrences.clone()).flatten());
+        self_occurrences.extend(args.iter().flat_map(|arg| arg.self_occurrences.clone()));
 
         let method_kind = visitor.build()?;
 

--- a/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
@@ -124,10 +124,10 @@ impl AttrSigInfo {
             ReturnType::Type(_, ref mut ty) => {
                 match ty.as_mut() {
                     x @ (Type::Array(_) | Type::Path(_) | Type::Tuple(_) | Type::Group(_)) => {
-                        *ty = utils::sanitize_self(x, source_type)?.into();
+                        *ty = utils::sanitize_self(x, source_type)?.ty.into();
                     }
                     Type::Reference(ref mut r) => {
-                        r.elem = utils::sanitize_self(&r.elem, source_type)?.into();
+                        r.elem = utils::sanitize_self(&r.elem, source_type)?.ty.into();
                     }
                     _ => return Err(Error::new(ty.span(), "Unsupported contract API type.")),
                 };
@@ -212,6 +212,13 @@ impl AttrSigInfo {
         let method_kind = visitor.build()?;
 
         *original_attrs = non_bindgen_attrs.clone();
+        let returns = match &original_sig.output {
+            ReturnType::Default => ReturnType::Default,
+            ReturnType::Type(arrow, ty) => {
+                let (_, _, ty) = utils::extract_ref_mut(ty, ty.span())?;
+                ReturnType::Type(*arrow, utils::sanitize_self(&ty, source_type)?.ty.into())
+            }
+        };
 
         let mut result: AttrSigInfo = AttrSigInfoV2 {
             ident,

--- a/near-sdk-macros/src/core_impl/utils/mod.rs
+++ b/near-sdk-macros/src/core_impl/utils/mod.rs
@@ -113,29 +113,49 @@ pub(crate) fn sig_is_supported(sig: &Signature) -> syn::Result<()> {
     Ok(())
 }
 
-fn _sanitize_self(typ: TokenStream2, replace_with: &TokenStream2) -> TokenStream2 {
+fn _sanitize_self(typ: TokenStream2, replace_with: &TokenStream2) -> (TokenStream2, bool) {
+    let mut self_occurred = false;
     let trees = typ.into_iter().map(|t| match t {
-        TokenTree::Ident(ident) if ident == "Self" => replace_with
-            .clone()
-            .into_iter()
-            .map(|mut t| {
-                t.set_span(ident.span());
-                t
-            })
-            .collect::<TokenStream2>(),
+        TokenTree::Ident(ident) if ident == "Self" => {
+            self_occurred = true;
+            replace_with
+                .clone()
+                .into_iter()
+                .map(|mut t| {
+                    t.set_span(ident.span());
+                    t
+                })
+                .collect::<TokenStream2>()
+        }
         TokenTree::Group(group) => {
-            let stream = _sanitize_self(group.stream(), replace_with);
+            let (stream, self_occurred_inner) = _sanitize_self(group.stream(), replace_with);
+            self_occurred |= self_occurred_inner;
             TokenTree::Group(Group::new(group.delimiter(), stream)).into()
         }
         rest => rest.into(),
     });
-    trees.collect()
+    (trees.collect(), self_occurred)
 }
 
-pub fn sanitize_self(typ: &Type, replace_with: &TokenStream2) -> syn::Result<Type> {
-    syn::parse2(_sanitize_self(quote! { #typ }, replace_with)).map_err(|original| {
-        syn::Error::new(original.span(), "Self sanitization failed. Please report this as a bug.")
-    })
+pub fn sanitize_self(typ: &Type, replace_with: &TokenStream2) -> syn::Result<SanitizeSelfResult> {
+    let (ty_tokens, self_occurred) = _sanitize_self(quote! { #typ }, replace_with);
+
+    let ty = syn::parse2(ty_tokens).map_err(|original| {
+        syn::Error::new(original.span(), "`Self` sanitization failed. Please report this as a bug.")
+    })?;
+
+    Ok(SanitizeSelfResult { ty, self_occurred })
+}
+
+pub struct SanitizeSelfResult {
+    pub ty: Type,
+    pub self_occurred: bool,
+}
+
+impl From<SanitizeSelfResult> for Type {
+    fn from(value: SanitizeSelfResult) -> Self {
+        value.ty
+    }
 }
 
 #[cfg(test)]
@@ -146,25 +166,43 @@ mod tests {
     fn sanitize_self_works() {
         let typ: Type = syn::parse_str("Self").unwrap();
         let replace_with: TokenStream2 = syn::parse_str("MyType").unwrap();
-        let sanitized = sanitize_self(&typ, &replace_with).unwrap();
+        let sanitized = sanitize_self(&typ, &replace_with).unwrap().ty;
         assert_eq!(quote! { #sanitized }.to_string(), "MyType");
 
         let typ: Type = syn::parse_str("Vec<Self>").unwrap();
         let replace_with: TokenStream2 = syn::parse_str("MyType").unwrap();
-        let sanitized = sanitize_self(&typ, &replace_with).unwrap();
+        let sanitized = sanitize_self(&typ, &replace_with).unwrap().ty;
         assert_eq!(quote! { #sanitized }.to_string(), "Vec < MyType >");
 
         let typ: Type = syn::parse_str("Vec<Vec<Self>>").unwrap();
         let replace_with: TokenStream2 = syn::parse_str("MyType").unwrap();
-        let sanitized = sanitize_self(&typ, &replace_with).unwrap();
+        let sanitized = sanitize_self(&typ, &replace_with).unwrap().ty;
         assert_eq!(quote! { #sanitized }.to_string(), "Vec < Vec < MyType > >");
 
         let typ: Type = syn::parse_str("Option<[(Self, Result<Self, ()>); 2]>").unwrap();
         let replace_with: TokenStream2 = syn::parse_str("MyType").unwrap();
-        let sanitized = sanitize_self(&typ, &replace_with).unwrap();
+        let sanitized = sanitize_self(&typ, &replace_with).unwrap().ty;
         assert_eq!(
             quote! { #sanitized }.to_string(),
             "Option < [(MyType , Result < MyType , () >) ; 2] >"
         );
+    }
+
+    #[test]
+    fn sanitize_self_keeps_track_of_replacements() {
+        let typ: Type = syn::parse_str("Self").unwrap();
+        let replace_with: TokenStream2 = syn::parse_str("MyType").unwrap();
+        let occurred = sanitize_self(&typ, &replace_with).unwrap().self_occurred;
+        assert!(occurred);
+
+        let typ: Type = syn::parse_str("SomeType").unwrap();
+        let replace_with: TokenStream2 = syn::parse_str("MyType").unwrap();
+        let occurred = sanitize_self(&typ, &replace_with).unwrap().self_occurred;
+        assert!(!occurred);
+
+        let typ: Type = syn::parse_str("Option<[(Self, Result<Self, ()>); 2]>").unwrap();
+        let replace_with: TokenStream2 = syn::parse_str("MyType").unwrap();
+        let occurred = sanitize_self(&typ, &replace_with).unwrap().self_occurred;
+        assert!(occurred);
     }
 }

--- a/near-sdk/compilation_tests/all.rs
+++ b/near-sdk/compilation_tests/all.rs
@@ -25,4 +25,9 @@ fn compilation_tests() {
     t.compile_fail("compilation_tests/generic_function.rs");
     t.compile_fail("compilation_tests/generic_const_function.rs");
     t.pass("compilation_tests/self_support.rs");
+    // The following couple tests should be activated before releasing 5.0
+    // See: https://github.com/near/near-sdk-rs/issues/1005
+    //
+    // t.compile_fail("compilation_tests/self_forbidden_in_non_init_fn_return.rs");
+    // t.compile_fail("compilation_tests/self_forbidden_in_non_init_fn_arg.rs");
 }

--- a/near-sdk/compilation_tests/cond_compilation.rs
+++ b/near-sdk/compilation_tests/cond_compilation.rs
@@ -1,7 +1,7 @@
 //! Rust contract that uses conditional compilation.
 
-use near_sdk::near_bindgen;
 use borsh::{BorshDeserialize, BorshSerialize};
+use near_sdk::near_bindgen;
 
 #[near_bindgen]
 #[derive(Default, BorshDeserialize, BorshSerialize)]
@@ -12,13 +12,15 @@ struct Incrementer {
 #[near_bindgen]
 impl Incrementer {
     #[cfg(feature = "myfeature")]
+    #[init]
     pub fn new() -> Self {
-        Self {value: 0}
+        Self { value: 0 }
     }
 
     #[cfg(not(feature = "myfeature"))]
+    #[init]
     pub fn new() -> Self {
-        Self {value: 1}
+        Self { value: 1 }
     }
 
     #[cfg(feature = "myfeature")]

--- a/near-sdk/compilation_tests/self_forbidden_in_non_init_fn_arg.rs
+++ b/near-sdk/compilation_tests/self_forbidden_in_non_init_fn_arg.rs
@@ -1,0 +1,19 @@
+//! Method signature uses Self.
+
+use near_sdk::near_bindgen;
+use serde::{Deserialize, Serialize};
+
+#[near_bindgen]
+#[derive(Default, Serialize, Deserialize)]
+pub struct Ident {
+    value: u32,
+}
+
+#[near_bindgen]
+impl Ident {
+    pub fn plain_arg(_value: Option<Self>) {
+        unimplemented!()
+    }
+}
+
+fn main() {}

--- a/near-sdk/compilation_tests/self_forbidden_in_non_init_fn_return.rs
+++ b/near-sdk/compilation_tests/self_forbidden_in_non_init_fn_return.rs
@@ -1,0 +1,19 @@
+//! Method signature uses Self.
+
+use near_sdk::near_bindgen;
+use serde::{Deserialize, Serialize};
+
+#[near_bindgen]
+#[derive(Default, Serialize, Deserialize)]
+pub struct Ident {
+    value: u32,
+}
+
+#[near_bindgen]
+impl Ident {
+    pub fn plain_ret() -> Self {
+        unimplemented!()
+    }
+}
+
+fn main() {}

--- a/near-sdk/compilation_tests/self_support.rs
+++ b/near-sdk/compilation_tests/self_support.rs
@@ -11,30 +11,47 @@ pub struct Ident {
 
 #[near_bindgen]
 impl Ident {
-    pub fn plain_arg(_a: Self) {
+    #[init]
+    pub fn plain_arg(_a: Self) -> Self {
         unimplemented!()
     }
+
+    #[init]
     pub fn plain_ret() -> Self {
         unimplemented!()
     }
+
+    #[init]
     pub fn plain_arg_ret(a: Self) -> Self {
         a
     }
-    pub fn nested_arg(_a: Vec<Self>) {
+
+    #[init]
+    pub fn nested_arg(_a: Vec<Self>) -> Self {
         unimplemented!()
     }
+
+    #[init]
     pub fn nested_ret() -> Vec<Self> {
         unimplemented!()
     }
+
+    #[init]
     pub fn nested_arg_ret(a: Vec<Self>) -> Vec<Self> {
         a
     }
-    pub fn deeply_nested_arg(_a: Option<[(Self, Result<Self, ()>); 2]>) {
+
+    #[init]
+    pub fn deeply_nested_arg(_a: Option<[(Self, Result<Self, ()>); 2]>) -> Self {
         unimplemented!()
     }
+
+    #[init]
     pub fn deeply_nested_ret() -> Option<[(Self, Result<Self, ()>); 2]> {
         unimplemented!()
     }
+
+    #[init]
     pub fn deeply_nested_arg_ret(
         a: Option<[(Self, Result<Self, ()>); 2]>,
     ) -> Option<[(Self, Result<Self, ()>); 2]> {


### PR DESCRIPTION
This is part of #1005, but doesn't close the issue.

I really wanted to produce nice compiler warnings with spans using the Proper Way, but [the API is unstable](https://doc.rust-lang.org/proc_macro/struct.Diagnostic.html). I've turned to the dark side and am using `println` instead. Happy for ideas on how to improve this!

The code already collects spans of all forbidden `Self` tokens. Once we switch to prohibiting this completely, it should be easy to emit compile errors using these spans with a much better DX.