### PR TITLE
clean up features

### DIFF
--- a/near-sdk-macros/Cargo.toml
+++ b/near-sdk-macros/Cargo.toml
@@ -15,14 +15,14 @@ Main macro of the library for writing NEAR smart contracts.
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1"
-syn = { version = "2", features = ["full", "fold", "extra-traits", "visit"] }
-strum = "0.24"
+proc-macro2 = { version = "1",  default-features = false }
+syn = { version = "2", default-features = false, features = [] }
+strum = { version = "0.24",  default-features = false }
 strum_macros = "0.24"
-quote = "1.0"
+quote = { version = "1.0",  default-features = false }
 Inflector = { version = "0.11.4", default-features = false, features = [] }
-darling = { version = "0.20.3" }
-serde = { version = "1", features = ["derive"] }
+darling = { version = "0.20.3", default-features = false }
+serde = { version = "1",  default-features = false, features = ["serde_derive"] }
 serde_json = "1"
 
 [dev-dependencies]

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -62,7 +62,7 @@ near-abi = { version = "0.4.0", features = ["__chunked-entries"] }
 symbolic-debuginfo = "8.8"
 
 [features]
-default = ["wee_alloc", "unit-testing", "legacy", "abi"]
+default = ["wee_alloc", "unit-testing"]
 expensive-debug = []
 unstable = []
 legacy = []


### PR DESCRIPTION
The project still compiles and can be used fine without these dependency features. 

On top of this, I removed abi and legacy from default near-sdk features.