### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [5.0.0-alpha.4](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.0.0-alpha.3...near-sdk-v5.0.0-alpha.4) - 2024-02-23
+
+### Other
+- Slimmed down the dependencies by default ([#1149](https://github.com/near/near-sdk-rs/pull/1149))
+
 ## [5.0.0-alpha.3](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.0.0-alpha.2...near-sdk-v5.0.0-alpha.3) - 2024-02-19
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.0.0-alpha.3"
+version = "5.0.0-alpha.4"
 
 # Special triple # comment for ci.
 [patch.crates-io]

--- a/near-contract-standards/CHANGELOG.md
+++ b/near-contract-standards/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0-alpha.4](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.0.0-alpha.3...near-contract-standards-v5.0.0-alpha.4) - 2024-02-23
+
+### Other
+- Slimmed down the dependencies by default ([#1149](https://github.com/near/near-sdk-rs/pull/1149))
+
 ## [5.0.0-alpha.3](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.0.0-alpha.2...near-contract-standards-v5.0.0-alpha.3) - 2024-02-19
 
 ### Fixed

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.0.0-alpha.3", default-features = false, features = ["legacy"] }
+near-sdk = { path = "../near-sdk", version = "~5.0.0-alpha.4", default-features = false, features = ["legacy"] }
 
 [dev-dependencies]
 near-sdk = { path = "../near-sdk", default-features = false, features = ["unit-testing"] }

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.0.0-alpha.3" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.0.0-alpha.4" }
 near-sys = { path = "../near-sys", version = "0.2.1" }
 base64 = "0.21"
 borsh = { version = "1.0.0", features = ["derive"] }


### PR DESCRIPTION
## 🤖 New release
* `near-sdk`: 5.0.0-alpha.3 -> 5.0.0-alpha.4 (✓ API compatible changes)
* `near-sdk-macros`: 5.0.0-alpha.3 -> 5.0.0-alpha.4
* `near-contract-standards`: 5.0.0-alpha.3 -> 5.0.0-alpha.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-sdk`
<blockquote>

## [5.0.0-alpha.4](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.0.0-alpha.3...near-sdk-v5.0.0-alpha.4) - 2024-02-23

### Other
- Slimmed down the dependencies by default ([#1149](https://github.com/near/near-sdk-rs/pull/1149))
</blockquote>

## `near-contract-standards`
<blockquote>

## [5.0.0-alpha.4](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.0.0-alpha.3...near-contract-standards-v5.0.0-alpha.4) - 2024-02-23

### Other
- Slimmed down the dependencies by default ([#1149](https://github.com/near/near-sdk-rs/pull/1149))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).