### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [5.0.0-alpha.2](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.0.0-alpha.1...near-sdk-v5.0.0-alpha.2) - 2024-01-16
+
+### Fixed
+- include `near-sdk/src/private/result_type_ext.rs` file into module tree ([#1122](https://github.com/near/near-sdk-rs/pull/1122))
+- Fixed `contract_source_metadata` compilation issue when multiple impl blocks are there ([#1118](https://github.com/near/near-sdk-rs/pull/1118))
+- remove leftover `near_sdk::__private::schemars` ([#1120](https://github.com/near/near-sdk-rs/pull/1120))
+
+### Other
+- [**breaking**] update `nearcore` crates from `0.17` -> `0.20` ([#1130](https://github.com/near/near-sdk-rs/pull/1130))
+- fix new 1.75 warnings ([#1128](https://github.com/near/near-sdk-rs/pull/1128))
+- Re-exported packages cleanup ([#1114](https://github.com/near/near-sdk-rs/pull/1114))
+
 ## [5.0.0-alpha.1](https://github.com/near/near-sdk-rs/compare/4.1.1...near-sdk-v5.0.0-alpha.1) - 2023-11-18
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.0.0-alpha.1"
+version = "5.0.0-alpha.2"
 
 # Special triple # comment for ci.
 [patch.crates-io]

--- a/near-contract-standards/CHANGELOG.md
+++ b/near-contract-standards/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0-alpha.2](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.0.0-alpha.1...near-contract-standards-v5.0.0-alpha.2) - 2024-01-16
+
+### Other
+- fix new 1.75 warnings ([#1128](https://github.com/near/near-sdk-rs/pull/1128))
+- Re-exported packages cleanup ([#1114](https://github.com/near/near-sdk-rs/pull/1114))
+
 ## [5.0.0-alpha.1](https://github.com/near/near-sdk-rs/compare/4.1.1...near-contract-standards-v5.0.0-alpha.1) - 2023-11-18
 
 ### Added

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.0.0-alpha.1", default-features = false, features = ["legacy"] }
+near-sdk = { path = "../near-sdk", version = "~5.0.0-alpha.2", default-features = false, features = ["legacy"] }
 
 [features]
 default = ["abi"]

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.0.0-alpha.1" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.0.0-alpha.2" }
 near-sys = { path = "../near-sys", version = "0.2.1" }
 base64 = "0.13"
 borsh = { version = "1.0.0", features = ["derive"] }


### PR DESCRIPTION
## 🤖 New release
* `near-sdk`: 5.0.0-alpha.1 -> 5.0.0-alpha.2 (⚠️ API breaking changes)
* `near-sdk-macros`: 5.0.0-alpha.1 -> 5.0.0-alpha.2
* `near-contract-standards`: 5.0.0-alpha.1 -> 5.0.0-alpha.2 (✓ API compatible changes)

### ⚠️ `near-sdk` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.27.0/src/lints/enum_missing.ron

Failed in:
  enum near_sdk::mock::VmAction, previously in file /tmp/.tmpV1uU7t/near-sdk/src/environment/mock/receipt.rs:12
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-sdk`
<blockquote>

## [5.0.0-alpha.2](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.0.0-alpha.1...near-sdk-v5.0.0-alpha.2) - 2024-01-16

### Fixed
- include `near-sdk/src/private/result_type_ext.rs` file into module tree ([#1122](https://github.com/near/near-sdk-rs/pull/1122))
- Fixed `contract_source_metadata` compilation issue when multiple impl blocks are there ([#1118](https://github.com/near/near-sdk-rs/pull/1118))
- remove leftover `near_sdk::__private::schemars` ([#1120](https://github.com/near/near-sdk-rs/pull/1120))

### Other
- [**breaking**] update `nearcore` crates from `0.17` -> `0.20` ([#1130](https://github.com/near/near-sdk-rs/pull/1130))
- fix new 1.75 warnings ([#1128](https://github.com/near/near-sdk-rs/pull/1128))
- Re-exported packages cleanup ([#1114](https://github.com/near/near-sdk-rs/pull/1114))
</blockquote>

## `near-contract-standards`
<blockquote>

## [5.0.0-alpha.2](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.0.0-alpha.1...near-contract-standards-v5.0.0-alpha.2) - 2024-01-16

### Other
- fix new 1.75 warnings ([#1128](https://github.com/near/near-sdk-rs/pull/1128))
- Re-exported packages cleanup ([#1114](https://github.com/near/near-sdk-rs/pull/1114))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).