### PR TITLE
ci: add examples `Cargo.lock`-s auto-update job

### DIFF
--- a/.github/workflows/release-plz-examples.yml
+++ b/.github/workflows/release-plz-examples.yml
@@ -1,0 +1,39 @@
+name: Release-plz auto-push Cargo.lock updates
+
+on:
+  push:
+    # Sequence of patterns matched against refs/heads
+    branches:    
+      - 'release-plz/*'
+jobs:
+  change-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: "1.69.0 rust toolchain"
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.69.0
+          default: true
+      - name: update Cargo.locks
+        run: |
+          for dir in examples/adder examples/callback-results examples/cross-contract-calls \
+          examples/status-message examples/factory-contract examples/fungible-token \
+          examples/lockable-fungible-token examples/mission-control examples/non-fungible-token \
+          examples/test-contract examples/versioned
+          do;
+            pushd $dir
+            cargo update -p near-sdk
+            cargo update -p near-sys
+            cargo update -p near-contract-standards
+            cargo update -p near-sdk-macros
+            popd
+          done
+      - name: Commit and push changes
+        uses: devops-infra/action-commit-push@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          commit_message: examples Cargo.lock-s update
+          commit_prefix: "[AUTO-COMMIT]"


### PR DESCRIPTION
this attempts to address ci issue, mentioned in [comment](https://github.com/near/near-sdk-rs/pull/1070#issuecomment-1683070430). 

according to [a piece of github actions documentation](https://docs.github.com/en/github-ae@latest/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow), 
this workflow will not cause an infinite loop, because the push is made from [GITHUB_TOKEN](https://github.com/dj8yfo/near-sdk-rs/blob/add_auto_commit_with_locks_update/.github/workflows/release-plz-examples.yml#L31). 

At the same time, it will be triggered in the first place by [release-plz worklow](https://github.com/near/near-sdk-rs/blob/master/.github/workflows/release-plz.yml#L28), because it uses `CUSTOM_GITHUB_TOKEN`. 
