### PR TITLE
refactor: change private init method from error to warning

### DIFF
--- a/near-sdk-macros/src/core_impl/info_extractor/visitor.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/visitor.rs
@@ -86,7 +86,7 @@ impl Visitor {
         }
     }
 
-    pub fn visit_private_attr(&mut self, attr: &Attribute) -> syn::Result<()> {
+    pub fn visit_private_attr(&mut self, _attr: &Attribute) -> syn::Result<()> {
         use VisitorKind::*;
 
         match self.kind {
@@ -95,8 +95,13 @@ impl Visitor {
                 Ok(())
             }
             Init => {
-                let message = format!("{} function can't be private.", self.kind);
-                Err(Error::new(attr.span(), message))
+                // TODO: return an error instead in 5.0
+                // see https://github.com/near/near-sdk-rs/issues/1040
+                println!("near_bindgen: private init functions will be disallowed in 5.0");
+                Ok(())
+
+                // let message = format!("{} function can't be private.", self.kind);
+                // Err(Error::new(attr.span(), message))
             }
         }
     }


### PR DESCRIPTION
As discussed in #1040, we jumped the gun on disallowing private init methods. In 4.x they should be deprecated and only disallowed in 5.0.

This PR rolls back emitting a compilation error for private init methods and instead just logs a warning. 

We cannot use the `#[deprecated]` attribute, since the `#[private]` attribute itself is not deprecated. 

Using the [`Diagnostic`](https://doc.rust-lang.org/proc_macro/struct.Diagnostic.html#method.warning) would be more elegant than a `println`, but unfortunately it's unstable at this time.

