### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [5.0.0-alpha.3](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.0.0-alpha.2...near-sdk-v5.0.0-alpha.3) - 2024-02-19
+
+### Fixed
+- Deprecated `store::UnorderedMap` and `store::UnorderedSet` due to not meeting the original requirements (iteration over a collection of more than 2k elements runs out of gas) ([#1139](https://github.com/near/near-sdk-rs/pull/1139))
+
+### Other
+- Added ABI tests for SDK-generated methods [contract_source_metadata] ([#1136](https://github.com/near/near-sdk-rs/pull/1136))
+
 ## [5.0.0-alpha.2](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.0.0-alpha.1...near-sdk-v5.0.0-alpha.2) - 2024-01-16
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.0.0-alpha.2"
+version = "5.0.0-alpha.3"
 
 # Special triple # comment for ci.
 [patch.crates-io]

--- a/near-contract-standards/CHANGELOG.md
+++ b/near-contract-standards/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0-alpha.3](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.0.0-alpha.2...near-contract-standards-v5.0.0-alpha.3) - 2024-02-19
+
+### Fixed
+- Fixed a typo in the storage_deposit refund computation (introduced in 5.0.0-alpha.1 release) ([#1146](https://github.com/near/near-sdk-rs/pull/1146))
+
 ## [5.0.0-alpha.2](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.0.0-alpha.1...near-contract-standards-v5.0.0-alpha.2) - 2024-01-16
 
 ### Other

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.0.0-alpha.2", default-features = false, features = ["legacy"] }
+near-sdk = { path = "../near-sdk", version = "~5.0.0-alpha.3", default-features = false, features = ["legacy"] }
 
 [features]
 default = ["abi"]

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.0.0-alpha.2" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.0.0-alpha.3" }
 near-sys = { path = "../near-sys", version = "0.2.1" }
 base64 = "0.13"
 borsh = { version = "1.0.0", features = ["derive"] }


### PR DESCRIPTION
## 🤖 New release
* `near-sdk`: 5.0.0-alpha.2 -> 5.0.0-alpha.3 (✓ API compatible changes)
* `near-sdk-macros`: 5.0.0-alpha.2 -> 5.0.0-alpha.3
* `near-contract-standards`: 5.0.0-alpha.2 -> 5.0.0-alpha.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-sdk`
<blockquote>

## [5.0.0-alpha.3](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.0.0-alpha.2...near-sdk-v5.0.0-alpha.3) - 2024-02-19

### Fixed
- Deprecated `store::UnorderedMap` and `store::UnorderedSet` due to not meeting the original requirements (iteration over a collection of more than 2k elements runs out of gas) ([#1139](https://github.com/near/near-sdk-rs/pull/1139))

### Other
- Added ABI tests for SDK-generated methods [contract_source_metadata] ([#1136](https://github.com/near/near-sdk-rs/pull/1136))
</blockquote>

## `near-contract-standards`
<blockquote>

## [5.0.0-alpha.3](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.0.0-alpha.2...near-contract-standards-v5.0.0-alpha.3) - 2024-02-19

### Fixed
- Fixed a typo in the storage_deposit refund computation (introduced in 5.0.0-alpha.1 release) ([#1146](https://github.com/near/near-sdk-rs/pull/1146))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).