### PR TITLE
feature: aliasing for functions with duplicate names

### DIFF
--- a/near-sdk-macros/src/core_impl/abi/abi_generator.rs
+++ b/near-sdk-macros/src/core_impl/abi/abi_generator.rs
@@ -339,7 +339,7 @@ mod tests {
             #[handle_result]
             pub fn f3(&mut self, arg0: FancyStruct, arg1: u64) -> Result<IsOk, Error> { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.abi_struct();
 
         local_insta_assert_snapshot!(pretty_print_fn_body_syn_str(actual));
@@ -354,7 +354,7 @@ mod tests {
             #[handle_result]
             pub fn f3(&mut self, #[serializer(borsh)] arg0: FancyStruct) -> Result<IsOk, Error> { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.abi_struct();
 
         local_insta_assert_snapshot!(pretty_print_fn_body_syn_str(actual));
@@ -370,7 +370,7 @@ mod tests {
                 #[callback_vec] x: Vec<String>, 
             ) -> bool { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.abi_struct();
        
         local_insta_assert_snapshot!(pretty_print_fn_body_syn_str(actual));
@@ -382,7 +382,7 @@ mod tests {
         let mut method = parse_quote! {
             pub fn method(&self, #[callback_unwrap] #[serializer(borsh)] x: &mut u64, #[serializer(borsh)] y: String, #[callback_unwrap] #[serializer(json)] z: Vec<u8>) { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.abi_struct();
 
         local_insta_assert_snapshot!(pretty_print_fn_body_syn_str(actual));
@@ -395,7 +395,7 @@ mod tests {
             #[init(ignore_state)]
             pub fn new() -> u64 { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.abi_struct();
 
         local_insta_assert_snapshot!(pretty_print_fn_body_syn_str(actual));
@@ -407,7 +407,7 @@ mod tests {
         let mut method = parse_quote! {
             pub fn method() { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.abi_struct();
 
         local_insta_assert_snapshot!(pretty_print_fn_body_syn_str(actual));

--- a/near-sdk-macros/src/core_impl/abi/abi_generator.rs
+++ b/near-sdk-macros/src/core_impl/abi/abi_generator.rs
@@ -92,7 +92,7 @@ impl ImplItemMethodInfo {
         let function_name_str = match &attr_signature_info.method_kind {
             MethodKind::View(m) => m.alias.clone().unwrap_or(ident_.to_string()),
             MethodKind::Call(m) => m.alias.clone().unwrap_or(ident_.to_string()),
-            MethodKind::Init(m) => m.alias.clone().unwrap_or(ident_.to_string()),
+            MethodKind::Init(_) => ident_.to_string(),
         };
 
         let function_doc = match parse_rustdoc(&attr_signature_info.non_bindgen_attrs) {

--- a/near-sdk-macros/src/core_impl/abi/abi_generator.rs
+++ b/near-sdk-macros/src/core_impl/abi/abi_generator.rs
@@ -13,7 +13,16 @@ pub fn generate(i: &ItemImplInfo) -> TokenStream2 {
     }
 
     let functions: Vec<TokenStream2> = i.methods.iter().map(|m| m.abi_struct()).collect();
-    let first_function_name = &i.methods[0].attr_signature_info.ident;
+    let ident_ = &i.methods[0].attr_signature_info.ident;
+    let first_function_name = match &i.methods[0].attr_signature_info.method_kind {
+        MethodKind::View(m) => m
+            .alias
+            .as_ref()
+            .map(|alias| syn::Ident::new(alias, ident_.span()))
+            .unwrap_or(ident_.clone()),
+        _ => ident_.clone(),
+    };
+
     let near_abi_symbol = format_ident!("__near_abi_{}", first_function_name);
     quote! {
         #[cfg(not(target_arch = "wasm32"))]

--- a/near-sdk-macros/src/core_impl/abi/abi_generator.rs
+++ b/near-sdk-macros/src/core_impl/abi/abi_generator.rs
@@ -88,7 +88,13 @@ impl ImplItemMethodInfo {
     pub fn abi_struct(&self) -> TokenStream2 {
         let attr_signature_info = &self.attr_signature_info;
 
-        let function_name_str = attr_signature_info.ident.to_string();
+        let ident_ = attr_signature_info.ident.to_string();
+        let function_name_str = match &attr_signature_info.method_kind {
+            MethodKind::View(m) => m.alias.clone().unwrap_or(ident_.to_string()),
+            MethodKind::Call(m) => m.alias.clone().unwrap_or(ident_.to_string()),
+            MethodKind::Init(m) => m.alias.clone().unwrap_or(ident_.to_string()),
+        };
+
         let function_doc = match parse_rustdoc(&attr_signature_info.non_bindgen_attrs) {
             Some(doc) => quote! { ::std::option::Option::Some(::std::string::String::from(#doc)) },
             None => quote! { ::std::option::Option::None },

--- a/near-sdk-macros/src/core_impl/code_generator/ext.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/ext.rs
@@ -125,7 +125,7 @@ fn generate_ext_function(attr_signature_info: &AttrSigInfo) -> TokenStream2 {
     let ident_ = ident.clone().to_string();
     let ident_str = match method_kind {
         MethodKind::Call(m) => &m.alias,
-        MethodKind::Init(m) => &m.alias,
+        MethodKind::Init(_) => &None,
         MethodKind::View(m) => &m.alias,
     }
     .as_ref()

--- a/near-sdk-macros/src/core_impl/code_generator/impl_item_method_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/impl_item_method_info.rs
@@ -417,7 +417,7 @@ impl ImplItemMethodInfo {
             MethodKind::View(view_method) => &view_method.alias,
         }
         .as_ref()
-        .map(|alias| syn::Ident::new(&alias, self.attr_signature_info.ident.span()))
+        .map(|alias| syn::Ident::new(alias, self.attr_signature_info.ident.span()))
         .unwrap_or(self.attr_signature_info.ident.clone())
     }
 }

--- a/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
@@ -344,4 +344,54 @@ mod tests {
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
+
+    #[test]
+    fn serialize_method_name(){
+        let impl_type: Type = syn::parse_str("Hello").unwrap();
+        let mut method: ImplItemFn = parse_quote! {
+            pub fn serialize(&mut self){ }
+        };
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
+        let actual = method_info.method_wrapper();
+        local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap())
+    }
+
+    #[test]
+    fn abi_aliased_method(){
+        let impl_type: Type = syn::parse_str("Hello").unwrap();
+        let mut method: ImplItemFn = parse_quote! {
+            #[abi_alias("foo_one")]
+            pub fn foo(&self){ }
+        };
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
+        let actual = method_info.method_wrapper();
+        local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap())
+    }
+
+    #[test]
+    fn abi_aliased_trait_method(){
+        let impl_type: Type = syn::parse_str("Hello").unwrap();
+        let mut method: ImplItemFn = parse_quote! {
+            #[abi_alias("foo_one")]
+            pub fn foo(&self){ }
+        };
+
+        let trait_ = (None, parse_quote! { T1 }, parse_quote! { for });
+        let method_info = ImplItemMethodInfo::new(&mut method, Some(trait_), impl_type).unwrap().unwrap();
+        let actual = method_info.method_wrapper();
+        local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap())
+    }
+    #[test]
+    fn abi_aliased_mut_trait_method(){
+        let impl_type: Type = syn::parse_str("Hello").unwrap();
+        let mut method: ImplItemFn = parse_quote! {
+            #[abi_alias("foo_one")]
+            pub fn foo(&mut self){ }
+        };
+
+        let trait_ = (None, parse_quote! { T1 }, parse_quote! { for });
+        let method_info = ImplItemMethodInfo::new(&mut method, Some(trait_), impl_type).unwrap().unwrap();
+        let actual = method_info.method_wrapper();
+        local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap())
+    }
 }

--- a/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
@@ -1,5 +1,5 @@
-use crate::core_impl::ext::generate_ext_function_wrappers;
 use crate::ItemImplInfo;
+use crate::{core_impl::ext::generate_ext_function_wrappers, MethodKind};
 use proc_macro2::TokenStream as TokenStream2;
 use quote::ToTokens;
 use syn::{spanned::Spanned, Ident};
@@ -7,6 +7,18 @@ use syn::{spanned::Spanned, Ident};
 impl ItemImplInfo {
     /// Generate the code that wraps
     pub fn wrapper_code(&self) -> TokenStream2 {
+        {
+            let ident_ = &self.methods[0].attr_signature_info.ident;
+            let ident = match &self.methods[0].attr_signature_info.method_kind {
+                MethodKind::Init(m) => m
+                    .alias
+                    .as_ref()
+                    .map(|alias| syn::Ident::new(alias, ident_.span()))
+                    .unwrap_or(ident_.clone()),
+                _ => ident_.clone(),
+            };
+        }
+
         let mut res = TokenStream2::new();
         for method in &self.methods {
             res.extend(method.method_wrapper());

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/abi_aliased_method.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/abi_aliased_method.snap
@@ -1,0 +1,13 @@
+---
+source: near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
+assertion_line: 371
+expression: pretty_print_syn_str(&actual).unwrap()
+---
+#[cfg(target_arch = "wasm32")]
+#[no_mangle]
+pub extern "C" fn foo_one() {
+    ::near_sdk::env::setup_panic_hook();
+    let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
+    contract.foo();
+}
+

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/abi_aliased_mut_trait_method.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/abi_aliased_mut_trait_method.snap
@@ -1,0 +1,17 @@
+---
+source: near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
+assertion_line: 396
+expression: pretty_print_syn_str(&actual).unwrap()
+---
+#[cfg(target_arch = "wasm32")]
+#[no_mangle]
+pub extern "C" fn foo_one() {
+    ::near_sdk::env::setup_panic_hook();
+    if ::near_sdk::env::attached_deposit().as_yoctonear() != 0 {
+        ::near_sdk::env::panic_str("Method foo doesn't accept deposit");
+    }
+    let mut contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
+    T1::foo(&mut contract);
+    ::near_sdk::env::state_write(&contract);
+}
+

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/abi_aliased_trait_method.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/abi_aliased_trait_method.snap
@@ -1,0 +1,13 @@
+---
+source: near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
+assertion_line: 383
+expression: pretty_print_syn_str(&actual).unwrap()
+---
+#[cfg(target_arch = "wasm32")]
+#[no_mangle]
+pub extern "C" fn foo_one() {
+    ::near_sdk::env::setup_panic_hook();
+    let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
+    T1::foo(&contract);
+}
+

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/serialize_method_name.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/serialize_method_name.snap
@@ -1,0 +1,17 @@
+---
+source: near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
+assertion_line: 354
+expression: pretty_print_syn_str(&actual).unwrap()
+---
+#[cfg(target_arch = "wasm32")]
+#[no_mangle]
+pub extern "C" fn serialize() {
+    ::near_sdk::env::setup_panic_hook();
+    if ::near_sdk::env::attached_deposit().as_yoctonear() != 0 {
+        ::near_sdk::env::panic_str("Method serialize doesn't accept deposit");
+    }
+    let mut contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
+    contract.serialize();
+    ::near_sdk::env::state_write(&contract);
+}
+

--- a/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
@@ -6,12 +6,17 @@ use crate::core_impl::{utils, Returns};
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::ToTokens;
 use syn::spanned::Spanned;
-use syn::{Attribute, Error, Expr, FnArg, GenericParam, Ident, Lit, ReturnType, Signature, Type};
+use syn::token::{For, Not};
+use syn::{
+    Attribute, Error, Expr, FnArg, GenericParam, Ident, Lit, Path, ReturnType, Signature, Type,
+};
 
 /// Information extracted from method attributes and signature.
 pub struct AttrSigInfo {
     /// The name of the method.
     pub ident: Ident,
+    /// Propagated to allow for the fully qualified path in the generated code.
+    pub trait_: Option<(Option<Not>, Path, For)>,
     /// Attributes not related to bindgen.
     pub non_bindgen_attrs: Vec<Attribute>,
     /// All arguments of the method.
@@ -67,6 +72,7 @@ impl AttrSigInfo {
         original_attrs: &mut Vec<Attribute>,
         original_sig: &mut Signature,
         source_type: &TokenStream2,
+        trait_: Option<(Option<Not>, Path, For)>,
     ) -> syn::Result<Self> {
         let mut self_occurrences = Self::sanitize_self(original_sig, source_type)?;
         let mut errors = vec![];
@@ -193,7 +199,7 @@ impl AttrSigInfo {
 
         let mut result = AttrSigInfo {
             ident,
-
+            trait_,
             non_bindgen_attrs,
             args,
             method_kind,

--- a/near-sdk-macros/src/core_impl/info_extractor/impl_item_method_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/impl_item_method_info.rs
@@ -35,7 +35,7 @@ impl ImplItemMethodInfo {
 #[cfg(test)]
 mod tests {
     use syn::{parse_quote, Type, ImplItemFn as ImplItemMethod , ReturnType};
-    use crate::core_impl::{ImplItemMethodInfo};
+    use crate::core_impl::ImplItemMethodInfo;
 
     #[test]
     fn init_no_return() {

--- a/near-sdk-macros/src/core_impl/info_extractor/impl_item_method_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/impl_item_method_info.rs
@@ -1,7 +1,10 @@
 use crate::core_impl::info_extractor::AttrSigInfo;
 use crate::core_impl::utils;
 use quote::ToTokens;
-use syn::{ImplItemFn as ImplItemMethod, Type, Visibility};
+use syn::{
+    token::{For, Not},
+    ImplItemFn as ImplItemMethod, Path, Type, Visibility,
+};
 
 /// Information extracted from `ImplItemMethod`.
 pub struct ImplItemMethodInfo {
@@ -15,14 +18,14 @@ impl ImplItemMethodInfo {
     /// Process the method and extract information important for near-sdk.
     pub fn new(
         original: &mut ImplItemMethod,
-        is_trait_impl: bool,
+        trait_: Option<(Option<Not>, Path, For)>,
         struct_type: Type,
     ) -> syn::Result<Option<Self>> {
         let ImplItemMethod { attrs, sig, .. } = original;
         utils::sig_is_supported(sig)?;
-        if is_trait_impl || matches!(original.vis, Visibility::Public(_)) {
+        if trait_.is_some() || matches!(original.vis, Visibility::Public(_)) {
             let source_type = &struct_type.to_token_stream();
-            let attr_signature_info = AttrSigInfo::new(attrs, sig, source_type)?;
+            let attr_signature_info = AttrSigInfo::new(attrs, sig, source_type, trait_)?;
             Ok(Some(Self { attr_signature_info, struct_type }))
         } else {
             Ok(None)
@@ -44,7 +47,7 @@ mod tests {
             #[init]
             pub fn method(k: &mut u64) { }
         };
-        let actual = ImplItemMethodInfo::new(&mut method, false, impl_type).map(|_| ()).unwrap_err();
+        let actual = ImplItemMethodInfo::new(&mut method, None, impl_type).map(|_| ()).unwrap_err();
         let expected = "Init function must return the contract state.";
         assert_eq!(expected, actual.to_string());
     }
@@ -57,7 +60,7 @@ mod tests {
             #[handle_result]
             pub fn method(k: &mut u64) -> Result<Self, Error> { }
         };
-        let method = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method.attr_signature_info.returns.original;
         let expected: Type = syn::parse_str("Result<Hello, Error>").unwrap();
         assert!(matches!(actual, ReturnType::Type(_, ty) if ty.as_ref() == &expected));
@@ -70,7 +73,7 @@ mod tests {
             #[handle_result]
             pub fn method(&self) -> &'static str { }
         };
-        let actual = ImplItemMethodInfo::new(&mut method, false, impl_type).map(|_| ()).unwrap_err();
+        let actual = ImplItemMethodInfo::new(&mut method, None, impl_type).map(|_| ()).unwrap_err();
         let expected = "Function marked with #[handle_result] should return Result<T, E> (where E implements FunctionError). If you're trying to use a type alias for `Result`, try `#[handle_result(aliased)]`.";
         assert_eq!(expected, actual.to_string());
     }
@@ -81,7 +84,7 @@ mod tests {
         let mut method: ImplItemMethod = parse_quote! {
             pub fn method(&self) -> Result<u64, &'static str> { }
         };
-        let actual = ImplItemMethodInfo::new(&mut method, false, impl_type).map(|_| ()).unwrap_err();
+        let actual = ImplItemMethodInfo::new(&mut method, None, impl_type).map(|_| ()).unwrap_err();
         let expected = "Serializing Result<T, E> has been deprecated. Consider marking your method with #[handle_result] if the second generic represents a panicable error or replacing Result with another two type sum enum otherwise. If you really want to keep the legacy behavior, mark the method with #[handle_result] and make it return Result<Result<T, E>, near_sdk::Abort>.";
         assert_eq!(expected, actual.to_string());
     }
@@ -93,11 +96,10 @@ mod tests {
             #[init]
             pub fn new() -> Result<Self, &'static str> { }
         };
-        let actual = ImplItemMethodInfo::new(&mut method, false, impl_type).map(|_| ()).unwrap_err();
+        let actual = ImplItemMethodInfo::new(&mut method, None, impl_type).map(|_| ()).unwrap_err();
         let expected = "Serializing Result<T, E> has been deprecated. Consider marking your method with #[handle_result] if the second generic represents a panicable error or replacing Result with another two type sum enum otherwise. If you really want to keep the legacy behavior, mark the method with #[handle_result] and make it return Result<Result<T, E>, near_sdk::Abort>.";
         assert_eq!(expected, actual.to_string());
     }
-
 
     #[test]
     fn payable_self_by_value_fails() {
@@ -106,7 +108,7 @@ mod tests {
             #[payable]
             pub fn method(self) -> Self { }
         };
-        let actual = ImplItemMethodInfo::new(&mut method, false, impl_type).map(|_| ()).unwrap_err();
+        let actual = ImplItemMethodInfo::new(&mut method, None, impl_type).map(|_| ()).unwrap_err();
         let expected = "View function can't be payable.";
         assert_eq!(expected.to_string(), actual.to_string());
     }

--- a/near-sdk-macros/src/core_impl/info_extractor/item_impl_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/item_impl_info.rs
@@ -18,14 +18,13 @@ impl ItemImplInfo {
                 "Impl type parameters are not supported for smart contracts.",
             ));
         }
-        let is_trait_impl = original.trait_.is_some();
         let ty = (*original.self_ty.as_ref()).clone();
 
         let mut methods = vec![];
         let mut errors = vec![];
         for subitem in &mut original.items {
             if let ImplItem::Fn(m) = subitem {
-                match ImplItemMethodInfo::new(m, is_trait_impl, ty.clone()) {
+                match ImplItemMethodInfo::new(m, original.trait_.clone(), ty.clone()) {
                     Ok(Some(method_info)) => methods.push(method_info),
                     Ok(None) => {} // do nothing
                     Err(e) => errors.push(e),

--- a/near-sdk-macros/src/core_impl/info_extractor/mod.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/mod.rs
@@ -10,7 +10,7 @@ mod handle_result_attr;
 pub use handle_result_attr::HandleResultAttr;
 
 mod attr_sig_info;
-pub use attr_sig_info::AttrSigInfo;
+pub use attr_sig_info::{retrieve_abi_alias, AttrSigInfo};
 
 mod impl_item_method_info;
 pub use impl_item_method_info::ImplItemMethodInfo;

--- a/near-sdk-macros/src/core_impl/info_extractor/mod.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/mod.rs
@@ -79,9 +79,6 @@ pub struct InitMethod {
     pub is_payable: bool,
     /// Whether init method ignores state
     pub ignores_state: bool,
-    /// The alias of the method as would appear in the ABI; here to
-    /// prevent method name collisions in the case of overloads or colliding trait methods.
-    pub alias: Option<String>,
 }
 
 #[derive(Clone, PartialEq, Eq)]

--- a/near-sdk-macros/src/core_impl/info_extractor/mod.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/mod.rs
@@ -55,6 +55,9 @@ pub struct CallMethod {
     pub result_serializer: SerializerType,
     /// The receiver, like `mut self`, `self`, `&mut self`, `&self`, or `None`.
     pub receiver: Option<Receiver>,
+    /// The alias of the method as would appear in the ABI; here to
+    /// prevent method name collisions in the case of overloads or colliding trait methods.
+    pub alias: Option<String>,
 }
 
 #[derive(Clone, PartialEq, Eq)]
@@ -65,6 +68,9 @@ pub struct ViewMethod {
     pub result_serializer: SerializerType,
     /// The receiver, like `mut self`, `self`, `&mut self`, `&self`, or `None`.
     pub receiver: Option<Receiver>,
+    /// The alias of the method as would appear in the ABI; here to
+    /// prevent method name collisions in the case of overloads or colliding trait methods.
+    pub alias: Option<String>,
 }
 
 #[derive(Clone, PartialEq, Eq)]
@@ -73,6 +79,9 @@ pub struct InitMethod {
     pub is_payable: bool,
     /// Whether init method ignores state
     pub ignores_state: bool,
+    /// The alias of the method as would appear in the ABI; here to
+    /// prevent method name collisions in the case of overloads or colliding trait methods.
+    pub alias: Option<String>,
 }
 
 #[derive(Clone, PartialEq, Eq)]

--- a/near-sdk-macros/src/core_impl/info_extractor/trait_item_method_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/trait_item_method_info.rs
@@ -28,7 +28,7 @@ impl TraitItemMethodInfo {
         let TraitItemFn { attrs, sig, .. } = original;
 
         utils::sig_is_supported(sig)?;
-        let attr_sig_info = AttrSigInfo::new(attrs, sig, trait_name)?;
+        let attr_sig_info = AttrSigInfo::new(attrs, sig, trait_name, None)?;
 
         let ident_byte_str =
             LitStr::new(&attr_sig_info.ident.to_string(), attr_sig_info.ident.span());

--- a/near-sdk-macros/src/core_impl/info_extractor/visitor.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/visitor.rs
@@ -201,7 +201,7 @@ impl Visitor {
                 receiver,
                 alias,
             }),
-            Init => MethodKind::Init(InitMethod { is_payable, ignores_state, alias }),
+            Init => MethodKind::Init(InitMethod { is_payable, ignores_state }),
             View => MethodKind::View(ViewMethod { is_private, result_serializer, receiver, alias }),
         };
 

--- a/near-sdk-macros/src/lib.rs
+++ b/near-sdk-macros/src/lib.rs
@@ -44,6 +44,38 @@ use syn::{parse_quote, ImplItem, ItemEnum, ItemImpl, ItemStruct, ItemTrait, Wher
 /// }
 /// ```
 ///
+/// ABI Name Aliasing:
+///
+/// By using `[abi_alias(alias_name)]`, `near_bindgen` will generate the relevant abi code under the alias.
+/// This is useful in cases where the function name collides with names that have been reserved by NEAR, and or
+/// trait methods that have the same name.
+///
+/// Examples
+///
+/// ```ignore
+/// #[near_bindgen]
+/// struct Contract;
+/// 
+/// // here we have two traits with the same method name
+/// trait T1 { fn foo(&self); }
+/// trait T2 { fn foo(&self); }
+/// 
+/// #[near_bindgen]
+/// impl T1 for Contract {
+///    fn foo(&self) {
+///        log!("foo_one")
+///     }
+/// }
+///
+/// #[near_bindgen]
+/// impl T2 for Contract {
+///    #[abi_alias("foo_two")]
+///    fn foo(&self) {
+///        log!("foo_two")
+///    }
+/// }
+/// ```
+///
 /// Events Standard:
 ///
 /// By passing `event_json` as an argument `near_bindgen` will generate the relevant code to format events

--- a/near-sdk-macros/src/lib.rs
+++ b/near-sdk-macros/src/lib.rs
@@ -223,7 +223,7 @@ fn process_impl_block(
     let ext_generated_code = item_impl_info.generate_ext_wrapper_code();
 
     Ok(TokenStream::from(quote! {
-        #ext_generated_code
+       // #ext_generated_code
         #input
         #generated_code
         #abi_generated

--- a/near-sdk-macros/src/lib.rs
+++ b/near-sdk-macros/src/lib.rs
@@ -223,7 +223,7 @@ fn process_impl_block(
     let ext_generated_code = item_impl_info.generate_ext_wrapper_code();
 
     Ok(TokenStream::from(quote! {
-       // #ext_generated_code
+        #ext_generated_code
         #input
         #generated_code
         #abi_generated

--- a/near-sdk/compilation_tests/all.rs
+++ b/near-sdk/compilation_tests/all.rs
@@ -36,4 +36,6 @@ fn compilation_tests() {
     t.pass("compilation_tests/contract_metadata.rs");
     t.compile_fail("compilation_tests/contract_metadata_fn_name.rs");
     t.pass("compilation_tests/contract_metadata_bindgen.rs");
+    t.pass("compilation_tests/trait_impl_name_aliasing.rs");
+    t.pass("compilation_tests/contract_serialize_method.rs");
 }

--- a/near-sdk/compilation_tests/contract_serialize_method.rs
+++ b/near-sdk/compilation_tests/contract_serialize_method.rs
@@ -1,0 +1,19 @@
+use near_sdk::{
+    borsh::{BorshDeserialize, BorshSerialize},
+    log, near_bindgen, PanicOnDefault,
+};
+
+#[near_bindgen]
+#[derive(BorshSerialize, BorshDeserialize, PanicOnDefault)]
+#[borsh(crate = "near_sdk::borsh")]
+pub struct Contract {}
+
+#[near_bindgen]
+impl Contract {
+    // See <https://github.com/near/near-sdk-rs/issues/1084#issue-1898868964> for more information.
+    pub fn serialize(&mut self) {
+        log!("serialize");
+    }
+}
+
+fn main() {}

--- a/near-sdk/compilation_tests/trait_impl_name_aliasing.rs
+++ b/near-sdk/compilation_tests/trait_impl_name_aliasing.rs
@@ -1,0 +1,41 @@
+use near_sdk::{
+    borsh::{BorshDeserialize, BorshSerialize},
+    log, near_bindgen,
+};
+
+#[near_bindgen]
+#[derive(Default, BorshDeserialize, BorshSerialize)]
+#[borsh(crate = "near_sdk::borsh")]
+struct Contract {}
+
+trait T1 {
+    fn foo(&self);
+}
+
+trait T2 {
+    fn foo(&self, a: u32);
+}
+
+#[near_bindgen]
+impl T1 for Contract {
+    fn foo(&self) {
+        log!("foo_one")
+    }
+}
+
+#[near_bindgen]
+impl T2 for Contract {
+    #[abi_alias("foo_two")]
+    fn foo(&self) {
+        log!("foo_two")
+    }
+}
+
+impl Contract {
+    fn bar(&self) {
+        T1::foo(self);
+        T2::foo(self);
+    }
+}
+
+fn main() {}

--- a/near-sdk/compilation_tests/trait_impl_name_aliasing.rs
+++ b/near-sdk/compilation_tests/trait_impl_name_aliasing.rs
@@ -13,7 +13,7 @@ trait T1 {
 }
 
 trait T2 {
-    fn foo(&self, a: u32);
+    fn foo(&self);
 }
 
 #[near_bindgen]

--- a/near-sdk/tests/abi_alias.rs
+++ b/near-sdk/tests/abi_alias.rs
@@ -1,0 +1,86 @@
+use near_sdk::{
+    borsh::{BorshDeserialize, BorshSerialize},
+    env, log, near_bindgen,
+    test_utils::get_logs,
+    PanicOnDefault,
+};
+
+trait T1 {
+    fn foo(&self);
+}
+
+trait T2 {
+    fn foo(&self);
+}
+
+trait T3 {
+    fn contract_source_metadata(&self);
+}
+
+#[near_bindgen]
+#[derive(BorshSerialize, BorshDeserialize, PanicOnDefault)]
+#[borsh(crate = "near_sdk::borsh")]
+pub struct Contract {}
+
+// here to make sure the method does not collide with the serialize method impl from borsh
+#[near_bindgen]
+impl Contract {
+    pub fn serialize(&mut self) {
+        log!("serialize");
+    }
+}
+
+#[near_bindgen]
+impl T1 for Contract {
+    fn foo(&self) {
+        log!("foo_one")
+    }
+}
+
+#[near_bindgen]
+impl T2 for Contract {
+    #[abi_alias("foo_two")]
+    fn foo(&self) {
+        log!("foo_two")
+    }
+}
+
+#[near_bindgen]
+impl T3 for Contract {
+    #[abi_alias("t3_contract_source_metadata")]
+    fn contract_source_metadata(&self) {
+        log!("contract_source_metadata from T3")
+    }
+}
+
+#[test]
+fn test_serialize_method() {
+    let mut contract = Contract {};
+    Contract::serialize(&mut contract);
+    let logs = get_logs();
+    assert_eq!(logs[0], "serialize");
+}
+
+#[test]
+fn test_aliased_method() {
+    let contract = Contract {};
+    T1::foo(&contract);
+    T2::foo(&contract);
+    let logs = get_logs();
+
+    assert_eq!(logs[0], "foo_one");
+    assert_eq!(logs[1], "foo_two");
+
+    // making sure the method T2::foo exists in abi as foo_two
+    let _ = Contract::ext(env::current_account_id()).foo_two();
+    // also making sure the method T1::foo exists in abi as foo
+    let _ = Contract::ext(env::current_account_id()).foo();
+}
+
+#[test]
+fn test_reserved_method_name() {
+    // making sure the method T3::contract_source_metadata exists in abi as t3_contract_source_metadata
+    let _ = Contract::ext(env::current_account_id()).t3_contract_source_metadata();
+    // making sure contract_source_metadata is also available
+    let _ = Contract::ext(env::current_account_id()).contract_source_metadata();
+}


### PR DESCRIPTION
The changes introduced addresses https://github.com/near/near-sdk-rs/issues/1084.
Concerned with aliasing colliding names in the generated abi using `#[abi_alias(...)]` as such:
```rust
trait T1{
   fn foo(&self);
}

trait T2 {
   fn foo(&self);
}

struct Contract;


impl T1 for Contract {
   fn foo(&self){
      log!("foo_one");
   }
}

impl T2 for Contract {
   #[abi_alias("foo_two")
   fn foo(&self){
      log!("foo_two");
   }
}
```