### PR TITLE
chore: release v5.0.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,62 @@
 
 ## [Unreleased]
 
+## [5.0.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v4.1.1...near-sdk-v5.0.0) - 2023-11-18
+
+### Added
+- adding `nep-0330` contract source metadata info ([#1106](https://github.com/near/near-sdk-rs/pull/1106))
+- Support Result types in #[handle_result] regardless of how they're referred to ([#1099](https://github.com/near/near-sdk-rs/pull/1099))
+- accumulate compilation errors to provide them all at once ([#1097](https://github.com/near/near-sdk-rs/pull/1097))
+- [**breaking**] prohibit `Self` in non-init methods to prevent common footguns ([#1073](https://github.com/near/near-sdk-rs/pull/1073))
+- [**breaking**] Make `PromiseIndex` a newtype, so it cannot be misused ([#1066](https://github.com/near/near-sdk-rs/pull/1066))
+- Expose alt_bn128 curve host functions via near_sdk::env ([#1028](https://github.com/near/near-sdk-rs/pull/1028))
+- Deprecate `Self` in non-init function's return type ([#1030](https://github.com/near/near-sdk-rs/pull/1030))
+- new `near_sdk::store::UnorderedMap::defrag` method useful for gas tuning ([#1023](https://github.com/near/near-sdk-rs/pull/1023))
+- add ed25519_verify host function ([#1010](https://github.com/near/near-sdk-rs/pull/1010))
+- add `Default` implementation to JSON types ([#1018](https://github.com/near/near-sdk-rs/pull/1018))
+
+### Fixed
+- Fixed compilation-tests after stable Rust release 1.72 ([#1081](https://github.com/near/near-sdk-rs/pull/1081))
+- Un-deprecate private init functions ([#1074](https://github.com/near/near-sdk-rs/pull/1074))
+- *(store::TreeMap)* remove of the entry API now correctly updates the tree root when changed ([#995](https://github.com/near/near-sdk-rs/pull/995))
+- strip return types of lifetimes ([#982](https://github.com/near/near-sdk-rs/pull/982))
+- prohibit NEAR function generics ([#980](https://github.com/near/near-sdk-rs/pull/980))
+- concretize `Self` references in method signatures ([#1001](https://github.com/near/near-sdk-rs/pull/1001))
+- make event `emit` public ([#975](https://github.com/near/near-sdk-rs/pull/975))
+- Expose missing UnorderedSet iter types ([#961](https://github.com/near/near-sdk-rs/pull/961))
+- add compiler error for using Result with init ([#1024](https://github.com/near/near-sdk-rs/pull/1024))
+- fully qualify the schema_container method call ([#1003](https://github.com/near/near-sdk-rs/pull/1003))
+- `__abi-embed` compilation error ([#971](https://github.com/near/near-sdk-rs/pull/971))
+
+### Other
+- [**breaking**] Use type-safe NearToken instead of u128/U128 ([#1104](https://github.com/near/near-sdk-rs/pull/1104))
+- migrate to a external near-account-id crate for reusable AccountId type ([#1108](https://github.com/near/near-sdk-rs/pull/1108))
+- [**breaking**] Delete the deprecated metadata module from near-sdk-macros in favor of near-abi ([#1098](https://github.com/near/near-sdk-rs/pull/1098))
+- documented env::random_seed ([#1096](https://github.com/near/near-sdk-rs/pull/1096))
+- Update borsh to 1.0.0 ([#1075](https://github.com/near/near-sdk-rs/pull/1075))
+- bump version of near-workspaces ([#1094](https://github.com/near/near-sdk-rs/pull/1094))
+- upgrade syn crate from version 1 to 2 ([#1088](https://github.com/near/near-sdk-rs/pull/1088))
+- Move from Gas to NearGas from near-gas crate ([#1082](https://github.com/near/near-sdk-rs/pull/1082))
+- Respect `{{ matrix.toolchain }}` in "Test Core: test" job ([#1085](https://github.com/near/near-sdk-rs/pull/1085))
+- Add release-plz to automate releases ([#1069](https://github.com/near/near-sdk-rs/pull/1069))
+- add `add_access_key` test coverage ([#1029](https://github.com/near/near-sdk-rs/pull/1029))
+- disentangle bindgen extractor logic ([#1025](https://github.com/near/near-sdk-rs/pull/1025))
+- Bumped supported rust version to minimum 1.68 - reflected in BuildKite ([#1014](https://github.com/near/near-sdk-rs/pull/1014))
+- Update visibility of FreeList and method ([#998](https://github.com/near/near-sdk-rs/pull/998))
+- Add documentation to collection cache types ([#997](https://github.com/near/near-sdk-rs/pull/997))
+- abstract common functions in `Keys` and `KeysRange` ([#989](https://github.com/near/near-sdk-rs/pull/989))
+- perf (`TreeMap.range`): Update the TreeMap->Range logic ([#964](https://github.com/near/near-sdk-rs/pull/964))
+- Took out a footgun with allowances ([#976](https://github.com/near/near-sdk-rs/pull/976))
+- Depreciated legacy tree map  ([#963](https://github.com/near/near-sdk-rs/pull/963))
+- Removed the not ready enum type ([#977](https://github.com/near/near-sdk-rs/pull/977))
+- use `insta` crate for testing macro generated code ([#1090](https://github.com/near/near-sdk-rs/pull/1090))
+- Use global paths in macro expansions ([#1060](https://github.com/near/near-sdk-rs/pull/1060))
+- fix typo ([#1052](https://github.com/near/near-sdk-rs/pull/1052))
+- change private init method from error to warning ([#1043](https://github.com/near/near-sdk-rs/pull/1043))
+- cover all features with clippy ([#1044](https://github.com/near/near-sdk-rs/pull/1044))
+- use attr sig info in abi generator ([#1036](https://github.com/near/near-sdk-rs/pull/1036))
+- disentangle bindgen code generation ([#1033](https://github.com/near/near-sdk-rs/pull/1033))
+
 ### Fixed
 - Exposed missing iterator types used in `near_sdk::store::UnorderedSet`. [PR 961](https://github.com/near/near-sdk-rs/pull/961)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## [5.0.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v4.1.1...near-sdk-v5.0.0) - 2023-11-18
+## [5.0.0-alpha.1](https://github.com/near/near-sdk-rs/compare/4.1.1...near-sdk-v5.0.0-alpha.1) - 2023-11-18
 
 ### Added
 - adding `nep-0330` contract source metadata info ([#1106](https://github.com/near/near-sdk-rs/pull/1106))
@@ -24,7 +24,7 @@
 - prohibit NEAR function generics ([#980](https://github.com/near/near-sdk-rs/pull/980))
 - concretize `Self` references in method signatures ([#1001](https://github.com/near/near-sdk-rs/pull/1001))
 - make event `emit` public ([#975](https://github.com/near/near-sdk-rs/pull/975))
-- Expose missing UnorderedSet iter types ([#961](https://github.com/near/near-sdk-rs/pull/961))
+- Exposed missing iterator types used in `near_sdk::store::UnorderedSet` ([#961](https://github.com/near/near-sdk-rs/pull/961))
 - add compiler error for using Result with init ([#1024](https://github.com/near/near-sdk-rs/pull/1024))
 - fully qualify the schema_container method call ([#1003](https://github.com/near/near-sdk-rs/pull/1003))
 - `__abi-embed` compilation error ([#971](https://github.com/near/near-sdk-rs/pull/971))
@@ -57,9 +57,6 @@
 - cover all features with clippy ([#1044](https://github.com/near/near-sdk-rs/pull/1044))
 - use attr sig info in abi generator ([#1036](https://github.com/near/near-sdk-rs/pull/1036))
 - disentangle bindgen code generation ([#1033](https://github.com/near/near-sdk-rs/pull/1033))
-
-### Fixed
-- Exposed missing iterator types used in `near_sdk::store::UnorderedSet`. [PR 961](https://github.com/near/near-sdk-rs/pull/961)
 
 ## [4.1.1] - 2022-11-10
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.0.0"
+version = "5.0.0-alpha.1"
 
 # Special triple # comment for ci.
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 exclude = ["examples/"]
 
 [workspace.package]
-version = "4.1.1"
+version = "5.0.0"
 
 # Special triple # comment for ci.
 [patch.crates-io]

--- a/contract-builder/build.sh
+++ b/contract-builder/build.sh
@@ -22,7 +22,7 @@ else
 fi
 
 if [[ ${branch} == "master" ]]; then
-    docker buildx build --platform $1 -t nearprotocol/"${image_name}:${branch}-${commit}-$1" -t nearprotocol/${image_name}:latest-$1 --push .
+    docker buildx build --platform linux/$1 -t nearprotocol/"${image_name}:${branch}-${commit}-$1" -t nearprotocol/${image_name}:latest-$1 --push .
 else
-    docker buildx build --platform $1 -t nearprotocol/"${image_name}:${branch}-${commit}-$1" --push .
+    docker buildx build --platform linux/$1 -t nearprotocol/"${image_name}:${branch}-${commit}-$1" --push .
 fi

--- a/examples/adder/Cargo.toml
+++ b/examples/adder/Cargo.toml
@@ -9,19 +9,15 @@ crate-type = ["cdylib"]
 
 [dependencies]
 near-sdk = { path = "../../near-sdk", features = ["unstable"] }
-serde = { version = "1", features = ["derive"] }
 schemars = "0.8"
 
 [dev-dependencies]
-near-workspaces = { version = "0.9.0" }
+near-workspaces = { version = "0.9.0", default-features = false, features = ["install"] }
 serde_json = "1.0"
 tokio = { version = "1.14", features = ["full"] }
 anyhow = "1.0"
 near-abi = "0.4.0"
 zstd = "0.11"
-
-[patch.crates-io]
-near-sdk = { path = "../../near-sdk" }
 
 [profile.release]
 codegen-units = 1
@@ -30,6 +26,3 @@ opt-level = "z"
 lto = true
 debug = false
 panic = "abort"
-
-[workspace]
-members = []

--- a/examples/adder/Cargo.toml
+++ b/examples/adder/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = { version = "4.1.1", features = ["unstable"] }
+near-sdk = { path = "../../near-sdk", features = ["unstable"] }
 serde = { version = "1", features = ["derive"] }
 schemars = "0.8"
 

--- a/examples/adder/src/lib.rs
+++ b/examples/adder/src/lib.rs
@@ -4,10 +4,12 @@ use near_sdk::{near_bindgen, NearSchema};
 
 #[derive(NearSchema, Serialize, Deserialize, BorshDeserialize, BorshSerialize)]
 #[borsh(crate = "near_sdk::borsh")]
+#[serde(crate = "near_sdk::serde")]
 #[abi(json, borsh)]
 pub struct Pair(u32, u32);
 
 #[derive(NearSchema, Serialize, Deserialize)]
+#[serde(crate = "near_sdk::serde")]
 #[abi(json, borsh)]
 pub struct DoublePair {
     first: Pair,
@@ -63,28 +65,28 @@ mod tests {
         let res = contract.view("__contract_abi").await?;
 
         let abi_root =
-            serde_json::from_slice::<AbiRoot>(&zstd::decode_all(&res.result[..])?).unwrap();
+            serde_json::from_slice::<AbiRoot>(&zstd::decode_all(&res.result[..])?)?;
 
         assert_eq!(abi_root.schema_version, "0.3.0");
         assert_eq!(abi_root.metadata.name, Some("adder".to_string()));
         assert_eq!(abi_root.metadata.version, Some("0.1.0".to_string()));
         assert_eq!(
             &abi_root.metadata.authors[..],
-            &["Near Inc <hello@nearprotocol.com>".to_string()]
+            &["Near Inc <hello@nearprotocol.com>"]
         );
         assert_eq!(abi_root.body.functions.len(), 3);
 
         let add_function = &abi_root.body.functions[0];
 
-        assert_eq!(add_function.name, "add".to_string());
+        assert_eq!(add_function.name, "add");
         assert_eq!(add_function.doc, Some(" Adds two pairs point-wise.".to_string()));
         assert_eq!(add_function.kind, AbiFunctionKind::View);
-        assert_eq!(add_function.modifiers, vec![]);
+        assert_eq!(add_function.modifiers, &[]);
         match &add_function.params {
             AbiParameters::Json { args } => {
                 assert_eq!(args.len(), 2);
-                assert_eq!(args[0].name, "a".to_string());
-                assert_eq!(args[1].name, "b".to_string());
+                assert_eq!(args[0].name, "a");
+                assert_eq!(args[1].name, "b");
             }
             AbiParameters::Borsh { .. } => {
                 assert!(false);

--- a/examples/callback-results/Cargo.toml
+++ b/examples/callback-results/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = "4.1.1"
+near-sdk = { path = "../../near-sdk" }
 
 [dev-dependencies]
 near-workspaces = { version = "0.9.0" }

--- a/examples/callback-results/Cargo.toml
+++ b/examples/callback-results/Cargo.toml
@@ -11,13 +11,10 @@ crate-type = ["cdylib"]
 near-sdk = { path = "../../near-sdk" }
 
 [dev-dependencies]
-near-workspaces = { version = "0.9.0" }
+near-workspaces = { version = "0.9.0", default-features = false, features = ["install"] }
 serde_json = "1.0"
 tokio = { version = "1.14", features = ["full"] }
 anyhow = "1.0"
-
-[patch.crates-io]
-near-sdk = { path = "../../near-sdk" }
 
 [profile.release]
 codegen-units = 1

--- a/examples/cross-contract-calls/Cargo.toml
+++ b/examples/cross-contract-calls/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dev-dependencies]
 anyhow = "1.0"
-near-sdk = { version = "4.1.1" }
+near-sdk = { path = "../../near-sdk" }
 serde_json = "1.0"
 test-case = "2.0"
 tokio = { version = "1.14", features = ["full"] }
@@ -14,7 +14,6 @@ near-workspaces = { version = "0.9.0" }
 
 cross-contract-high-level = { path = "./high-level" }
 cross-contract-low-level = { path = "./low-level" }
-
 
 [patch.crates-io]
 near-sdk = { path = "../../near-sdk" }

--- a/examples/cross-contract-calls/Cargo.toml
+++ b/examples/cross-contract-calls/Cargo.toml
@@ -10,13 +10,10 @@ near-sdk = { path = "../../near-sdk" }
 serde_json = "1.0"
 test-case = "2.0"
 tokio = { version = "1.14", features = ["full"] }
-near-workspaces = { version = "0.9.0" }
+near-workspaces = { version = "0.9.0", default-features = false, features = ["install"] }
 
 cross-contract-high-level = { path = "./high-level" }
 cross-contract-low-level = { path = "./low-level" }
-
-[patch.crates-io]
-near-sdk = { path = "../../near-sdk" }
 
 [profile.release]
 codegen-units = 1

--- a/examples/factory-contract/Cargo.toml
+++ b/examples/factory-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dev-dependencies]
 anyhow = "1.0"
-near-sdk = { version = "4.1.1"}
+near-sdk = { path = "../../near-sdk" }
 serde_json = "1.0"
 test-case = "2.0"
 tokio = { version = "1.14", features = ["full"] }
@@ -16,7 +16,6 @@ factory-contract-low-level = { path = "./low-level" }
 
 [patch.crates-io]
 near-sdk = { path = "../../near-sdk" }
-
 
 [profile.release]
 codegen-units = 1

--- a/examples/factory-contract/Cargo.toml
+++ b/examples/factory-contract/Cargo.toml
@@ -6,16 +6,8 @@ edition = "2021"
 
 [dev-dependencies]
 anyhow = "1.0"
-near-sdk = { path = "../../near-sdk" }
-serde_json = "1.0"
-test-case = "2.0"
 tokio = { version = "1.14", features = ["full"] }
-near-workspaces = { version = "0.9.0" }
-factory-contract-high-level = { path = "./high-level" }
-factory-contract-low-level = { path = "./low-level" }
-
-[patch.crates-io]
-near-sdk = { path = "../../near-sdk" }
+near-workspaces = { version = "0.9.0", default-features = false, features = ["install"] }
 
 [profile.release]
 codegen-units = 1

--- a/examples/factory-contract/Cargo.toml
+++ b/examples/factory-contract/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dev-dependencies]
 anyhow = "1.0"
+test-case = "2.0"
 tokio = { version = "1.14", features = ["full"] }
 near-workspaces = { version = "0.9.0", default-features = false, features = ["install"] }
 

--- a/examples/factory-contract/tests/workspaces.rs
+++ b/examples/factory-contract/tests/workspaces.rs
@@ -1,4 +1,4 @@
-use near_workspaces::types::NearToken;
+use near_workspaces::types::{AccountIdRef, NearToken};
 use test_case::test_case;
 
 #[test_case("factory_contract_high_level")]
@@ -11,11 +11,11 @@ async fn test_deploy_status_message(contract_name: &str) -> anyhow::Result<()> {
 
     // Needed because of 32 character minimum for TLA
     // https://docs.near.org/docs/concepts/account#top-level-accounts
-    let status_id: near_sdk::AccountId = "status-top-level-account-long-name".parse().unwrap();
+    let status_id = AccountIdRef::new_or_panic("status-top-level-account-long-name");
     let status_amt = NearToken::from_near(20);
     let res = contract
         .call("deploy_status_message")
-        .args_json((status_id.clone(), status_amt))
+        .args_json((status_id, status_amt))
         .max_gas()
         .deposit(NearToken::from_near(50))
         .transact()

--- a/examples/factory-contract/tests/workspaces.rs
+++ b/examples/factory-contract/tests/workspaces.rs
@@ -1,4 +1,4 @@
-use near_workspaces::types::{AccountIdRef, NearToken};
+use near_workspaces::types::{AccountId, NearToken};
 use test_case::test_case;
 
 #[test_case("factory_contract_high_level")]
@@ -11,11 +11,11 @@ async fn test_deploy_status_message(contract_name: &str) -> anyhow::Result<()> {
 
     // Needed because of 32 character minimum for TLA
     // https://docs.near.org/docs/concepts/account#top-level-accounts
-    let status_id = AccountIdRef::new_or_panic("status-top-level-account-long-name");
+    let status_id: AccountId = "status-top-level-account-long-name".parse()?;
     let status_amt = NearToken::from_near(20);
     let res = contract
         .call("deploy_status_message")
-        .args_json((status_id, status_amt))
+        .args_json((&status_id, status_amt))
         .max_gas()
         .deposit(NearToken::from_near(50))
         .transact()

--- a/examples/fungible-token/Cargo.toml
+++ b/examples/fungible-token/Cargo.toml
@@ -6,19 +6,9 @@ edition = "2021"
 
 [dev-dependencies]
 anyhow = "1.0"
-base64 = "0.13"
-near-primitives = "0.17"
 near-sdk = { path = "../../near-sdk" }
-serde_json = "1.0"
 tokio = { version = "1.14", features = ["full"] }
-near-workspaces = { version = "0.9.0" }
-
-# remember to include a line for each contract
-fungible-token = { path = "./ft" }
-defi = { path = "./test-contract-defi" }
-
-[patch.crates-io]
-near-sdk = { path = "../../near-sdk" }
+near-workspaces = { version = "0.9.0", default-features = false, features = ["install"] }
 
 [profile.release]
 codegen-units = 1

--- a/examples/fungible-token/Cargo.toml
+++ b/examples/fungible-token/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 anyhow = "1.0"
 base64 = "0.13"
 near-primitives = "0.17"
-near-sdk = { version = "4.1.1" }
+near-sdk = { path = "../../near-sdk" }
 serde_json = "1.0"
 tokio = { version = "1.14", features = ["full"] }
 near-workspaces = { version = "0.9.0" }

--- a/examples/fungible-token/test-contract-defi/Cargo.toml
+++ b/examples/fungible-token/test-contract-defi/Cargo.toml
@@ -10,4 +10,3 @@ crate-type = ["cdylib"]
 [dependencies]
 near-sdk = { path = "../../../near-sdk" }
 near-contract-standards = { path = "../../../near-contract-standards" }
-schemars = "0.8"

--- a/examples/lockable-fungible-token/Cargo.toml
+++ b/examples/lockable-fungible-token/Cargo.toml
@@ -8,13 +8,12 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = { version = "4.1.1"}
-
+near-sdk = { path = "../../near-sdk" }
 
 [dev-dependencies]
 anyhow = "1.0"
 near-primitives = "0.17"
-near-sdk = { version = "4.1.1" }
+near-sdk = { path = "../../near-sdk" }
 serde_json = "1.0"
 tokio = { version = "1.14", features = ["full"] }
 near-workspaces = { version = "0.9.0" }

--- a/examples/lockable-fungible-token/Cargo.toml
+++ b/examples/lockable-fungible-token/Cargo.toml
@@ -12,14 +12,8 @@ near-sdk = { path = "../../near-sdk" }
 
 [dev-dependencies]
 anyhow = "1.0"
-near-primitives = "0.17"
-near-sdk = { path = "../../near-sdk" }
-serde_json = "1.0"
 tokio = { version = "1.14", features = ["full"] }
-near-workspaces = { version = "0.9.0" }
-
-[patch.crates-io]
-near-sdk = { path = "../../near-sdk" }
+near-workspaces = { version = "0.9.0", default-features = false, features = ["install"] }
 
 [profile.release]
 codegen-units = 1
@@ -28,6 +22,3 @@ opt-level = "z"
 lto = true
 debug = false
 panic = "abort"
-
-[workspace]
-members = []

--- a/examples/mission-control/Cargo.toml
+++ b/examples/mission-control/Cargo.toml
@@ -17,6 +17,3 @@ opt-level = "z"
 lto = true
 debug = false
 panic = "abort"
-
-[workspace]
-members = []

--- a/examples/non-fungible-token/Cargo.toml
+++ b/examples/non-fungible-token/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 anyhow = "1.0"
 near-primitives = "0.17"
 near-contract-standards = { path = "../../near-contract-standards" }
-near-sdk = { version = "4.1.1" }
+near-sdk = { path = "../../near-sdk" }
 serde_json = "1.0"
 tokio = { version = "1.14", features = ["full"] }
 near-workspaces = { version = "0.9.0" }

--- a/examples/non-fungible-token/Cargo.toml
+++ b/examples/non-fungible-token/Cargo.toml
@@ -6,12 +6,10 @@ edition = "2021"
 
 [dev-dependencies]
 anyhow = "1.0"
-near-primitives = "0.17"
 near-contract-standards = { path = "../../near-contract-standards" }
 near-sdk = { path = "../../near-sdk" }
-serde_json = "1.0"
 tokio = { version = "1.14", features = ["full"] }
-near-workspaces = { version = "0.9.0" }
+near-workspaces = { version = "0.9.0", default-features = false, features = ["install"] }
 
 [profile.release]
 codegen-units = 1
@@ -21,9 +19,6 @@ lto = true
 debug = false
 panic = "abort"
 overflow-checks = true
-
-[patch.crates-io]
-near-sdk = { path = "../../near-sdk" }
 
 [workspace]
 # remember to include a member for each contract

--- a/examples/status-message/Cargo.toml
+++ b/examples/status-message/Cargo.toml
@@ -17,6 +17,3 @@ opt-level = "z"
 lto = true
 debug = false
 panic = "abort"
-
-[workspace]
-members = []

--- a/examples/test-contract/Cargo.toml
+++ b/examples/test-contract/Cargo.toml
@@ -17,6 +17,3 @@ opt-level = "z"
 lto = true
 debug = false
 panic = "abort"
-
-[workspace]
-members = []

--- a/examples/versioned/Cargo.toml
+++ b/examples/versioned/Cargo.toml
@@ -17,6 +17,3 @@ opt-level = "z"
 lto = true
 debug = false
 panic = "abort"
-
-[workspace]
-members = []

--- a/near-contract-standards/CHANGELOG.md
+++ b/near-contract-standards/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [5.0.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v4.1.1...near-contract-standards-v5.0.0) - 2023-11-18
+
+### Added
+- adding `nep-0330` contract source metadata info ([#1106](https://github.com/near/near-sdk-rs/pull/1106))
+
+### Fixed
+- remove receiver approval ([#1020](https://github.com/near/near-sdk-rs/pull/1020))
+- rename param `approvals` to `approved_account_ids` ([#1019](https://github.com/near/near-sdk-rs/pull/1019))
+- Properly report an error when Approval Extension is not enabled vs when account is not approved ([#1021](https://github.com/near/near-sdk-rs/pull/1021))
+
+### Other
+- [**breaking**] Use type-safe NearToken instead of u128/U128 ([#1104](https://github.com/near/near-sdk-rs/pull/1104))
+- migrate to a external near-account-id crate for reusable AccountId type ([#1108](https://github.com/near/near-sdk-rs/pull/1108))
+- Update borsh to 1.0.0 ([#1075](https://github.com/near/near-sdk-rs/pull/1075))
+- Move from Gas to NearGas from near-gas crate ([#1082](https://github.com/near/near-sdk-rs/pull/1082))
+- Deprecate Fungible Token declarative macros. ([#1054](https://github.com/near/near-sdk-rs/pull/1054))
+- Add release-plz to automate releases ([#1069](https://github.com/near/near-sdk-rs/pull/1069))
+- *(contract-standards)* deprecate declarative macros in NFT helpers, promote explicit trait implementations instead ([#1042](https://github.com/near/near-sdk-rs/pull/1042))
+- Added a default method for TokenMetadata ([#978](https://github.com/near/near-sdk-rs/pull/978))
+- Removed the not ready enum type ([#977](https://github.com/near/near-sdk-rs/pull/977))
+- Fix empty owner tokens `start_index` error ([#962](https://github.com/near/near-sdk-rs/pull/962))

--- a/near-contract-standards/CHANGELOG.md
+++ b/near-contract-standards/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [5.0.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v4.1.1...near-contract-standards-v5.0.0) - 2023-11-18
+## [5.0.0-alpha.1](https://github.com/near/near-sdk-rs/compare/4.1.1...near-contract-standards-v5.0.0-alpha.1) - 2023-11-18
 
 ### Added
 - adding `nep-0330` contract source metadata info ([#1106](https://github.com/near/near-sdk-rs/pull/1106))

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.0.0", default-features = false, features = ["legacy"] }
+near-sdk = { path = "../near-sdk", version = "~5.0.0-alpha.1", default-features = false, features = ["legacy"] }
 serde = "1"
 serde_json = "1"
 schemars = "0.8"

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~4.1.1", default-features = false, features = ["legacy"] }
+near-sdk = { path = "../near-sdk", version = "~5.0.0", default-features = false, features = ["legacy"] }
 serde = "1"
 serde_json = "1"
 schemars = "0.8"

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,8 +21,8 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.0.0" }
-near-sys = { path = "../near-sys", version = "0.2" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.0.0-alpha.1" }
+near-sys = { path = "../near-sys", version = "0.2.1" }
 base64 = "0.13"
 borsh = { version = "1.0.0", features = ["derive"] }
 bs58 = "0.4"

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~4.1.1" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.0.0" }
 near-sys = { path = "../near-sys", version = "0.2" }
 base64 = "0.13"
 borsh = { version = "1.0.0", features = ["derive"] }

--- a/near-sys/CHANGELOG.md
+++ b/near-sys/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.1](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.0...near-sys-v0.2.1) - 2023-11-18
+## [0.2.1](https://github.com/near/near-sdk-rs/compare/4.1.1...near-sys-v0.2.1) - 2023-11-18
 
 ### Other
 - Add release-plz to automate releases ([#1069](https://github.com/near/near-sdk-rs/pull/1069))

--- a/near-sys/CHANGELOG.md
+++ b/near-sys/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.1](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.0...near-sys-v0.2.1) - 2023-11-18
+
+### Other
+- Add release-plz to automate releases ([#1069](https://github.com/near/near-sdk-rs/pull/1069))

--- a/near-sys/Cargo.toml
+++ b/near-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sys"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Near Inc <hello@near.org>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `near-sdk`: 4.1.1 -> 5.0.0 (⚠️ API breaking changes)
* `near-sdk-macros`: 4.1.1 -> 5.0.0
* `near-sys`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `near-contract-standards`: 4.1.1 -> 5.0.0 (✓ API compatible changes)

### ⚠️ `near-sdk` breaking changes

```
--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.24.2/src/lints/enum_variant_missing.ron

Failed in:
  variant PromiseError::NotReady, previously in file /tmp/.tmpGbdLOj/near-sdk/src/types/vm_types.rs:41
  variant PromiseResult::NotReady, previously in file /tmp/.tmpGbdLOj/near-sdk/src/types/vm_types.rs:18

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing, renamed, or changed from const to static.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.24.2/src/lints/pub_module_level_const_missing.ron

Failed in:
  ONE_YOCTO in file /tmp/.tmpGbdLOj/near-sdk/src/types/mod.rs:50
  STORAGE_PRICE_PER_BYTE in file /tmp/.tmpGbdLOj/near-sdk/src/environment/env.rs:804
  ONE_NEAR in file /tmp/.tmpGbdLOj/near-sdk/src/types/mod.rs:53

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.24.2/src/lints/struct_missing.ron

Failed in:
  struct near_sdk::__private::Metadata, previously in file /tmp/.tmpGbdLOj/near-sdk/src/private/metadata.rs:7
  struct near_sdk::ParseAccountIdError, previously in file /tmp/.tmpGbdLOj/near-sdk/src/types/account_id.rs:124
  struct near_sdk::Gas, previously in file /tmp/.tmpGbdLOj/near-sdk/src/types/gas.rs:21
  struct near_sdk::json_types::ValidAccountId, previously in file /tmp/.tmpGbdLOj/near-sdk/src/types/account_id.rs:40
  struct near_sdk::AccountId, previously in file /tmp/.tmpGbdLOj/near-sdk/src/types/account_id.rs:40
  struct near_sdk::__private::MethodMetadata, previously in file /tmp/.tmpGbdLOj/near-sdk/src/private/metadata.rs:22

--- failure type_marked_deprecated: #[deprecated] added on type ---

Description:
A type is now #[deprecated]. Downstream crates will get a compiler warning when using this type.
        ref: https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-deprecated-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.24.2/src/lints/type_marked_deprecated.ron

Failed in:
  Struct LegacyTreeMap in /tmp/.tmpbkllow/near-sdk-rs/near-sdk/src/collections/legacy_tree_map.rs:25
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-sdk`
<blockquote>

## [5.0.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v4.1.1...near-sdk-v5.0.0) - 2023-11-18

### Added
- adding `nep-0330` contract source metadata info ([#1106](https://github.com/near/near-sdk-rs/pull/1106))
- Support Result types in #[handle_result] regardless of how they're referred to ([#1099](https://github.com/near/near-sdk-rs/pull/1099))
- accumulate compilation errors to provide them all at once ([#1097](https://github.com/near/near-sdk-rs/pull/1097))
- [**breaking**] prohibit `Self` in non-init methods to prevent common footguns ([#1073](https://github.com/near/near-sdk-rs/pull/1073))
- [**breaking**] Make `PromiseIndex` a newtype, so it cannot be misused ([#1066](https://github.com/near/near-sdk-rs/pull/1066))
- Expose alt_bn128 curve host functions via near_sdk::env ([#1028](https://github.com/near/near-sdk-rs/pull/1028))
- Deprecate `Self` in non-init function's return type ([#1030](https://github.com/near/near-sdk-rs/pull/1030))
- new `near_sdk::store::UnorderedMap::defrag` method useful for gas tuning ([#1023](https://github.com/near/near-sdk-rs/pull/1023))
- add ed25519_verify host function ([#1010](https://github.com/near/near-sdk-rs/pull/1010))
- add `Default` implementation to JSON types ([#1018](https://github.com/near/near-sdk-rs/pull/1018))

### Fixed
- Fixed compilation-tests after stable Rust release 1.72 ([#1081](https://github.com/near/near-sdk-rs/pull/1081))
- Un-deprecate private init functions ([#1074](https://github.com/near/near-sdk-rs/pull/1074))
- *(store::TreeMap)* remove of the entry API now correctly updates the tree root when changed ([#995](https://github.com/near/near-sdk-rs/pull/995))
- strip return types of lifetimes ([#982](https://github.com/near/near-sdk-rs/pull/982))
- prohibit NEAR function generics ([#980](https://github.com/near/near-sdk-rs/pull/980))
- concretize `Self` references in method signatures ([#1001](https://github.com/near/near-sdk-rs/pull/1001))
- make event `emit` public ([#975](https://github.com/near/near-sdk-rs/pull/975))
- Expose missing UnorderedSet iter types ([#961](https://github.com/near/near-sdk-rs/pull/961))
- add compiler error for using Result with init ([#1024](https://github.com/near/near-sdk-rs/pull/1024))
- fully qualify the schema_container method call ([#1003](https://github.com/near/near-sdk-rs/pull/1003))
- `__abi-embed` compilation error ([#971](https://github.com/near/near-sdk-rs/pull/971))

### Other
- [**breaking**] Use type-safe NearToken instead of u128/U128 ([#1104](https://github.com/near/near-sdk-rs/pull/1104))
- migrate to a external near-account-id crate for reusable AccountId type ([#1108](https://github.com/near/near-sdk-rs/pull/1108))
- [**breaking**] Delete the deprecated metadata module from near-sdk-macros in favor of near-abi ([#1098](https://github.com/near/near-sdk-rs/pull/1098))
- documented env::random_seed ([#1096](https://github.com/near/near-sdk-rs/pull/1096))
- Update borsh to 1.0.0 ([#1075](https://github.com/near/near-sdk-rs/pull/1075))
- bump version of near-workspaces ([#1094](https://github.com/near/near-sdk-rs/pull/1094))
- upgrade syn crate from version 1 to 2 ([#1088](https://github.com/near/near-sdk-rs/pull/1088))
- Move from Gas to NearGas from near-gas crate ([#1082](https://github.com/near/near-sdk-rs/pull/1082))
- Respect `{{ matrix.toolchain }}` in "Test Core: test" job ([#1085](https://github.com/near/near-sdk-rs/pull/1085))
- Add release-plz to automate releases ([#1069](https://github.com/near/near-sdk-rs/pull/1069))
- add `add_access_key` test coverage ([#1029](https://github.com/near/near-sdk-rs/pull/1029))
- disentangle bindgen extractor logic ([#1025](https://github.com/near/near-sdk-rs/pull/1025))
- Bumped supported rust version to minimum 1.68 - reflected in BuildKite ([#1014](https://github.com/near/near-sdk-rs/pull/1014))
- Update visibility of FreeList and method ([#998](https://github.com/near/near-sdk-rs/pull/998))
- Add documentation to collection cache types ([#997](https://github.com/near/near-sdk-rs/pull/997))
- abstract common functions in `Keys` and `KeysRange` ([#989](https://github.com/near/near-sdk-rs/pull/989))
- perf (`TreeMap.range`): Update the TreeMap->Range logic ([#964](https://github.com/near/near-sdk-rs/pull/964))
- Took out a footgun with allowances ([#976](https://github.com/near/near-sdk-rs/pull/976))
- Depreciated legacy tree map  ([#963](https://github.com/near/near-sdk-rs/pull/963))
- Removed the not ready enum type ([#977](https://github.com/near/near-sdk-rs/pull/977))
- use `insta` crate for testing macro generated code ([#1090](https://github.com/near/near-sdk-rs/pull/1090))
- Use global paths in macro expansions ([#1060](https://github.com/near/near-sdk-rs/pull/1060))
- fix typo ([#1052](https://github.com/near/near-sdk-rs/pull/1052))
- change private init method from error to warning ([#1043](https://github.com/near/near-sdk-rs/pull/1043))
- cover all features with clippy ([#1044](https://github.com/near/near-sdk-rs/pull/1044))
- use attr sig info in abi generator ([#1036](https://github.com/near/near-sdk-rs/pull/1036))
- disentangle bindgen code generation ([#1033](https://github.com/near/near-sdk-rs/pull/1033))

### Fixed
- Exposed missing iterator types used in `near_sdk::store::UnorderedSet`. [PR 961](https://github.com/near/near-sdk-rs/pull/961)
</blockquote>

## `near-sys`
<blockquote>

## [0.2.1](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.0...near-sys-v0.2.1) - 2023-11-18

### Other
- Add release-plz to automate releases ([#1069](https://github.com/near/near-sdk-rs/pull/1069))
</blockquote>

## `near-contract-standards`
<blockquote>

## [5.0.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v4.1.1...near-contract-standards-v5.0.0) - 2023-11-18

### Added
- adding `nep-0330` contract source metadata info ([#1106](https://github.com/near/near-sdk-rs/pull/1106))

### Fixed
- remove receiver approval ([#1020](https://github.com/near/near-sdk-rs/pull/1020))
- rename param `approvals` to `approved_account_ids` ([#1019](https://github.com/near/near-sdk-rs/pull/1019))
- Properly report an error when Approval Extension is not enabled vs when account is not approved ([#1021](https://github.com/near/near-sdk-rs/pull/1021))

### Other
- [**breaking**] Use type-safe NearToken instead of u128/U128 ([#1104](https://github.com/near/near-sdk-rs/pull/1104))
- migrate to a external near-account-id crate for reusable AccountId type ([#1108](https://github.com/near/near-sdk-rs/pull/1108))
- Update borsh to 1.0.0 ([#1075](https://github.com/near/near-sdk-rs/pull/1075))
- Move from Gas to NearGas from near-gas crate ([#1082](https://github.com/near/near-sdk-rs/pull/1082))
- Deprecate Fungible Token declarative macros. ([#1054](https://github.com/near/near-sdk-rs/pull/1054))
- Add release-plz to automate releases ([#1069](https://github.com/near/near-sdk-rs/pull/1069))
- *(contract-standards)* deprecate declarative macros in NFT helpers, promote explicit trait implementations instead ([#1042](https://github.com/near/near-sdk-rs/pull/1042))
- Added a default method for TokenMetadata ([#978](https://github.com/near/near-sdk-rs/pull/978))
- Removed the not ready enum type ([#977](https://github.com/near/near-sdk-rs/pull/977))
- Fix empty owner tokens `start_index` error ([#962](https://github.com/near/near-sdk-rs/pull/962))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).