### PR TITLE
Make `PromiseIndex` a newtype

### DIFF
--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -456,7 +456,7 @@ pub fn promise_create(
 ) -> PromiseIndex {
     let account_id = account_id.as_bytes();
     unsafe {
-        sys::promise_create(
+        PromiseIndex::new(sys::promise_create(
             account_id.len() as _,
             account_id.as_ptr() as _,
             function_name.len() as _,
@@ -465,7 +465,7 @@ pub fn promise_create(
             arguments.as_ptr() as _,
             &amount as *const Balance as _,
             gas.0,
-        )
+        ))
     }
 }
 
@@ -480,8 +480,8 @@ pub fn promise_then(
 ) -> PromiseIndex {
     let account_id = account_id.as_bytes();
     unsafe {
-        sys::promise_then(
-            promise_idx,
+        PromiseIndex::new(sys::promise_then(
+            promise_idx.raw(),
             account_id.len() as _,
             account_id.as_ptr() as _,
             function_name.len() as _,
@@ -490,7 +490,7 @@ pub fn promise_then(
             arguments.as_ptr() as _,
             &amount as *const Balance as _,
             gas.0,
-        )
+        ))
     }
 }
 
@@ -499,31 +499,40 @@ pub fn promise_and(promise_indices: &[PromiseIndex]) -> PromiseIndex {
     let mut data = vec![0u8; size_of_val(promise_indices)];
     for i in 0..promise_indices.len() {
         data[i * size_of::<PromiseIndex>()..(i + 1) * size_of::<PromiseIndex>()]
-            .copy_from_slice(&promise_indices[i].to_le_bytes());
+            .copy_from_slice(&promise_indices[i].raw().to_le_bytes());
     }
-    unsafe { sys::promise_and(data.as_ptr() as _, promise_indices.len() as _) }
+    unsafe { PromiseIndex::new(sys::promise_and(data.as_ptr() as _, promise_indices.len() as _)) }
 }
 
 pub fn promise_batch_create(account_id: &AccountId) -> PromiseIndex {
     let account_id = account_id.as_ref();
-    unsafe { sys::promise_batch_create(account_id.len() as _, account_id.as_ptr() as _) }
+    unsafe {
+        PromiseIndex::new(sys::promise_batch_create(
+            account_id.len() as _,
+            account_id.as_ptr() as _,
+        ))
+    }
 }
 
 pub fn promise_batch_then(promise_index: PromiseIndex, account_id: &AccountId) -> PromiseIndex {
     let account_id: &str = account_id.as_ref();
     unsafe {
-        sys::promise_batch_then(promise_index, account_id.len() as _, account_id.as_ptr() as _)
+        PromiseIndex::new(sys::promise_batch_then(
+            promise_index.raw(),
+            account_id.len() as _,
+            account_id.as_ptr() as _,
+        ))
     }
 }
 
 pub fn promise_batch_action_create_account(promise_index: PromiseIndex) {
-    unsafe { sys::promise_batch_action_create_account(promise_index) }
+    unsafe { sys::promise_batch_action_create_account(promise_index.raw()) }
 }
 
-pub fn promise_batch_action_deploy_contract(promise_index: u64, code: &[u8]) {
+pub fn promise_batch_action_deploy_contract(promise_index: PromiseIndex, code: &[u8]) {
     unsafe {
         sys::promise_batch_action_deploy_contract(
-            promise_index,
+            promise_index.raw(),
             code.len() as _,
             code.as_ptr() as _,
         )
@@ -539,7 +548,7 @@ pub fn promise_batch_action_function_call(
 ) {
     unsafe {
         sys::promise_batch_action_function_call(
-            promise_index,
+            promise_index.raw(),
             function_name.len() as _,
             function_name.as_ptr() as _,
             arguments.len() as _,
@@ -560,7 +569,7 @@ pub fn promise_batch_action_function_call_weight(
 ) {
     unsafe {
         sys::promise_batch_action_function_call_weight(
-            promise_index,
+            promise_index.raw(),
             function_name.len() as _,
             function_name.as_ptr() as _,
             arguments.len() as _,
@@ -573,7 +582,9 @@ pub fn promise_batch_action_function_call_weight(
 }
 
 pub fn promise_batch_action_transfer(promise_index: PromiseIndex, amount: Balance) {
-    unsafe { sys::promise_batch_action_transfer(promise_index, &amount as *const Balance as _) }
+    unsafe {
+        sys::promise_batch_action_transfer(promise_index.raw(), &amount as *const Balance as _)
+    }
 }
 
 pub fn promise_batch_action_stake(
@@ -583,7 +594,7 @@ pub fn promise_batch_action_stake(
 ) {
     unsafe {
         sys::promise_batch_action_stake(
-            promise_index,
+            promise_index.raw(),
             &amount as *const Balance as _,
             public_key.as_bytes().len() as _,
             public_key.as_bytes().as_ptr() as _,
@@ -597,7 +608,7 @@ pub fn promise_batch_action_add_key_with_full_access(
 ) {
     unsafe {
         sys::promise_batch_action_add_key_with_full_access(
-            promise_index,
+            promise_index.raw(),
             public_key.as_bytes().len() as _,
             public_key.as_bytes().as_ptr() as _,
             nonce,
@@ -645,7 +656,7 @@ pub fn promise_batch_action_add_key_allowance_with_function_call(
     };
     unsafe {
         sys::promise_batch_action_add_key_with_function_call(
-            promise_index,
+            promise_index.raw(),
             public_key.as_bytes().len() as _,
             public_key.as_bytes().as_ptr() as _,
             nonce,
@@ -660,7 +671,7 @@ pub fn promise_batch_action_add_key_allowance_with_function_call(
 pub fn promise_batch_action_delete_key(promise_index: PromiseIndex, public_key: &PublicKey) {
     unsafe {
         sys::promise_batch_action_delete_key(
-            promise_index,
+            promise_index.raw(),
             public_key.as_bytes().len() as _,
             public_key.as_bytes().as_ptr() as _,
         )
@@ -674,7 +685,7 @@ pub fn promise_batch_action_delete_account(
     let beneficiary_id: &str = beneficiary_id.as_ref();
     unsafe {
         sys::promise_batch_action_delete_account(
-            promise_index,
+            promise_index.raw(),
             beneficiary_id.len() as _,
             beneficiary_id.as_ptr() as _,
         )
@@ -709,7 +720,7 @@ pub(crate) fn promise_result_internal(result_idx: u64) -> Result<(), PromiseErro
 /// Consider the execution result of promise under `promise_idx` as execution result of this
 /// function.
 pub fn promise_return(promise_idx: PromiseIndex) {
-    unsafe { sys::promise_return(promise_idx) }
+    unsafe { sys::promise_return(promise_idx.raw()) }
 }
 
 // ###############

--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -456,7 +456,7 @@ pub fn promise_create(
 ) -> PromiseIndex {
     let account_id = account_id.as_bytes();
     unsafe {
-        PromiseIndex::new(sys::promise_create(
+        PromiseIndex(sys::promise_create(
             account_id.len() as _,
             account_id.as_ptr() as _,
             function_name.len() as _,
@@ -480,8 +480,8 @@ pub fn promise_then(
 ) -> PromiseIndex {
     let account_id = account_id.as_bytes();
     unsafe {
-        PromiseIndex::new(sys::promise_then(
-            promise_idx.raw(),
+        PromiseIndex(sys::promise_then(
+            promise_idx.0,
             account_id.len() as _,
             account_id.as_ptr() as _,
             function_name.len() as _,
@@ -499,26 +499,23 @@ pub fn promise_and(promise_indices: &[PromiseIndex]) -> PromiseIndex {
     let mut data = vec![0u8; size_of_val(promise_indices)];
     for i in 0..promise_indices.len() {
         data[i * size_of::<PromiseIndex>()..(i + 1) * size_of::<PromiseIndex>()]
-            .copy_from_slice(&promise_indices[i].raw().to_le_bytes());
+            .copy_from_slice(&promise_indices[i].0.to_le_bytes());
     }
-    unsafe { PromiseIndex::new(sys::promise_and(data.as_ptr() as _, promise_indices.len() as _)) }
+    unsafe { PromiseIndex(sys::promise_and(data.as_ptr() as _, promise_indices.len() as _)) }
 }
 
 pub fn promise_batch_create(account_id: &AccountId) -> PromiseIndex {
     let account_id = account_id.as_ref();
     unsafe {
-        PromiseIndex::new(sys::promise_batch_create(
-            account_id.len() as _,
-            account_id.as_ptr() as _,
-        ))
+        PromiseIndex(sys::promise_batch_create(account_id.len() as _, account_id.as_ptr() as _))
     }
 }
 
 pub fn promise_batch_then(promise_index: PromiseIndex, account_id: &AccountId) -> PromiseIndex {
     let account_id: &str = account_id.as_ref();
     unsafe {
-        PromiseIndex::new(sys::promise_batch_then(
-            promise_index.raw(),
+        PromiseIndex(sys::promise_batch_then(
+            promise_index.0,
             account_id.len() as _,
             account_id.as_ptr() as _,
         ))
@@ -526,13 +523,13 @@ pub fn promise_batch_then(promise_index: PromiseIndex, account_id: &AccountId) -
 }
 
 pub fn promise_batch_action_create_account(promise_index: PromiseIndex) {
-    unsafe { sys::promise_batch_action_create_account(promise_index.raw()) }
+    unsafe { sys::promise_batch_action_create_account(promise_index.0) }
 }
 
 pub fn promise_batch_action_deploy_contract(promise_index: PromiseIndex, code: &[u8]) {
     unsafe {
         sys::promise_batch_action_deploy_contract(
-            promise_index.raw(),
+            promise_index.0,
             code.len() as _,
             code.as_ptr() as _,
         )
@@ -548,7 +545,7 @@ pub fn promise_batch_action_function_call(
 ) {
     unsafe {
         sys::promise_batch_action_function_call(
-            promise_index.raw(),
+            promise_index.0,
             function_name.len() as _,
             function_name.as_ptr() as _,
             arguments.len() as _,
@@ -569,7 +566,7 @@ pub fn promise_batch_action_function_call_weight(
 ) {
     unsafe {
         sys::promise_batch_action_function_call_weight(
-            promise_index.raw(),
+            promise_index.0,
             function_name.len() as _,
             function_name.as_ptr() as _,
             arguments.len() as _,
@@ -582,9 +579,7 @@ pub fn promise_batch_action_function_call_weight(
 }
 
 pub fn promise_batch_action_transfer(promise_index: PromiseIndex, amount: Balance) {
-    unsafe {
-        sys::promise_batch_action_transfer(promise_index.raw(), &amount as *const Balance as _)
-    }
+    unsafe { sys::promise_batch_action_transfer(promise_index.0, &amount as *const Balance as _) }
 }
 
 pub fn promise_batch_action_stake(
@@ -594,7 +589,7 @@ pub fn promise_batch_action_stake(
 ) {
     unsafe {
         sys::promise_batch_action_stake(
-            promise_index.raw(),
+            promise_index.0,
             &amount as *const Balance as _,
             public_key.as_bytes().len() as _,
             public_key.as_bytes().as_ptr() as _,
@@ -608,7 +603,7 @@ pub fn promise_batch_action_add_key_with_full_access(
 ) {
     unsafe {
         sys::promise_batch_action_add_key_with_full_access(
-            promise_index.raw(),
+            promise_index.0,
             public_key.as_bytes().len() as _,
             public_key.as_bytes().as_ptr() as _,
             nonce,
@@ -656,7 +651,7 @@ pub fn promise_batch_action_add_key_allowance_with_function_call(
     };
     unsafe {
         sys::promise_batch_action_add_key_with_function_call(
-            promise_index.raw(),
+            promise_index.0,
             public_key.as_bytes().len() as _,
             public_key.as_bytes().as_ptr() as _,
             nonce,
@@ -671,7 +666,7 @@ pub fn promise_batch_action_add_key_allowance_with_function_call(
 pub fn promise_batch_action_delete_key(promise_index: PromiseIndex, public_key: &PublicKey) {
     unsafe {
         sys::promise_batch_action_delete_key(
-            promise_index.raw(),
+            promise_index.0,
             public_key.as_bytes().len() as _,
             public_key.as_bytes().as_ptr() as _,
         )
@@ -685,7 +680,7 @@ pub fn promise_batch_action_delete_account(
     let beneficiary_id: &str = beneficiary_id.as_ref();
     unsafe {
         sys::promise_batch_action_delete_account(
-            promise_index.raw(),
+            promise_index.0,
             beneficiary_id.len() as _,
             beneficiary_id.as_ptr() as _,
         )
@@ -720,7 +715,7 @@ pub(crate) fn promise_result_internal(result_idx: u64) -> Result<(), PromiseErro
 /// Consider the execution result of promise under `promise_idx` as execution result of this
 /// function.
 pub fn promise_return(promise_idx: PromiseIndex) {
-    unsafe { sys::promise_return(promise_idx.raw()) }
+    unsafe { sys::promise_return(promise_idx.0) }
 }
 
 // ###############

--- a/near-sdk/src/types/vm_types.rs
+++ b/near-sdk/src/types/vm_types.rs
@@ -3,7 +3,19 @@ pub use near_vm_logic::types::{PromiseResult as VmPromiseResult, ReturnData};
 
 //* Types from near_vm_logic
 /// Promise index that is computed only once.
-pub type PromiseIndex = u64;
+#[derive(Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Copy, Clone)]
+pub struct PromiseIndex(u64);
+
+impl PromiseIndex {
+    pub(crate) fn new(ix: u64) -> Self {
+        Self(ix)
+    }
+
+    pub(crate) fn raw(self) -> u64 {
+        self.0
+    }
+}
+
 /// An index of Receipt to append an action
 #[deprecated(since = "4.1.0", note = "type not used within SDK, use u64 directly or another alias")]
 pub type ReceiptIndex = u64;

--- a/near-sdk/src/types/vm_types.rs
+++ b/near-sdk/src/types/vm_types.rs
@@ -4,17 +4,7 @@ pub use near_vm_logic::types::{PromiseResult as VmPromiseResult, ReturnData};
 //* Types from near_vm_logic
 /// Promise index that is computed only once.
 #[derive(Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Copy, Clone)]
-pub struct PromiseIndex(u64);
-
-impl PromiseIndex {
-    pub(crate) fn new(ix: u64) -> Self {
-        Self(ix)
-    }
-
-    pub(crate) fn raw(self) -> u64 {
-        self.0
-    }
-}
+pub struct PromiseIndex(pub(crate) u64);
 
 /// An index of Receipt to append an action
 #[deprecated(since = "4.1.0", note = "type not used within SDK, use u64 directly or another alias")]


### PR DESCRIPTION
Closes #945

This is **breaking** and should only be released with a major version bump (5.0.0)