### PR TITLE
[Fix] Ignore a security audit error.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,4 +74,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: audit
-          args: --ignore RUSTSEC-2020-0071
+          args: --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2022-0093


### PR DESCRIPTION
It would be nice to create an `audit.toml` going forward and have comments there in regards to what and why is ignored. 