### PR TITLE
ci: cover all features with clippy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - name: Test Format
         run: cargo fmt -- --check
-      - run: cargo clippy --features unstable,legacy --tests -- -Dclippy::all
+      - run: cargo clippy --tests --all-features -- -Dclippy::all
   windows:
     name: Windows
     runs-on: windows-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,10 +18,6 @@ Please use descriptive PR titles. We loosely follow the [conventional commits](h
 
 Ensure the following are satisfied before opening a PR:
 - Code is formatted with `rustfmt` by running `cargo fmt`
-- Run `clippy`
-  - The exact command run by the CI is `cargo clippy --tests -- -Dclippy::all`
-- Run tests with `cargo test`
-- Test all examples with `./examples/test_all.sh`
-  - This must be done after the previous step
+- Run all tests and linters with [./run-tests.sh](./run-tests.sh)
 - Ensure any new functionality is adequately tested
 - If any new public types or functions are added, ensure they have appropriate [rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) documentation

--- a/near-sdk-macros/src/core_impl/abi/abi_generator.rs
+++ b/near-sdk-macros/src/core_impl/abi/abi_generator.rs
@@ -210,7 +210,7 @@ impl ImplItemMethodInfo {
         use MethodKind::*;
 
         let some_abi_type = |result_serializer: &SerializerType| {
-            let abi_type = generate_abi_type(&return_value_type, result_serializer);
+            let abi_type = generate_abi_type(return_value_type, result_serializer);
             quote! { Some(#abi_type) }
         };
 
@@ -250,7 +250,7 @@ fn generate_schema(ty: &Type, serializer_type: &SerializerType) -> TokenStream2 
 }
 
 fn generate_abi_type(ty: &Type, serializer_type: &SerializerType) -> TokenStream2 {
-    let schema = generate_schema(&ty, serializer_type);
+    let schema = generate_schema(ty, serializer_type);
     match serializer_type {
         SerializerType::JSON => quote! {
             near_sdk::__private::AbiType::Json {

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+cargo fmt --check --all
+cargo clippy --tests --all-features -- -Dclippy::all
+cargo test --all --features unstable,legacy
+./examples/test_all.sh


### PR DESCRIPTION
This PR changes the flags to `clippy` in the CI to cover all features. Previously the abi generator code in bindgen wasn't covered.

There are two related commits in this branch:

470c3769834f44a9d20ee0b2d8eb13c70aaecf12 to fix the error discovered by expanding `clippy` coverage.
a077e8cfb4162c8d48bd1781abe2722631de4501 to provide a single script to run all checks locally that are ran by the CI.