### PR TITLE
fix: remove leftover `near_sdk::__private::schemars`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,13 +23,15 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           default: true
           target: wasm32-unknown-unknown
-      - name: downgrade `anstyle`,`anstyle-parse`,`clap`,`clap_lex` crates to support older Rust toolchain
+      - name: downgrade `anstyle`,`anstyle-parse`,`anstyle-query`,`clap`,`clap_lex`, `home` crates to support older Rust toolchain
         if: matrix.toolchain == '1.69.0' 
         run: |
           cargo update -p anstyle --precise 1.0.2
+          cargo update -p anstyle-query --precise 1.0.0
           cargo update -p anstyle-parse --precise 0.2.1
           cargo update -p clap --precise 4.3.24
           cargo update -p clap_lex --precise 0.5.0
+          cargo update -p home --precise 0.5.5
       - uses: Swatinem/rust-cache@v1
       - name: Test
         run: cargo test --all --features unstable,legacy

--- a/near-sdk-macros/src/core_impl/abi/abi_generator.rs
+++ b/near-sdk-macros/src/core_impl/abi/abi_generator.rs
@@ -22,7 +22,7 @@ pub fn generate(i: &ItemImplInfo) -> TokenStream2 {
             pub extern "C" fn #near_abi_symbol() -> (*const u8, usize) {
                 use ::std::string::String;
 
-                let mut gen = ::near_sdk::__private::schemars::gen::SchemaGenerator::default();
+                let mut gen = ::near_sdk::schemars::gen::SchemaGenerator::default();
                 let functions = vec![#(#functions),*];
                 let mut data = ::std::mem::ManuallyDrop::new(
                     ::near_sdk::serde_json::to_vec(&::near_sdk::__private::ChunkedAbiEntry::new(


### PR DESCRIPTION
this prevents compiling sample contract
```rust
use near_sdk::borsh::{BorshDeserialize, BorshSerialize};
use near_sdk::near_bindgen;
#[near_bindgen]
#[derive(Default, BorshDeserialize, BorshSerialize)]
#[borsh(crate = "near_sdk::borsh")]
pub struct Contract {}
#[near_bindgen]
impl Contract {
    pub fn foo(&self, a: bool, b: u32) {}
}
```
with `cargo build --features "near-sdk/__abi-generate"`