### PR TITLE
chore: adding an `audit.toml` file

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -3,7 +3,3 @@ ignore = [
     "RUSTSEC-2020-0071", # `chrono` is a transient dependency used by `near-sandbox-utils` and other dependencies
     "RUSTSEC-2022-0093", # security audit error in ed25519-dalek which is not relevant for near-sdk-rs
 ]
-
-[output]
-quiet = false
-deny = ["warnings"]

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,9 @@
+[advisories]
+ignore = [
+    "RUSTSEC-2020-0071", # `chrono` is a transient dependency used by `near-sandbox-utils` and other dependencies
+    "RUSTSEC-2022-0093", # security audit error in ed25519-dalek which is not relevant for near-sdk-rs
+]
+
+[output]
+quiet = false
+deny = ["warnings"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,4 @@ jobs:
       - name: Install Audit
         run: cargo install cargo-audit
       - name: Run Audit
-        uses: actions-rs/cargo@v1
-        with:
-          command: audit
-          args: --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2022-0093
+        run:  cargo audit


### PR DESCRIPTION
Closes https://github.com/near/near-sdk-rs/issues/1071
Using an config file for audit reports and comments.