### PR TITLE
fix: include `near-sdk/src/private/result_type_ext.rs` file into module tree

### DIFF
--- a/near-sdk/src/private/mod.rs
+++ b/near-sdk/src/private/mod.rs
@@ -5,6 +5,11 @@ pub use near_abi::{
     AbiBorshParameter, AbiFunction, AbiFunctionKind, AbiFunctionModifier, AbiJsonParameter,
     AbiParameters, AbiType,
 };
+#[cfg(feature = "abi")]
+mod result_type_ext;
+
+#[cfg(feature = "abi")]
+pub use result_type_ext::ResultTypeExt;
 
 use crate::IntoStorageKey;
 use borsh::{to_vec, BorshSerialize};


### PR DESCRIPTION
this prevents compiling sample contract with `cargo build --features "near-sdk/__abi-generate"`
```rust
use near_sdk::borsh::{BorshDeserialize, BorshSerialize};
use near_sdk::near_bindgen;
#[near_bindgen]
#[derive(Default, BorshDeserialize, BorshSerialize)]
#[borsh(crate = "near_sdk::borsh")]
pub struct Contract {}
#[near_bindgen]
impl Contract {
    #[handle_result]
    pub fn foo(&self) -> Result<u32, &'static str> {
        Ok(1)
    }
}
```