### PR TITLE
Use global paths in macro expansions

### DIFF
--- a/near-sdk-macros/src/core_impl/abi/abi_embed.rs
+++ b/near-sdk-macros/src/core_impl/abi/abi_embed.rs
@@ -5,10 +5,10 @@ pub fn embed() -> TokenStream2 {
     let abi_path = env!("CARGO_NEAR_ABI_PATH");
     quote! {
         const _: () = {
-            const __CONTRACT_ABI: &'static [u8] = include_bytes!(#abi_path);
+            const __CONTRACT_ABI: &'static [u8] = ::std::include_bytes!(#abi_path);
             #[no_mangle]
             pub extern "C" fn __contract_abi() {
-                near_sdk::env::value_return(__CONTRACT_ABI);
+                ::near_sdk::env::value_return(__CONTRACT_ABI);
             }
         };
     }

--- a/near-sdk-macros/src/core_impl/code_generator/ext.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/ext.rs
@@ -13,12 +13,12 @@ pub(crate) fn generate_ext_structs(
     let name = format_ident!("{}Ext", ident);
     let mut ext_code = quote! {
         /// API for calling this contract's functions in a subsequent execution.
-        pub fn ext(account_id: near_sdk::AccountId) -> #name {
+        pub fn ext(account_id: ::near_sdk::AccountId) -> #name {
             #name {
                 account_id,
                 deposit: 0,
-                static_gas: near_sdk::Gas(0),
-                gas_weight: near_sdk::GasWeight::default(),
+                static_gas: ::near_sdk::Gas(0),
+                gas_weight: ::near_sdk::GasWeight::default(),
             }
         }
     };
@@ -34,23 +34,23 @@ pub(crate) fn generate_ext_structs(
     quote! {
       #[must_use]
       pub struct #name {
-          pub(crate) account_id: near_sdk::AccountId,
-          pub(crate) deposit: near_sdk::Balance,
-          pub(crate) static_gas: near_sdk::Gas,
-          pub(crate) gas_weight: near_sdk::GasWeight,
+          pub(crate) account_id: ::near_sdk::AccountId,
+          pub(crate) deposit: ::near_sdk::Balance,
+          pub(crate) static_gas: ::near_sdk::Gas,
+          pub(crate) gas_weight: ::near_sdk::GasWeight,
       }
 
       impl #name {
-          pub fn with_attached_deposit(mut self, amount: near_sdk::Balance) -> Self {
+          pub fn with_attached_deposit(mut self, amount: ::near_sdk::Balance) -> Self {
               self.deposit = amount;
               self
           }
-          pub fn with_static_gas(mut self, static_gas: near_sdk::Gas) -> Self {
+          pub fn with_static_gas(mut self, static_gas: ::near_sdk::Gas) -> Self {
               self.static_gas = static_gas;
               self
           }
           pub fn with_unused_gas_weight(mut self, gas_weight: u64) -> Self {
-              self.gas_weight = near_sdk::GasWeight(gas_weight);
+              self.gas_weight = ::near_sdk::GasWeight(gas_weight);
               self
           }
       }
@@ -127,11 +127,11 @@ fn generate_ext_function(attr_signature_info: &AttrSigInfo) -> TokenStream2 {
     let Signature { generics, .. } = original_sig;
     quote! {
         #new_non_bindgen_attrs
-        pub fn #ident #generics(self, #pat_type_list) -> near_sdk::Promise {
+        pub fn #ident #generics(self, #pat_type_list) -> ::near_sdk::Promise {
             let __args = #serialize;
-            near_sdk::Promise::new(self.account_id)
+            ::near_sdk::Promise::new(self.account_id)
             .function_call_weight(
-                #ident_str.to_string(),
+                ::std::string::String::from(#ident_str),
                 __args,
                 self.deposit,
                 self.static_gas,
@@ -157,33 +157,33 @@ mod tests {
         let expected = quote!(
           #[must_use]
           pub struct TestExt {
-              pub(crate) account_id: near_sdk::AccountId,
-              pub(crate) deposit: near_sdk::Balance,
-              pub(crate) static_gas: near_sdk::Gas,
-              pub(crate) gas_weight: near_sdk::GasWeight,
+              pub(crate) account_id: ::near_sdk::AccountId,
+              pub(crate) deposit: ::near_sdk::Balance,
+              pub(crate) static_gas: ::near_sdk::Gas,
+              pub(crate) gas_weight: ::near_sdk::GasWeight,
           }
           impl TestExt {
-              pub fn with_attached_deposit(mut self, amount: near_sdk::Balance) -> Self {
+              pub fn with_attached_deposit(mut self, amount: ::near_sdk::Balance) -> Self {
                   self.deposit = amount;
                   self
               }
-              pub fn with_static_gas(mut self, static_gas: near_sdk::Gas) -> Self {
+              pub fn with_static_gas(mut self, static_gas: ::near_sdk::Gas) -> Self {
                   self.static_gas = static_gas;
                   self
               }
               pub fn with_unused_gas_weight(mut self, gas_weight: u64) -> Self {
-                  self.gas_weight = near_sdk::GasWeight(gas_weight);
+                  self.gas_weight = ::near_sdk::GasWeight(gas_weight);
                   self
               }
           }
           impl Test {
             /// API for calling this contract's functions in a subsequent execution.
-            pub fn ext(account_id: near_sdk::AccountId) -> TestExt {
+            pub fn ext(account_id: ::near_sdk::AccountId) -> TestExt {
                 TestExt {
                     account_id,
                     deposit: 0,
-                    static_gas: near_sdk::Gas(0),
-                    gas_weight: near_sdk::GasWeight::default(),
+                    static_gas: ::near_sdk::Gas(0),
+                    gas_weight: ::near_sdk::GasWeight::default(),
                 }
             }
           }
@@ -198,32 +198,32 @@ mod tests {
         let expected = quote!(
           #[must_use]
           pub struct TestExt {
-              pub(crate) account_id: near_sdk::AccountId,
-              pub(crate) deposit: near_sdk::Balance,
-              pub(crate) static_gas: near_sdk::Gas,
-              pub(crate) gas_weight: near_sdk::GasWeight,
+              pub(crate) account_id: ::near_sdk::AccountId,
+              pub(crate) deposit: ::near_sdk::Balance,
+              pub(crate) static_gas: ::near_sdk::Gas,
+              pub(crate) gas_weight: ::near_sdk::GasWeight,
           }
           impl TestExt {
-              pub fn with_attached_deposit(mut self, amount: near_sdk::Balance) -> Self {
+              pub fn with_attached_deposit(mut self, amount: ::near_sdk::Balance) -> Self {
                   self.deposit = amount;
                   self
               }
-              pub fn with_static_gas(mut self, static_gas: near_sdk::Gas) -> Self {
+              pub fn with_static_gas(mut self, static_gas: ::near_sdk::Gas) -> Self {
                   self.static_gas = static_gas;
                   self
               }
               pub fn with_unused_gas_weight(mut self, gas_weight: u64) -> Self {
-                  self.gas_weight = near_sdk::GasWeight(gas_weight);
+                  self.gas_weight = ::near_sdk::GasWeight(gas_weight);
                   self
               }
           }
           /// API for calling this contract's functions in a subsequent execution.
-          pub fn ext(account_id: near_sdk::AccountId) -> TestExt {
+          pub fn ext(account_id: ::near_sdk::AccountId) -> TestExt {
               TestExt {
                   account_id,
                   deposit: 0,
-                  static_gas: near_sdk::Gas(0),
-                  gas_weight: near_sdk::GasWeight::default(),
+                  static_gas: ::near_sdk::Gas(0),
+                  gas_weight: ::near_sdk::GasWeight::default(),
               }
           }
         );
@@ -247,10 +247,10 @@ mod tests {
         // Note: only whitelisted non-bindgen attributes are forwarded.
         let expected = quote! {
             #[cfg(target_os = "linux")]
-            pub fn method (self,) -> near_sdk::Promise {
-                let __args = vec![];
-                near_sdk::Promise::new(self.account_id).function_call_weight(
-                    "method".to_string(),
+            pub fn method (self,) -> ::near_sdk::Promise {
+                let __args = ::std::vec![];
+                ::near_sdk::Promise::new(self.account_id).function_call_weight(
+                    ::std::string::String::from("method"),
                     __args,
                     self.deposit,
                     self.static_gas,
@@ -270,18 +270,18 @@ mod tests {
         let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
         let actual = generate_ext_function(&method_info.attr_signature_info);
         let expected = quote!(
-            pub fn method(self, k: &String,) -> near_sdk::Promise {
-                let __args = {#[derive(near_sdk :: serde :: Serialize)]
-                    #[serde(crate = "near_sdk::serde")]
+            pub fn method(self, k: &String,) -> ::near_sdk::Promise {
+                let __args = {#[derive(::near_sdk :: serde :: Serialize)]
+                    #[serde(crate = "::near_sdk::serde")]
                     struct Input<'nearinput> {
                         k: &'nearinput String,
                     }
                     let __args = Input { k: &k, };
-                    near_sdk::serde_json::to_vec(&__args)
+                    ::near_sdk::serde_json::to_vec(&__args)
                         .expect("Failed to serialize the cross contract args using JSON.")
                 };
-                near_sdk::Promise::new(self.account_id).function_call_weight(
-                    "method".to_string(),
+                ::near_sdk::Promise::new(self.account_id).function_call_weight(
+                    ::std::string::String::from("method"),
                     __args,
                     self.deposit,
                     self.static_gas,
@@ -301,19 +301,19 @@ mod tests {
         let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
         let actual = generate_ext_function(&method_info.attr_signature_info);
         let expected = quote!(
-          pub fn borsh_test(self, a: String,) -> near_sdk::Promise {
+          pub fn borsh_test(self, a: String,) -> ::near_sdk::Promise {
             let __args = {
-              #[derive(near_sdk :: borsh :: BorshSerialize)]
+              #[derive(::near_sdk :: borsh :: BorshSerialize)]
               struct Input<'nearinput> {
                   a: &'nearinput String,
               }
               let __args = Input { a: &a, };
-              near_sdk::borsh::BorshSerialize::try_to_vec(&__args)
+              ::near_sdk::borsh::BorshSerialize::try_to_vec(&__args)
                   .expect("Failed to serialize the cross contract args using Borsh.")
             };
-              near_sdk::Promise::new(self.account_id)
+              ::near_sdk::Promise::new(self.account_id)
                   .function_call_weight(
-                      "borsh_test".to_string(),
+                      ::std::string::String::from("borsh_test"),
                       __args,
                       self.deposit,
                       self.static_gas,

--- a/near-sdk-macros/src/core_impl/code_generator/impl_item_method_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/impl_item_method_info.rs
@@ -89,19 +89,19 @@ impl ImplItemMethodInfo {
             #contract_init
             #method_invocation_with_return
             match #result_identifier {
-                Ok(#result_identifier) => {
+                ::std::result::Result::Ok(#result_identifier) => {
                     #value_ser
                     #value_return
                     #contract_ser
                 }
-                Err(err) => near_sdk::FunctionError::panic(&err)
+                ::std::result::Result::Err(err) => ::near_sdk::FunctionError::panic(&err)
             }
         }
     }
 
     fn panic_hook_tokens(&self) -> TokenStream2 {
         quote! {
-            near_sdk::env::setup_panic_hook();
+            ::near_sdk::env::setup_panic_hook();
         }
     }
 
@@ -118,13 +118,13 @@ impl ImplItemMethodInfo {
             let decomposition = self.attr_signature_info.decomposition_pattern();
             let serializer_invocation = match self.attr_signature_info.input_serializer {
                 SerializerType::JSON => quote! {
-                    near_sdk::serde_json::from_slice(
-                        &near_sdk::env::input().expect("Expected input since method has arguments.")
+                    ::near_sdk::serde_json::from_slice(
+                        &::near_sdk::env::input().expect("Expected input since method has arguments.")
                     ).expect("Failed to deserialize input from JSON.")
                 },
                 SerializerType::Borsh => quote! {
-                    near_sdk::borsh::BorshDeserialize::try_from_slice(
-                        &near_sdk::env::input().expect("Expected input since method has arguments.")
+                    ::near_sdk::borsh::BorshDeserialize::try_from_slice(
+                        &::near_sdk::env::input().expect("Expected input since method has arguments.")
                     ).expect("Failed to deserialize input from Borsh.")
                 },
             };
@@ -143,8 +143,8 @@ impl ImplItemMethodInfo {
             // If method is not payable, do a check to make sure that it doesn't consume deposit
             let error = format!("Method {} doesn't accept deposit", self.attr_signature_info.ident);
             quote! {
-                if near_sdk::env::attached_deposit() != 0 {
-                    near_sdk::env::panic_str(#error);
+                if ::near_sdk::env::attached_deposit() != 0 {
+                    ::near_sdk::env::panic_str(#error);
                 }
             }
         };
@@ -174,8 +174,8 @@ impl ImplItemMethodInfo {
         if self.attr_signature_info.is_private() {
             let error = format!("Method {} is private", self.attr_signature_info.ident);
             quote! {
-                if near_sdk::env::current_account_id() != near_sdk::env::predecessor_account_id() {
-                    near_sdk::env::panic_str(#error);
+                if ::near_sdk::env::current_account_id() != ::near_sdk::env::predecessor_account_id() {
+                    ::near_sdk::env::panic_str(#error);
                 }
             }
         } else {
@@ -194,8 +194,8 @@ impl ImplItemMethodInfo {
             Init(init_method) => {
                 if !init_method.ignores_state {
                     quote! {
-                        if near_sdk::env::state_exists() {
-                            near_sdk::env::panic_str("The contract has already been initialized");
+                        if ::near_sdk::env::state_exists() {
+                            ::near_sdk::env::panic_str("The contract has already been initialized");
                         }
                     }
                 } else {
@@ -218,7 +218,7 @@ impl ImplItemMethodInfo {
             let mutability = receiver.mutability;
 
             quote! {
-                let #mutability contract: #struct_type = near_sdk::env::state_read().unwrap_or_default();
+                let #mutability contract: #struct_type = ::near_sdk::env::state_read().unwrap_or_default();
             }
         };
 
@@ -252,7 +252,7 @@ impl ImplItemMethodInfo {
 
         fn contract_ser() -> TokenStream2 {
             quote! {
-                near_sdk::env::state_write(&contract);
+                ::near_sdk::env::state_write(&contract);
             }
         }
 
@@ -337,10 +337,10 @@ impl ImplItemMethodInfo {
 
         let value_ser = |result_serializer: &SerializerType| match result_serializer {
             SerializerType::JSON => quote! {
-                let result = near_sdk::serde_json::to_vec(&result).expect("Failed to serialize the return value using JSON.");
+                let result = ::near_sdk::serde_json::to_vec(&result).expect("Failed to serialize the return value using JSON.");
             },
             SerializerType::Borsh => quote! {
-                let result = near_sdk::borsh::BorshSerialize::try_to_vec(&result).expect("Failed to serialize the return value using Borsh.");
+                let result = ::near_sdk::borsh::BorshSerialize::try_to_vec(&result).expect("Failed to serialize the return value using Borsh.");
             },
         };
 
@@ -360,7 +360,7 @@ impl ImplItemMethodInfo {
 
         let value_return = || {
             quote! {
-                near_sdk::env::value_return(&result);
+                ::near_sdk::env::value_return(&result);
             }
         };
 

--- a/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
@@ -43,8 +43,8 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn method() {
-                near_sdk::env::setup_panic_hook();
-                let contract: Hello = near_sdk::env::state_read().unwrap_or_default();
+                ::near_sdk::env::setup_panic_hook();
+                let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
                 contract.method();
             }
         );
@@ -61,8 +61,8 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn method() {
-                near_sdk::env::setup_panic_hook();
-                let contract: Hello = near_sdk::env::state_read().unwrap_or_default();
+                ::near_sdk::env::setup_panic_hook();
+                let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
                 contract.method();
             }
         );
@@ -79,8 +79,8 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn method() {
-                near_sdk::env::setup_panic_hook();
-                let contract: Hello = near_sdk::env::state_read().unwrap_or_default();
+                ::near_sdk::env::setup_panic_hook();
+                let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
                 contract.method();
             }
         );
@@ -98,8 +98,8 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn method() {
-                near_sdk::env::setup_panic_hook();
-                let mut contract: Hello = near_sdk::env::state_read().unwrap_or_default();
+                ::near_sdk::env::setup_panic_hook();
+                let mut contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
                 contract.method();
             }
         );
@@ -116,13 +116,13 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn method() {
-                near_sdk::env::setup_panic_hook();
-                if near_sdk::env::attached_deposit() != 0 {
-                    near_sdk::env::panic_str("Method method doesn't accept deposit");
+                ::near_sdk::env::setup_panic_hook();
+                if ::near_sdk::env::attached_deposit() != 0 {
+                    ::near_sdk::env::panic_str("Method method doesn't accept deposit");
                 }
-                let mut contract: Hello = near_sdk::env::state_read().unwrap_or_default();
+                let mut contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
                 contract.method();
-                near_sdk::env::state_write(&contract);
+                ::near_sdk::env::state_write(&contract);
             }
         );
         assert_eq!(expected.to_string(), actual.to_string());
@@ -138,17 +138,17 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn method() {
-                near_sdk::env::setup_panic_hook();
-                #[derive(near_sdk :: serde :: Deserialize)]
-                #[serde(crate = "near_sdk::serde")]
+                ::near_sdk::env::setup_panic_hook();
+                #[derive(::near_sdk :: serde :: Deserialize)]
+                #[serde(crate = "::near_sdk::serde")]
                 struct Input {
                     k: u64,
                 }
-                let Input { k, }: Input = near_sdk::serde_json::from_slice(
-                    &near_sdk::env::input().expect("Expected input since method has arguments.")
+                let Input { k, }: Input = ::near_sdk::serde_json::from_slice(
+                    &::near_sdk::env::input().expect("Expected input since method has arguments.")
                 )
                 .expect("Failed to deserialize input from JSON.");
-                let contract: Hello = near_sdk::env::state_read().unwrap_or_default();
+                let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
                 contract.method(k, );
             }
         );
@@ -166,23 +166,23 @@ mod tests {
                 #[cfg(target_arch = "wasm32")]
                 #[no_mangle]
                 pub extern "C" fn method() {
-                    near_sdk::env::setup_panic_hook();
-                    if near_sdk::env::attached_deposit() != 0 {
-                        near_sdk::env::panic_str("Method method doesn't accept deposit");
+                    ::near_sdk::env::setup_panic_hook();
+                    if ::near_sdk::env::attached_deposit() != 0 {
+                        ::near_sdk::env::panic_str("Method method doesn't accept deposit");
                     }
-                    #[derive(near_sdk :: serde :: Deserialize)]
-                    #[serde(crate = "near_sdk::serde")]
+                    #[derive(::near_sdk :: serde :: Deserialize)]
+                    #[serde(crate = "::near_sdk::serde")]
                     struct Input {
                         k: u64,
                         m: Bar,
                     }
-                    let Input { k, m, }: Input = near_sdk::serde_json::from_slice(
-                        &near_sdk::env::input().expect("Expected input since method has arguments.")
+                    let Input { k, m, }: Input = ::near_sdk::serde_json::from_slice(
+                        &::near_sdk::env::input().expect("Expected input since method has arguments.")
                     )
                     .expect("Failed to deserialize input from JSON.");
-                    let mut contract: Hello = near_sdk::env::state_read().unwrap_or_default();
+                    let mut contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
                     contract.method(k, m, );
-                    near_sdk::env::state_write(&contract);
+                    ::near_sdk::env::state_write(&contract);
                 }
         );
         assert_eq!(expected.to_string(), actual.to_string());
@@ -199,26 +199,26 @@ mod tests {
                 #[cfg(target_arch = "wasm32")]
                 #[no_mangle]
                 pub extern "C" fn method() {
-                    near_sdk::env::setup_panic_hook();
-                    if near_sdk::env::attached_deposit() != 0 {
-                        near_sdk::env::panic_str("Method method doesn't accept deposit");
+                    ::near_sdk::env::setup_panic_hook();
+                    if ::near_sdk::env::attached_deposit() != 0 {
+                        ::near_sdk::env::panic_str("Method method doesn't accept deposit");
                     }
-                    #[derive(near_sdk :: serde :: Deserialize)]
-                    #[serde(crate = "near_sdk::serde")]
+                    #[derive(::near_sdk :: serde :: Deserialize)]
+                    #[serde(crate = "::near_sdk::serde")]
                     struct Input {
                         k: u64,
                         m: Bar,
                     }
-                    let Input { k, m, }: Input = near_sdk::serde_json::from_slice(
-                        &near_sdk::env::input().expect("Expected input since method has arguments.")
+                    let Input { k, m, }: Input = ::near_sdk::serde_json::from_slice(
+                        &::near_sdk::env::input().expect("Expected input since method has arguments.")
                     )
                     .expect("Failed to deserialize input from JSON.");
-                    let mut contract: Hello = near_sdk::env::state_read().unwrap_or_default();
+                    let mut contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
                     let result = contract.method(k, m, );
                     let result =
-                        near_sdk::serde_json::to_vec(&result).expect("Failed to serialize the return value using JSON.");
-                    near_sdk::env::value_return(&result);
-                    near_sdk::env::state_write(&contract);
+                        ::near_sdk::serde_json::to_vec(&result).expect("Failed to serialize the return value using JSON.");
+                    ::near_sdk::env::value_return(&result);
+                    ::near_sdk::env::state_write(&contract);
                 }
         );
         assert_eq!(expected.to_string(), actual.to_string());
@@ -235,12 +235,12 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn method() {
-                near_sdk::env::setup_panic_hook();
-                let contract: Hello = near_sdk::env::state_read().unwrap_or_default();
+                ::near_sdk::env::setup_panic_hook();
+                let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
                 let result = contract.method();
                 let result =
-                    near_sdk::serde_json::to_vec(&result).expect("Failed to serialize the return value using JSON.");
-                near_sdk::env::value_return(&result);
+                    ::near_sdk::serde_json::to_vec(&result).expect("Failed to serialize the return value using JSON.");
+                ::near_sdk::env::value_return(&result);
             }
         );
         assert_eq!(expected.to_string(), actual.to_string());
@@ -256,17 +256,17 @@ mod tests {
                 #[cfg(target_arch = "wasm32")]
                 #[no_mangle]
                 pub extern "C" fn method() {
-                    near_sdk::env::setup_panic_hook();
-                    #[derive(near_sdk :: serde :: Deserialize)]
-                    #[serde(crate = "near_sdk::serde")]
+                    ::near_sdk::env::setup_panic_hook();
+                    #[derive(::near_sdk :: serde :: Deserialize)]
+                    #[serde(crate = "::near_sdk::serde")]
                     struct Input {
                         k: u64,
                     }
-                    let Input { k, }: Input = near_sdk::serde_json::from_slice(
-                        &near_sdk::env::input().expect("Expected input since method has arguments.")
+                    let Input { k, }: Input = ::near_sdk::serde_json::from_slice(
+                        &::near_sdk::env::input().expect("Expected input since method has arguments.")
                     )
                     .expect("Failed to deserialize input from JSON.");
-                    let contract: Hello = near_sdk::env::state_read().unwrap_or_default();
+                    let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
                     contract.method(&k, );
                 }
         );
@@ -284,17 +284,17 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn method() {
-                near_sdk::env::setup_panic_hook();
-                #[derive(near_sdk :: serde :: Deserialize)]
-                #[serde(crate = "near_sdk::serde")]
+                ::near_sdk::env::setup_panic_hook();
+                #[derive(::near_sdk :: serde :: Deserialize)]
+                #[serde(crate = "::near_sdk::serde")]
                 struct Input {
                     k: u64,
                 }
-                let Input { mut k, }: Input = near_sdk::serde_json::from_slice(
-                    &near_sdk::env::input().expect("Expected input since method has arguments.")
+                let Input { mut k, }: Input = ::near_sdk::serde_json::from_slice(
+                    &::near_sdk::env::input().expect("Expected input since method has arguments.")
                 )
                 .expect("Failed to deserialize input from JSON.");
-                let contract: Hello = near_sdk::env::state_read().unwrap_or_default();
+                let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
                 contract.method(&mut k, );
             }
         );
@@ -305,7 +305,7 @@ mod tests {
     fn callback_args() {
         let impl_type: Type = syn::parse_str("Hello").unwrap();
         let mut method: ImplItemMethod = parse_quote! {
-            #[private] pub fn method(&self, #[callback_unwrap] x: &mut u64, y: String, #[callback_unwrap] z: Vec<u8>) { }
+            #[private] pub fn method(&self, #[callback_unwrap] x: &mut u64, y: ::std::string::String, #[callback_unwrap] z: ::std::vec::Vec<u8>) { }
         };
         let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
@@ -313,32 +313,32 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn method() {
-                near_sdk::env::setup_panic_hook();
-                if near_sdk::env::current_account_id() != near_sdk::env::predecessor_account_id() {
-                    near_sdk::env::panic_str("Method method is private");
+                ::near_sdk::env::setup_panic_hook();
+                if ::near_sdk::env::current_account_id() != ::near_sdk::env::predecessor_account_id() {
+                    ::near_sdk::env::panic_str("Method method is private");
                 }
-                #[derive(near_sdk :: serde :: Deserialize)]
-                #[serde(crate = "near_sdk::serde")]
+                #[derive(::near_sdk :: serde :: Deserialize)]
+                #[serde(crate = "::near_sdk::serde")]
                 struct Input {
-                    y: String,
+                    y: ::std::string::String,
                 }
-                let Input { y, }: Input = near_sdk::serde_json::from_slice(
-                    &near_sdk::env::input().expect("Expected input since method has arguments.")
+                let Input { y, }: Input = ::near_sdk::serde_json::from_slice(
+                    &::near_sdk::env::input().expect("Expected input since method has arguments.")
                 )
                 .expect("Failed to deserialize input from JSON.");
-                let data: Vec<u8> = match near_sdk::env::promise_result(0u64) {
-                    near_sdk::PromiseResult::Successful(x) => x,
-                    _ => near_sdk::env::panic_str("Callback computation 0 was not successful")
+                let data: ::std::vec::Vec<u8> = match ::near_sdk::env::promise_result(0u64) {
+                    ::near_sdk::PromiseResult::Successful(x) => x,
+                    _ => ::near_sdk::env::panic_str("Callback computation 0 was not successful")
                 };
                 let mut x: u64 =
-                    near_sdk::serde_json::from_slice(&data).expect("Failed to deserialize callback using JSON");
-                let data: Vec<u8> = match near_sdk::env::promise_result(1u64) {
-                    near_sdk::PromiseResult::Successful(x) => x,
-                    _ => near_sdk::env::panic_str("Callback computation 1 was not successful")
+                    ::near_sdk::serde_json::from_slice(&data).expect("Failed to deserialize callback using JSON");
+                let data: ::std::vec::Vec<u8> = match ::near_sdk::env::promise_result(1u64) {
+                    ::near_sdk::PromiseResult::Successful(x) => x,
+                    _ => ::near_sdk::env::panic_str("Callback computation 1 was not successful")
                 };
-                let z: Vec<u8> =
-                    near_sdk::serde_json::from_slice(&data).expect("Failed to deserialize callback using JSON");
-                let contract: Hello = near_sdk::env::state_read().unwrap_or_default();
+                let z: ::std::vec::Vec<u8> =
+                    ::near_sdk::serde_json::from_slice(&data).expect("Failed to deserialize callback using JSON");
+                let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
                 contract.method(&mut x, y, z, );
             }
         );
@@ -349,7 +349,7 @@ mod tests {
     fn callback_args_only() {
         let impl_type: Type = syn::parse_str("Hello").unwrap();
         let mut method: ImplItemMethod = parse_quote! {
-            #[private] pub fn method(&self, #[callback_unwrap] x: &mut u64, #[callback_unwrap] y: String) { }
+            #[private] pub fn method(&self, #[callback_unwrap] x: &mut u64, #[callback_unwrap] y: ::std::string::String) { }
         };
         let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
@@ -357,23 +357,23 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn method() {
-                near_sdk::env::setup_panic_hook();
-                if near_sdk::env::current_account_id() != near_sdk::env::predecessor_account_id() {
-                    near_sdk::env::panic_str("Method method is private");
+                ::near_sdk::env::setup_panic_hook();
+                if ::near_sdk::env::current_account_id() != ::near_sdk::env::predecessor_account_id() {
+                    ::near_sdk::env::panic_str("Method method is private");
                 }
-                let data: Vec<u8> = match near_sdk::env::promise_result(0u64) {
-                    near_sdk::PromiseResult::Successful(x) => x,
-                    _ => near_sdk::env::panic_str("Callback computation 0 was not successful")
+                let data: ::std::vec::Vec<u8> = match ::near_sdk::env::promise_result(0u64) {
+                    ::near_sdk::PromiseResult::Successful(x) => x,
+                    _ => ::near_sdk::env::panic_str("Callback computation 0 was not successful")
                 };
                 let mut x: u64 =
-                    near_sdk::serde_json::from_slice(&data).expect("Failed to deserialize callback using JSON");
-                let data: Vec<u8> = match near_sdk::env::promise_result(1u64) {
-                    near_sdk::PromiseResult::Successful(x) => x,
-                    _ => near_sdk::env::panic_str("Callback computation 1 was not successful")
+                    ::near_sdk::serde_json::from_slice(&data).expect("Failed to deserialize callback using JSON");
+                let data: ::std::vec::Vec<u8> = match ::near_sdk::env::promise_result(1u64) {
+                    ::near_sdk::PromiseResult::Successful(x) => x,
+                    _ => ::near_sdk::env::panic_str("Callback computation 1 was not successful")
                 };
-                let y: String =
-                    near_sdk::serde_json::from_slice(&data).expect("Failed to deserialize callback using JSON");
-                let contract: Hello = near_sdk::env::state_read().unwrap_or_default();
+                let y: ::std::string::String =
+                    ::near_sdk::serde_json::from_slice(&data).expect("Failed to deserialize callback using JSON");
+                let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
                 contract.method(&mut x, y, );
             }
         );
@@ -385,7 +385,7 @@ mod tests {
     fn callback_args_results() {
         let impl_type: Type = syn::parse_str("Hello").unwrap();
         let mut method: ImplItemMethod = parse_quote! {
-            #[private] pub fn method(&self, #[callback_result] x: &mut Result<u64, PromiseError>, #[callback_result] y: Result<String, PromiseError>) { }
+            #[private] pub fn method(&self, #[callback_result] x: &mut Result<u64, PromiseError>, #[callback_result] y: Result<::std::string::String, PromiseError>) { }
         };
         let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
@@ -393,19 +393,19 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn method() {
-                near_sdk::env::setup_panic_hook();
-                if near_sdk::env::current_account_id() != near_sdk::env::predecessor_account_id() {
-                    near_sdk::env::panic_str("Method method is private");
+                ::near_sdk::env::setup_panic_hook();
+                if ::near_sdk::env::current_account_id() != ::near_sdk::env::predecessor_account_id() {
+                    ::near_sdk::env::panic_str("Method method is private");
                 }
-                let mut x: Result<u64, PromiseError> = match near_sdk::env::promise_result(0u64) {
-                    near_sdk::PromiseResult::Successful(data) => Ok(near_sdk::serde_json::from_slice(&data).expect("Failed to deserialize callback using JSON")),
-                    near_sdk::PromiseResult::Failed => Err(near_sdk::PromiseError::Failed),
+                let mut x: Result<u64, PromiseError> = match ::near_sdk::env::promise_result(0u64) {
+                    ::near_sdk::PromiseResult::Successful(data) => ::std::result::Result::Ok(::near_sdk::serde_json::from_slice(&data).expect("Failed to deserialize callback using JSON")),
+                    ::near_sdk::PromiseResult::Failed => ::std::result::Result::Err(::near_sdk::PromiseError::Failed),
                 };
-                let y: Result<String, PromiseError> = match near_sdk::env::promise_result(1u64) {
-                    near_sdk::PromiseResult::Successful(data) => Ok(near_sdk::serde_json::from_slice(&data).expect("Failed to deserialize callback using JSON")),
-                    near_sdk::PromiseResult::Failed => Err(near_sdk::PromiseError::Failed),
+                let y: Result<::std::string::String, PromiseError> = match ::near_sdk::env::promise_result(1u64) {
+                    ::near_sdk::PromiseResult::Successful(data) => ::std::result::Result::Ok(::near_sdk::serde_json::from_slice(&data).expect("Failed to deserialize callback using JSON")),
+                    ::near_sdk::PromiseResult::Failed => ::std::result::Result::Err(::near_sdk::PromiseError::Failed),
                 };
-                let contract: Hello = near_sdk::env::state_read().unwrap_or_default();
+                let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
                 contract.method(&mut x, y, );
             }
         );
@@ -425,29 +425,27 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn method() {
-                near_sdk::env::setup_panic_hook();
-                if near_sdk::env::current_account_id() != near_sdk::env::predecessor_account_id() {
-                    near_sdk::env::panic_str("Method method is private");
+                ::near_sdk::env::setup_panic_hook();
+                if ::near_sdk::env::current_account_id() != ::near_sdk::env::predecessor_account_id() {
+                    ::near_sdk::env::panic_str("Method method is private");
                 }
-                #[derive(near_sdk :: serde :: Deserialize)]
-                #[serde(crate = "near_sdk::serde")]
+                #[derive(::near_sdk :: serde :: Deserialize)]
+                #[serde(crate = "::near_sdk::serde")]
                 struct Input {
                     y: String,
                 }
-                let Input { y, }: Input = near_sdk::serde_json::from_slice(
-                    &near_sdk::env::input().expect("Expected input since method has arguments.")
+                let Input { y, }: Input = ::near_sdk::serde_json::from_slice(
+                    &::near_sdk::env::input().expect("Expected input since method has arguments.")
                 )
                 .expect("Failed to deserialize input from JSON.");
-                let x: Vec<String> = (0..near_sdk::env::promise_results_count())
-                    .map(|i| {
-                        let data: Vec<u8> = match near_sdk::env::promise_result(i) {
-                            near_sdk::PromiseResult::Successful(x) => x,
-                            _ => near_sdk::env::panic_str(&format!("Callback computation {} was not successful", i)),
+                let x: Vec<String> = ::std::iter::Iterator::collect(::std::iter::Iterator::map(0..::near_sdk::env::promise_results_count(), |i| {
+                        let data: ::std::vec::Vec<u8> = match ::near_sdk::env::promise_result(i) {
+                            ::near_sdk::PromiseResult::Successful(x) => x,
+                            _ => ::near_sdk::env::panic_str(&::std::format!("Callback computation {} was not successful", i)),
                         };
-                        near_sdk::serde_json::from_slice(&data).expect("Failed to deserialize callback using JSON")
-                    })
-                    .collect();
-                let contract: Hello = near_sdk::env::state_read().unwrap_or_default();
+                        ::near_sdk::serde_json::from_slice(&data).expect("Failed to deserialize callback using JSON")
+                    }));
+                let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
                 contract.method(x, y, );
             }
         );
@@ -467,24 +465,24 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn method() {
-                near_sdk::env::setup_panic_hook();
-                if near_sdk::env::attached_deposit() != 0 {
-                    near_sdk::env::panic_str("Method method doesn't accept deposit");
+                ::near_sdk::env::setup_panic_hook();
+                if ::near_sdk::env::attached_deposit() != 0 {
+                    ::near_sdk::env::panic_str("Method method doesn't accept deposit");
                 }
-                #[derive(near_sdk :: serde :: Deserialize)]
-                #[serde(crate = "near_sdk::serde")]
+                #[derive(::near_sdk :: serde :: Deserialize)]
+                #[serde(crate = "::near_sdk::serde")]
                 struct Input {
                     k: u64,
                 }
-                let Input { mut k, }: Input = near_sdk::serde_json::from_slice(
-                    &near_sdk::env::input().expect("Expected input since method has arguments.")
+                let Input { mut k, }: Input = ::near_sdk::serde_json::from_slice(
+                    &::near_sdk::env::input().expect("Expected input since method has arguments.")
                 )
                 .expect("Failed to deserialize input from JSON.");
-                if near_sdk::env::state_exists() {
-                    near_sdk::env::panic_str("The contract has already been initialized");
+                if ::near_sdk::env::state_exists() {
+                    ::near_sdk::env::panic_str("The contract has already been initialized");
                 }
                 let contract = Hello::method(&mut k,);
-                near_sdk::env::state_write(&contract);
+                ::near_sdk::env::state_write(&contract);
             }
         );
         assert_eq!(expected.to_string(), actual.to_string());
@@ -515,21 +513,21 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn method() {
-                near_sdk::env::setup_panic_hook();
-                if near_sdk::env::attached_deposit() != 0 {
-                    near_sdk::env::panic_str("Method method doesn't accept deposit");
+                ::near_sdk::env::setup_panic_hook();
+                if ::near_sdk::env::attached_deposit() != 0 {
+                    ::near_sdk::env::panic_str("Method method doesn't accept deposit");
                 }
-                #[derive(near_sdk :: serde :: Deserialize)]
-                #[serde(crate = "near_sdk::serde")]
+                #[derive(::near_sdk :: serde :: Deserialize)]
+                #[serde(crate = "::near_sdk::serde")]
                 struct Input {
                     k: u64,
                 }
-                let Input { mut k, }: Input = near_sdk::serde_json::from_slice(
-                    &near_sdk::env::input().expect("Expected input since method has arguments.")
+                let Input { mut k, }: Input = ::near_sdk::serde_json::from_slice(
+                    &::near_sdk::env::input().expect("Expected input since method has arguments.")
                 )
                 .expect("Failed to deserialize input from JSON.");
                 let contract = Hello::method(&mut k,);
-                near_sdk::env::state_write(&contract);
+                ::near_sdk::env::state_write(&contract);
             }
         );
         assert_eq!(expected.to_string(), actual.to_string());
@@ -549,21 +547,21 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn method() {
-                near_sdk::env::setup_panic_hook();
-                #[derive(near_sdk :: serde :: Deserialize)]
-                #[serde(crate = "near_sdk::serde")]
+                ::near_sdk::env::setup_panic_hook();
+                #[derive(::near_sdk :: serde :: Deserialize)]
+                #[serde(crate = "::near_sdk::serde")]
                 struct Input {
                     k: u64,
                 }
-                let Input { mut k, }: Input = near_sdk::serde_json::from_slice(
-                    &near_sdk::env::input().expect("Expected input since method has arguments.")
+                let Input { mut k, }: Input = ::near_sdk::serde_json::from_slice(
+                    &::near_sdk::env::input().expect("Expected input since method has arguments.")
                 )
                 .expect("Failed to deserialize input from JSON.");
-                if near_sdk::env::state_exists() {
-                    near_sdk::env::panic_str("The contract has already been initialized");
+                if ::near_sdk::env::state_exists() {
+                    ::near_sdk::env::panic_str("The contract has already been initialized");
                 }
                 let contract = Hello::method(&mut k,);
-                near_sdk::env::state_write(&contract);
+                ::near_sdk::env::state_write(&contract);
             }
         );
         assert_eq!(expected.to_string(), actual.to_string());
@@ -582,25 +580,25 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn method() {
-                near_sdk::env::setup_panic_hook();
-                if near_sdk::env::attached_deposit() != 0 {
-                    near_sdk::env::panic_str("Method method doesn't accept deposit");
+                ::near_sdk::env::setup_panic_hook();
+                if ::near_sdk::env::attached_deposit() != 0 {
+                    ::near_sdk::env::panic_str("Method method doesn't accept deposit");
                 }
-                #[derive(near_sdk :: borsh :: BorshDeserialize)]
+                #[derive(::near_sdk :: borsh :: BorshDeserialize)]
                 struct Input {
                     k: u64,
                     m: Bar,
                 }
-                let Input { k, m, }: Input = near_sdk::borsh::BorshDeserialize::try_from_slice(
-                    &near_sdk::env::input().expect("Expected input since method has arguments.")
+                let Input { k, m, }: Input = ::near_sdk::borsh::BorshDeserialize::try_from_slice(
+                    &::near_sdk::env::input().expect("Expected input since method has arguments.")
                 )
                 .expect("Failed to deserialize input from Borsh.");
-                let mut contract: Hello = near_sdk::env::state_read().unwrap_or_default();
+                let mut contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
                 let result = contract.method(k, m, );
-                let result = near_sdk::borsh::BorshSerialize::try_to_vec(&result)
+                let result = ::near_sdk::borsh::BorshSerialize::try_to_vec(&result)
                     .expect("Failed to serialize the return value using Borsh.");
-                near_sdk::env::value_return(&result);
-                near_sdk::env::state_write(&contract);
+                ::near_sdk::env::value_return(&result);
+                ::near_sdk::env::state_write(&contract);
             }
         );
         assert_eq!(expected.to_string(), actual.to_string());
@@ -610,7 +608,7 @@ mod tests {
     fn callback_args_mixed_serialization() {
         let impl_type: Type = syn::parse_str("Hello").unwrap();
         let mut method: ImplItemMethod = parse_quote! {
-            #[private] pub fn method(&self, #[callback_unwrap] #[serializer(borsh)] x: &mut u64, #[serializer(borsh)] y: String, #[callback_unwrap] #[serializer(json)] z: Vec<u8>) { }
+            #[private] pub fn method(&self, #[callback_unwrap] #[serializer(borsh)] x: &mut u64, #[serializer(borsh)] y: ::std::string::String, #[callback_unwrap] #[serializer(json)] z: ::std::vec::Vec<u8>) { }
         };
         let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
@@ -618,31 +616,31 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn method() {
-                near_sdk::env::setup_panic_hook();
-                if near_sdk::env::current_account_id() != near_sdk::env::predecessor_account_id() {
-                    near_sdk::env::panic_str("Method method is private");
+                ::near_sdk::env::setup_panic_hook();
+                if ::near_sdk::env::current_account_id() != ::near_sdk::env::predecessor_account_id() {
+                    ::near_sdk::env::panic_str("Method method is private");
                 }
-                #[derive(near_sdk :: borsh :: BorshDeserialize)]
+                #[derive(::near_sdk :: borsh :: BorshDeserialize)]
                 struct Input {
-                    y: String,
+                    y: ::std::string::String,
                 }
-                let Input { y, }: Input = near_sdk::borsh::BorshDeserialize::try_from_slice(
-                    &near_sdk::env::input().expect("Expected input since method has arguments.")
+                let Input { y, }: Input = ::near_sdk::borsh::BorshDeserialize::try_from_slice(
+                    &::near_sdk::env::input().expect("Expected input since method has arguments.")
                 )
                 .expect("Failed to deserialize input from Borsh.");
-                let data: Vec<u8> = match near_sdk::env::promise_result(0u64) {
-                    near_sdk::PromiseResult::Successful(x) => x,
-                    _ => near_sdk::env::panic_str("Callback computation 0 was not successful")
+                let data: ::std::vec::Vec<u8> = match ::near_sdk::env::promise_result(0u64) {
+                    ::near_sdk::PromiseResult::Successful(x) => x,
+                    _ => ::near_sdk::env::panic_str("Callback computation 0 was not successful")
                 };
-                let mut x: u64 = near_sdk::borsh::BorshDeserialize::try_from_slice(&data)
+                let mut x: u64 = ::near_sdk::borsh::BorshDeserialize::try_from_slice(&data)
                     .expect("Failed to deserialize callback using Borsh");
-                let data: Vec<u8> = match near_sdk::env::promise_result(1u64) {
-                    near_sdk::PromiseResult::Successful(x) => x,
-                    _ => near_sdk::env::panic_str("Callback computation 1 was not successful")
+                let data: ::std::vec::Vec<u8> = match ::near_sdk::env::promise_result(1u64) {
+                    ::near_sdk::PromiseResult::Successful(x) => x,
+                    _ => ::near_sdk::env::panic_str("Callback computation 1 was not successful")
                 };
-                let z: Vec<u8> =
-                    near_sdk::serde_json::from_slice(&data).expect("Failed to deserialize callback using JSON");
-                let contract: Hello = near_sdk::env::state_read().unwrap_or_default();
+                let z: ::std::vec::Vec<u8> =
+                    ::near_sdk::serde_json::from_slice(&data).expect("Failed to deserialize callback using JSON");
+                let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
                 contract.method(&mut x, y, z, );
             }
         );
@@ -659,10 +657,10 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn method() {
-                near_sdk::env::setup_panic_hook();
-                let mut contract: Hello = near_sdk::env::state_read().unwrap_or_default();
+                ::near_sdk::env::setup_panic_hook();
+                let mut contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
                 contract.method();
-                near_sdk::env::state_write(&contract);
+                ::near_sdk::env::state_write(&contract);
             }
         );
         assert_eq!(expected.to_string(), actual.to_string());
@@ -678,16 +676,16 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn private_method() {
-                near_sdk::env::setup_panic_hook();
-                if near_sdk::env::current_account_id() != near_sdk::env::predecessor_account_id() {
-                    near_sdk::env::panic_str("Method private_method is private");
+                ::near_sdk::env::setup_panic_hook();
+                if ::near_sdk::env::current_account_id() != ::near_sdk::env::predecessor_account_id() {
+                    ::near_sdk::env::panic_str("Method private_method is private");
                 }
-                if near_sdk::env::attached_deposit() != 0 {
-                    near_sdk::env::panic_str("Method private_method doesn't accept deposit");
+                if ::near_sdk::env::attached_deposit() != 0 {
+                    ::near_sdk::env::panic_str("Method private_method doesn't accept deposit");
                 }
-                let mut contract: Hello = near_sdk::env::state_read().unwrap_or_default();
+                let mut contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
                 contract.private_method();
-                near_sdk::env::state_write(&contract);
+                ::near_sdk::env::state_write(&contract);
             }
         );
         assert_eq!(expected.to_string(), actual.to_string());
@@ -698,7 +696,7 @@ mod tests {
         let impl_type: Type = syn::parse_str("Hello").unwrap();
         let mut method: ImplItemMethod = parse_quote! {
             #[handle_result]
-            pub fn method(&self) -> Result<u64, &'static str> { }
+            pub fn method(&self) -> Result::<u64, &'static str> { }
         };
         let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
@@ -706,16 +704,16 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn method() {
-                near_sdk::env::setup_panic_hook();
-                let contract: Hello = near_sdk::env::state_read().unwrap_or_default();
+                ::near_sdk::env::setup_panic_hook();
+                let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
                 let result = contract.method();
                 match result {
-                    Ok(result) => {
+                    ::std::result::Result::Ok(result) => {
                         let result =
-                            near_sdk::serde_json::to_vec(&result).expect("Failed to serialize the return value using JSON.");
-                        near_sdk::env::value_return(&result);
+                            ::near_sdk::serde_json::to_vec(&result).expect("Failed to serialize the return value using JSON.");
+                        ::near_sdk::env::value_return(&result);
                     }
-                    Err(err) => near_sdk::FunctionError::panic(&err)
+                    ::std::result::Result::Err(err) => ::near_sdk::FunctionError::panic(&err)
                 }
             }
         );
@@ -735,20 +733,20 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn method() {
-                near_sdk::env::setup_panic_hook();
-                if near_sdk::env::attached_deposit() != 0 {
-                    near_sdk::env::panic_str("Method method doesn't accept deposit");
+                ::near_sdk::env::setup_panic_hook();
+                if ::near_sdk::env::attached_deposit() != 0 {
+                    ::near_sdk::env::panic_str("Method method doesn't accept deposit");
                 }
-                let mut contract: Hello = near_sdk::env::state_read().unwrap_or_default();
+                let mut contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
                 let result = contract.method();
                 match result {
-                    Ok(result) => {
+                    ::std::result::Result::Ok(result) => {
                         let result =
-                            near_sdk::serde_json::to_vec(&result).expect("Failed to serialize the return value using JSON.");
-                        near_sdk::env::value_return(&result);
-                        near_sdk::env::state_write(&contract);
+                            ::near_sdk::serde_json::to_vec(&result).expect("Failed to serialize the return value using JSON.");
+                        ::near_sdk::env::value_return(&result);
+                        ::near_sdk::env::state_write(&contract);
                     }
-                    Err(err) => near_sdk::FunctionError::panic(&err)
+                    ::std::result::Result::Err(err) => ::near_sdk::FunctionError::panic(&err)
                 }
             }
         );
@@ -769,16 +767,16 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn method() {
-                near_sdk::env::setup_panic_hook();
-                let contract: Hello = near_sdk::env::state_read().unwrap_or_default();
+                ::near_sdk::env::setup_panic_hook();
+                let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
                 let result = contract.method();
                 match result {
-                    Ok(result) => {
+                    ::std::result::Result::Ok(result) => {
                         let result =
-                            near_sdk::borsh::BorshSerialize::try_to_vec(&result).expect("Failed to serialize the return value using Borsh.");
-                        near_sdk::env::value_return(&result);
+                            ::near_sdk::borsh::BorshSerialize::try_to_vec(&result).expect("Failed to serialize the return value using Borsh.");
+                        ::near_sdk::env::value_return(&result);
                     }
-                    Err(err) => near_sdk::FunctionError::panic(&err)
+                    ::std::result::Result::Err(err) => ::near_sdk::FunctionError::panic(&err)
                 }
             }
         );
@@ -799,19 +797,19 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn new() {
-                near_sdk::env::setup_panic_hook();
-                if near_sdk::env::attached_deposit() != 0 {
-                    near_sdk::env::panic_str("Method new doesn't accept deposit");
+                ::near_sdk::env::setup_panic_hook();
+                if ::near_sdk::env::attached_deposit() != 0 {
+                    ::near_sdk::env::panic_str("Method new doesn't accept deposit");
                 }
-                if near_sdk::env::state_exists() {
-                    near_sdk::env::panic_str("The contract has already been initialized");
+                if ::near_sdk::env::state_exists() {
+                    ::near_sdk::env::panic_str("The contract has already been initialized");
                 }
                 let contract = Hello::new();
                 match contract {
-                    Ok(contract) => {
-                        near_sdk::env::state_write(&contract);
+                    ::std::result::Result::Ok(contract) => {
+                        ::near_sdk::env::state_write(&contract);
                     }
-                    Err(err) => near_sdk::FunctionError::panic(&err)
+                    ::std::result::Result::Err(err) => ::near_sdk::FunctionError::panic(&err)
                 }
             }
         );
@@ -832,16 +830,16 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn new() {
-                near_sdk::env::setup_panic_hook();
-                if near_sdk::env::attached_deposit() != 0 {
-                    near_sdk::env::panic_str("Method new doesn't accept deposit");
+                ::near_sdk::env::setup_panic_hook();
+                if ::near_sdk::env::attached_deposit() != 0 {
+                    ::near_sdk::env::panic_str("Method new doesn't accept deposit");
                 }
                 let contract = Hello::new();
                 match contract {
-                    Ok(contract) => {
-                        near_sdk::env::state_write(&contract);
+                    ::std::result::Result::Ok(contract) => {
+                        ::near_sdk::env::state_write(&contract);
                     }
-                    Err(err) => near_sdk::FunctionError::panic(&err)
+                    ::std::result::Result::Err(err) => ::near_sdk::FunctionError::panic(&err)
                 }
             }
         );
@@ -858,7 +856,7 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn method() {
-                near_sdk::env::setup_panic_hook();
+                ::near_sdk::env::setup_panic_hook();
                 Hello::method();
             }
         );

--- a/near-sdk-macros/src/core_impl/code_generator/item_trait_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/item_trait_info.rs
@@ -37,16 +37,16 @@ mod tests {
         let mut t: ItemTrait = syn::parse2(
             quote!{
                 pub trait ExternalCrossContract {
-                    fn merge_sort(&self, arr: ::std::vec::Vec<u8>) -> PromiseOrValue<::std::vec::Vec<u8>>;
+                    fn merge_sort(&self, arr: Vec<u8>) -> PromiseOrValue<Vec<u8>>;
                     fn merge(
                         &self,
                         #[callback_unwrap]
                         #[serializer(borsh)]
-                        data0: ::std::vec::Vec<u8>,
+                        data0: Vec<u8>,
                         #[callback_unwrap]
                         #[serializer(borsh)]
-                        data1: ::std::vec::Vec<u8>,
-                    ) -> ::std::vec::Vec<u8>;
+                        data1: Vec<u8>,
+                    ) -> Vec<u8>;
                 }
             }
         ).unwrap();
@@ -89,13 +89,13 @@ mod tests {
                 impl ExternalCrossContractExt {
                     pub fn merge_sort(
                         self,
-                        arr: ::std::vec::Vec<u8>,
+                        arr: Vec<u8>,
                     ) -> ::near_sdk::Promise {
                         let __args = {
                             #[derive(::near_sdk :: serde :: Serialize)]
                             #[serde(crate = "::near_sdk::serde")]
                             struct Input<'nearinput> {
-                                arr: &'nearinput ::std::vec::Vec<u8>,
+                                arr: &'nearinput Vec<u8>,
                             }
                             let __args = Input { arr: &arr, };
                             ::near_sdk::serde_json::to_vec(&__args)
@@ -133,7 +133,7 @@ mod tests {
             quote!{
               trait Test {
                 #[result_serializer(borsh)]
-                fn test(#[serializer(borsh)] v: ::std::vec::Vec<String>) -> ::std::vec::Vec<String>;
+                fn test(#[serializer(borsh)] v: Vec<String>) -> Vec<String>;
               }
             }
         ).unwrap();
@@ -176,12 +176,12 @@ mod tests {
             impl TestExt {
                 pub fn test(
                     self,
-                    v: ::std::vec::Vec<String>,
+                    v: Vec<String>,
                 ) -> ::near_sdk::Promise {
                     let __args = {
                         #[derive(::near_sdk :: borsh :: BorshSerialize)]
                         struct Input<'nearinput> {
-                            v: &'nearinput ::std::vec::Vec<String>,
+                            v: &'nearinput Vec<String>,
                         }
                         let __args = Input { v: &v, };
                         ::near_sdk::borsh::BorshSerialize::try_to_vec(&__args)

--- a/near-sdk-macros/src/core_impl/code_generator/item_trait_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/item_trait_info.rs
@@ -37,16 +37,16 @@ mod tests {
         let mut t: ItemTrait = syn::parse2(
             quote!{
                 pub trait ExternalCrossContract {
-                    fn merge_sort(&self, arr: Vec<u8>) -> PromiseOrValue<Vec<u8>>;
+                    fn merge_sort(&self, arr: ::std::vec::Vec<u8>) -> PromiseOrValue<::std::vec::Vec<u8>>;
                     fn merge(
                         &self,
                         #[callback_unwrap]
                         #[serializer(borsh)]
-                        data0: Vec<u8>,
+                        data0: ::std::vec::Vec<u8>,
                         #[callback_unwrap]
                         #[serializer(borsh)]
-                        data1: Vec<u8>,
-                    ) -> Vec<u8>;
+                        data1: ::std::vec::Vec<u8>,
+                    ) -> ::std::vec::Vec<u8>;
                 }
             }
         ).unwrap();
@@ -58,63 +58,63 @@ mod tests {
                 use super::*;
                 #[must_use]
                 pub struct ExternalCrossContractExt {
-                    pub(crate) account_id: near_sdk::AccountId,
-                    pub(crate) deposit: near_sdk::Balance,
-                    pub(crate) static_gas: near_sdk::Gas,
-                    pub(crate) gas_weight: near_sdk::GasWeight,
+                    pub(crate) account_id: ::near_sdk::AccountId,
+                    pub(crate) deposit: ::near_sdk::Balance,
+                    pub(crate) static_gas: ::near_sdk::Gas,
+                    pub(crate) gas_weight: ::near_sdk::GasWeight,
                 }
                 impl ExternalCrossContractExt {
-                    pub fn with_attached_deposit(mut self, amount: near_sdk::Balance) -> Self {
+                    pub fn with_attached_deposit(mut self, amount: ::near_sdk::Balance) -> Self {
                         self.deposit = amount;
                         self
                     }
-                    pub fn with_static_gas(mut self, static_gas: near_sdk::Gas) -> Self {
+                    pub fn with_static_gas(mut self, static_gas: ::near_sdk::Gas) -> Self {
                         self.static_gas = static_gas;
                         self
                     }
                     pub fn with_unused_gas_weight(mut self, gas_weight: u64) -> Self {
-                        self.gas_weight = near_sdk::GasWeight(gas_weight);
+                        self.gas_weight = ::near_sdk::GasWeight(gas_weight);
                         self
                     }
                 }
                 /// API for calling this contract's functions in a subsequent execution.
-                pub fn ext(account_id: near_sdk::AccountId) -> ExternalCrossContractExt {
+                pub fn ext(account_id: ::near_sdk::AccountId) -> ExternalCrossContractExt {
                     ExternalCrossContractExt {
                         account_id,
                         deposit: 0,
-                        static_gas: near_sdk::Gas(0),
-                        gas_weight: near_sdk::GasWeight::default(),
+                        static_gas: ::near_sdk::Gas(0),
+                        gas_weight: ::near_sdk::GasWeight::default(),
                     }
                 }
                 impl ExternalCrossContractExt {
                     pub fn merge_sort(
                         self,
-                        arr: Vec<u8>,
-                    ) -> near_sdk::Promise {
+                        arr: ::std::vec::Vec<u8>,
+                    ) -> ::near_sdk::Promise {
                         let __args = {
-                            #[derive(near_sdk :: serde :: Serialize)]
-                            #[serde(crate = "near_sdk::serde")]
+                            #[derive(::near_sdk :: serde :: Serialize)]
+                            #[serde(crate = "::near_sdk::serde")]
                             struct Input<'nearinput> {
-                                arr: &'nearinput Vec<u8>,
+                                arr: &'nearinput ::std::vec::Vec<u8>,
                             }
                             let __args = Input { arr: &arr, };
-                            near_sdk::serde_json::to_vec(&__args)
+                            ::near_sdk::serde_json::to_vec(&__args)
                                 .expect("Failed to serialize the cross contract args using JSON.")
                         };
-                        near_sdk::Promise::new(self.account_id)
+                        ::near_sdk::Promise::new(self.account_id)
                             .function_call_weight(
-                                "merge_sort".to_string(),
+                                ::std::string::String::from("merge_sort"),
                                 __args,
                                 self.deposit,
                                 self.static_gas,
                                 self.gas_weight,
                             )
                     }
-                    pub fn merge(self,) -> near_sdk::Promise {
-                        let __args = vec![];
-                        near_sdk::Promise::new(self.account_id)
+                    pub fn merge(self,) -> ::near_sdk::Promise {
+                        let __args = ::std::vec![];
+                        ::near_sdk::Promise::new(self.account_id)
                             .function_call_weight(
-                                "merge".to_string(),
+                                ::std::string::String::from("merge"),
                                 __args,
                                 self.deposit,
                                 self.static_gas,
@@ -133,7 +133,7 @@ mod tests {
             quote!{
               trait Test {
                 #[result_serializer(borsh)]
-                fn test(#[serializer(borsh)] v: Vec<String>) -> Vec<String>;
+                fn test(#[serializer(borsh)] v: ::std::vec::Vec<String>) -> ::std::vec::Vec<String>;
               }
             }
         ).unwrap();
@@ -145,51 +145,51 @@ mod tests {
             use super::*;
             #[must_use]
             pub struct TestExt {
-                pub(crate) account_id: near_sdk::AccountId,
-                pub(crate) deposit: near_sdk::Balance,
-                pub(crate) static_gas: near_sdk::Gas,
-                pub(crate) gas_weight: near_sdk::GasWeight,
+                pub(crate) account_id: ::near_sdk::AccountId,
+                pub(crate) deposit: ::near_sdk::Balance,
+                pub(crate) static_gas: ::near_sdk::Gas,
+                pub(crate) gas_weight: ::near_sdk::GasWeight,
             }
             impl TestExt {
-                pub fn with_attached_deposit(mut self, amount: near_sdk::Balance) -> Self {
+                pub fn with_attached_deposit(mut self, amount: ::near_sdk::Balance) -> Self {
                     self.deposit = amount;
                     self
                 }
-                pub fn with_static_gas(mut self, static_gas: near_sdk::Gas) -> Self {
+                pub fn with_static_gas(mut self, static_gas: ::near_sdk::Gas) -> Self {
                     self.static_gas = static_gas;
                     self
                 }
                 pub fn with_unused_gas_weight(mut self, gas_weight: u64) -> Self {
-                    self.gas_weight = near_sdk::GasWeight(gas_weight);
+                    self.gas_weight = ::near_sdk::GasWeight(gas_weight);
                     self
                 }
             }
             /// API for calling this contract's functions in a subsequent execution.
-            pub fn ext(account_id: near_sdk::AccountId) -> TestExt {
+            pub fn ext(account_id: ::near_sdk::AccountId) -> TestExt {
                 TestExt {
                     account_id,
                     deposit: 0,
-                    static_gas: near_sdk::Gas(0),
-                    gas_weight: near_sdk::GasWeight::default(),
+                    static_gas: ::near_sdk::Gas(0),
+                    gas_weight: ::near_sdk::GasWeight::default(),
                 }
             }
             impl TestExt {
                 pub fn test(
                     self,
-                    v: Vec<String>,
-                ) -> near_sdk::Promise {
+                    v: ::std::vec::Vec<String>,
+                ) -> ::near_sdk::Promise {
                     let __args = {
-                        #[derive(near_sdk :: borsh :: BorshSerialize)]
+                        #[derive(::near_sdk :: borsh :: BorshSerialize)]
                         struct Input<'nearinput> {
-                            v: &'nearinput Vec<String>,
+                            v: &'nearinput ::std::vec::Vec<String>,
                         }
                         let __args = Input { v: &v, };
-                        near_sdk::borsh::BorshSerialize::try_to_vec(&__args)
+                        ::near_sdk::borsh::BorshSerialize::try_to_vec(&__args)
                             .expect("Failed to serialize the cross contract args using Borsh.")
                     };
-                    near_sdk::Promise::new(self.account_id)
+                    ::near_sdk::Promise::new(self.account_id)
                         .function_call_weight(
-                            "test".to_string(),
+                            ::std::string::String::from("test"),
                             __args,
                             self.deposit,
                             self.static_gas,

--- a/near-sdk-macros/src/core_impl/code_generator/serializer.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/serializer.rs
@@ -8,17 +8,17 @@ pub fn generate_serializer(
 ) -> TokenStream2 {
     let has_input_args = attr_sig_info.input_args().next().is_some();
     if !has_input_args {
-        return quote! { vec![] };
+        return quote! { ::std::vec![] };
     }
     let struct_decl = attr_sig_info.input_struct_ser();
     let constructor_call = attr_sig_info.constructor_expr_ref();
     let constructor = quote! { let __args = #constructor_call; };
     let value_ser = match serializer {
         SerializerType::JSON => quote! {
-            near_sdk::serde_json::to_vec(&__args).expect("Failed to serialize the cross contract args using JSON.")
+            ::near_sdk::serde_json::to_vec(&__args).expect("Failed to serialize the cross contract args using JSON.")
         },
         SerializerType::Borsh => quote! {
-            near_sdk::borsh::BorshSerialize::try_to_vec(&__args).expect("Failed to serialize the cross contract args using Borsh.")
+            ::near_sdk::borsh::BorshSerialize::try_to_vec(&__args).expect("Failed to serialize the cross contract args using Borsh.")
         },
     };
 

--- a/near-sdk-macros/src/core_impl/event/mod.rs
+++ b/near-sdk-macros/src/core_impl/event/mod.rs
@@ -24,10 +24,10 @@ pub(crate) fn near_events(attr: TokenStream, item: TokenStream) -> TokenStream {
         let standard_name = format!("{}_event_standard", name);
         let standard_ident = syn::Ident::new(&standard_name, Span::call_site());
         // NearEvent Macro handles implementation
-        input
-            .attrs
-            .push(parse_quote! (#[derive(near_sdk::serde::Serialize, near_sdk::EventMetadata)]));
-        input.attrs.push(parse_quote! (#[serde(crate="near_sdk::serde")]));
+        input.attrs.push(
+            parse_quote! (#[derive(::near_sdk::serde::Serialize, ::near_sdk::EventMetadata)]),
+        );
+        input.attrs.push(parse_quote! (#[serde(crate="::near_sdk::serde")]));
         input.attrs.push(parse_quote! (#[serde(tag = "event", content = "data")]));
         input.attrs.push(parse_quote! (#[serde(rename_all = "snake_case")]));
 

--- a/near-sdk-macros/src/core_impl/metadata/metadata_generator.rs
+++ b/near-sdk-macros/src/core_impl/metadata/metadata_generator.rs
@@ -44,7 +44,7 @@ impl ImplItemMethodInfo {
             let additional_schema = match &self.attr_signature_info.input_serializer {
                 SerializerType::Borsh => TokenStream2::new(),
                 SerializerType::JSON => quote! {
-                    #[derive(borsh::BorshSchema)]
+                    #[derive(::borsh::BorshSchema)]
                 },
             };
             quote! {
@@ -52,12 +52,12 @@ impl ImplItemMethodInfo {
                     #additional_schema
                     #[allow(dead_code)]
                     #input_struct
-                    Some(Input::schema_container())
+                    ::std::option::Option::Some(<Input as ::near_sdk::borsh::BorshSchema>::schema_container())
                 }
             }
         } else {
             quote! {
-                 None
+                 ::std::option::Option::None
             }
         };
         let callbacks: Vec<_> = self
@@ -68,7 +68,7 @@ impl ImplItemMethodInfo {
             .map(|arg| {
                 let ty = &arg.ty;
                 quote! {
-                    #ty::schema_container()
+                    <#ty as ::near_sdk::borsh::BorshSchema>::schema_container()
                 }
             })
             .collect();
@@ -81,36 +81,36 @@ impl ImplItemMethodInfo {
         {
             None => {
                 quote! {
-                    None
+                    ::std::option::Option::None
                 }
             }
             Some(arg) => {
                 let ty = &arg.ty;
                 quote! {
-                    Some(#ty::schema_container())
+                    ::std::option::Option::Some(<#ty as ::near_sdk::borsh::BorshSchema>::schema_container())
                 }
             }
         };
         let result = match &self.attr_signature_info.returns.original {
             ReturnType::Default => {
                 quote! {
-                    None
+                    ::std::option::Option::None
                 }
             }
             ReturnType::Type(_, ty) => {
                 quote! {
-                    Some(#ty::schema_container())
+                    ::std::option::Option::Some(<#ty as ::near_sdk::borsh::BorshSchema>::schema_container())
                 }
             }
         };
 
         quote! {
-             near_sdk::__private::MethodMetadata {
-                 name: #method_name_str.to_string(),
+             ::near_sdk::__private::MethodMetadata {
+                 name: ::std::string::String::from(#method_name_str),
                  is_view: #is_view,
                  is_init: #is_init,
                  args: #args,
-                 callbacks: vec![#(#callbacks),*],
+                 callbacks: ::std::vec![#(#callbacks),*],
                  callbacks_vec: #callbacks_vec,
                  result: #result
              }

--- a/near-sdk-macros/src/core_impl/metadata/metadata_visitor.rs
+++ b/near-sdk-macros/src/core_impl/metadata/metadata_visitor.rs
@@ -43,7 +43,7 @@ impl MetadataVisitor {
             return Err(self.errors[0].clone());
         }
         let panic_hook = quote! {
-            near_sdk::env::setup_panic_hook();
+            ::near_sdk::env::setup_panic_hook();
         };
         let methods: Vec<TokenStream2> = self
             .impl_item_infos
@@ -56,12 +56,12 @@ impl MetadataVisitor {
             #[no_mangle]
             pub extern "C" fn metadata() {
                 #panic_hook
-                use borsh::*;
-                let metadata = near_sdk::__private::Metadata::new(vec![
+                use ::borsh::*;
+                let metadata = ::near_sdk::__private::Metadata::new(::std::vec![
                     #(#methods),*
                 ]);
-                let data = near_sdk::borsh::BorshSerialize::try_to_vec(&metadata).expect("Failed to serialize the metadata using Borsh");
-                near_sdk::env::value_return(&data);
+                let data = ::near_sdk::borsh::BorshSerialize::try_to_vec(&metadata).expect("Failed to serialize the metadata using Borsh");
+                ::near_sdk::env::value_return(&data);
             }
         })
     }
@@ -98,60 +98,60 @@ mod tests {
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn metadata() {
-                near_sdk::env::setup_panic_hook();
-                use borsh::*;
-                let metadata = near_sdk::__private::Metadata::new(vec![
-                    near_sdk::__private::MethodMetadata {
-                        name: "f1".to_string(),
+                ::near_sdk::env::setup_panic_hook();
+                use ::borsh::*;
+                let metadata = ::near_sdk::__private::Metadata::new(::std::vec![
+                    ::near_sdk::__private::MethodMetadata {
+                        name: ::std::string::String::from("f1"),
                         is_view: true,
                         is_init: false,
-                        args: None,
-                        callbacks: vec![],
-                        callbacks_vec: None,
-                        result: None
+                        args: ::std::option::Option::None,
+                        callbacks: ::std::vec![],
+                        callbacks_vec: ::std::option::Option::None,
+                        result: ::std::option::Option::None
                     },
-                    near_sdk::__private::MethodMetadata {
-                        name: "f2".to_string(),
+                    ::near_sdk::__private::MethodMetadata {
+                        name: ::std::string::String::from("f2"),
                         is_view: false,
                         is_init: false,
                         args: {
-                            #[derive(borsh::BorshSchema)]
+                            #[derive(::borsh::BorshSchema)]
                             #[allow(dead_code)]
-                            #[derive(near_sdk :: serde :: Deserialize)]
-                            #[serde(crate = "near_sdk::serde")]
+                            #[derive(::near_sdk :: serde :: Deserialize)]
+                            #[serde(crate = "::near_sdk::serde")]
                             struct Input {
                                 arg0: FancyStruct,
                                 arg1: u64,
                             }
-                            Some(Input::schema_container())
+                            ::std::option::Option::Some(<Input as ::near_sdk::borsh::BorshSchema>::schema_container())
                         },
-                        callbacks: vec![],
-                        callbacks_vec: None,
-                        result: None
+                        callbacks: ::std::vec![],
+                        callbacks_vec: ::std::option::Option::None,
+                        result: ::std::option::Option::None
                     },
-                    near_sdk::__private::MethodMetadata {
-                        name: "f3".to_string(),
+                    ::near_sdk::__private::MethodMetadata {
+                        name: ::std::string::String::from("f3"),
                         is_view: false,
                         is_init: false,
                         args: {
-                            #[derive(borsh::BorshSchema)]
+                            #[derive(::borsh::BorshSchema)]
                             #[allow(dead_code)]
-                            #[derive(near_sdk :: serde :: Deserialize)]
-                            #[serde(crate = "near_sdk::serde")]
+                            #[derive(::near_sdk :: serde :: Deserialize)]
+                            #[serde(crate = "::near_sdk::serde")]
                             struct Input {
                                 arg0: FancyStruct,
                                 arg1: u64,
                             }
-                            Some(Input::schema_container())
+                            ::std::option::Option::Some(<Input as ::near_sdk::borsh::BorshSchema>::schema_container())
                         },
-                        callbacks: vec![],
-                        callbacks_vec: None,
-                        result: Some(Either < IsOk, Error > ::schema_container())
+                        callbacks: ::std::vec![],
+                        callbacks_vec: ::std::option::Option::None,
+                        result: ::std::option::Option::Some(<Either < IsOk, Error > as ::near_sdk::borsh::BorshSchema> ::schema_container())
                     }
                 ]);
-                let data = near_sdk::borsh::BorshSerialize::try_to_vec(&metadata)
+                let data = ::near_sdk::borsh::BorshSerialize::try_to_vec(&metadata)
                     .expect("Failed to serialize the metadata using Borsh");
-                near_sdk::env::value_return(&data);
+                ::near_sdk::env::value_return(&data);
             }
         );
         assert_eq!(expected.to_string(), actual.to_string());


### PR DESCRIPTION
Closes #1058 

Switching to global paths (the ones that start with `::`) means the intended symbols can't be shadowed by user code except maybe by more advanced things like aliasing crates via `extern`.