### PR TITLE
fix: remove deprecated wee_alloc

### DIFF
--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -34,8 +34,6 @@ near-account-id = { version="1.0.0", features = ["serde", "borsh"] }
 near-gas = { version = "0.2.3", features = ["serde", "borsh"] }
 near-token = { version = "0.2.0", features = ["serde", "borsh"] }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-wee_alloc = { version = "0.4.5", default-features = false, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 schemars = { version = "0.8.8", optional = true }
@@ -63,7 +61,7 @@ near-abi = { version = "0.4.0", features = ["__chunked-entries"] }
 symbolic-debuginfo = "12"
 
 [features]
-default = ["wee_alloc"]
+default = []
 expensive-debug = []
 unstable = []
 legacy = []

--- a/near-sdk/src/lib.rs
+++ b/near-sdk/src/lib.rs
@@ -52,11 +52,6 @@ pub use crate::utils::*;
 #[cfg(all(feature = "unit-testing", not(target_arch = "wasm32")))]
 pub mod test_utils;
 
-// Set up global allocator by default if custom-allocator feature is not set in wasm32 architecture.
-#[cfg(all(feature = "wee_alloc", target_arch = "wasm32"))]
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-
 // Exporting common crates
 
 pub use base64;


### PR DESCRIPTION
The wee_alloc library has been unmaintained for 3 years and has serious issues (e.g. a memory leak affecting some WASM compiles)

https://github.com/rustwasm/wee_alloc/issues/106