### PR TITLE
Add Borsh/Json -Schema to types

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,8 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - name: Downgrade dependencies
         run: |
-          cargo update -p clap@4.5.3 --precise 4.4.18
-          cd examples/adder && cargo update -p clap@4.5.3 --precise 4.4.18
+          cargo update -p clap@4.5.4 --precise 4.4.18
+          cd examples/adder && cargo update -p clap@4.5.4 --precise 4.4.18
       - name: test
         run: cargo test --all --features unstable,legacy
   lint:

--- a/near-contract-standards/src/fungible_token/metadata.rs
+++ b/near-contract-standards/src/fungible_token/metadata.rs
@@ -1,10 +1,15 @@
+use near_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::json_types::Base64VecU8;
-use near_sdk::{ext_contract, near, require};
+use near_sdk::serde::{Deserialize, Serialize};
+use near_sdk::{ext_contract, near, require, NearSchema};
 
 pub const FT_METADATA_SPEC: &str = "ft-1.0.0";
 
 #[derive(Clone)]
-#[near(serializers=[borsh, json])]
+#[derive(Serialize, Deserialize, BorshDeserialize, BorshSerialize)]
+#[serde(crate = "near_sdk::serde")]
+#[borsh(crate = "near_sdk::borsh")]
+#[derive(NearSchema)]
 pub struct FungibleTokenMetadata {
     pub spec: String,
     pub name: String,

--- a/near-contract-standards/src/fungible_token/metadata.rs
+++ b/near-contract-standards/src/fungible_token/metadata.rs
@@ -1,15 +1,10 @@
-use near_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::json_types::Base64VecU8;
-use near_sdk::serde::{Deserialize, Serialize};
-use near_sdk::{ext_contract, near, require, NearSchema};
+use near_sdk::{ext_contract, near, require};
 
 pub const FT_METADATA_SPEC: &str = "ft-1.0.0";
 
 #[derive(Clone)]
-#[derive(Serialize, Deserialize, BorshDeserialize, BorshSerialize)]
-#[serde(crate = "near_sdk::serde")]
-#[borsh(crate = "near_sdk::borsh")]
-#[derive(NearSchema)]
+#[near(serializers=[borsh, json])]
 pub struct FungibleTokenMetadata {
     pub spec: String,
     pub name: String,

--- a/near-contract-standards/src/non_fungible_token/metadata.rs
+++ b/near-contract-standards/src/non_fungible_token/metadata.rs
@@ -1,15 +1,12 @@
-use near_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::json_types::Base64VecU8;
-use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::{near, require};
 
 /// This spec can be treated like a version of the standard.
 pub const NFT_METADATA_SPEC: &str = "nft-1.0.0";
 
 /// Metadata for the NFT contract itself.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, BorshDeserialize, BorshSerialize)]
-#[serde(crate = "near_sdk::serde")]
-#[borsh(crate = "near_sdk::borsh")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[near(serializers=[borsh, json])]
 pub struct NFTContractMetadata {
     pub spec: String,              // required, essentially a version like "nft-1.0.0"
     pub name: String,              // required, ex. "Mosaics"

--- a/near-contract-standards/src/non_fungible_token/metadata.rs
+++ b/near-contract-standards/src/non_fungible_token/metadata.rs
@@ -23,37 +23,19 @@ pub struct NFTContractMetadata {
 #[near(serializers=[borsh, json])]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TokenMetadata {
-    pub title: Option<String>,
-    pub description: Option<String>,
-    pub media: Option<String>,
-    pub media_hash: Option<Base64VecU8>,
-    pub copies: Option<u64>,
-    pub issued_at: Option<String>,
-    pub expires_at: Option<String>,
-    pub starts_at: Option<String>,
-    pub updated_at: Option<String>,
-    pub extra: Option<String>,
-    pub reference: Option<String>,
-    pub reference_hash: Option<Base64VecU8>,
+    pub title: Option<String>, // ex. "Arch Nemesis: Mail Carrier" or "Parcel #5055"
+    pub description: Option<String>, // free-form description
+    pub media: Option<String>, // URL to associated media, preferably to decentralized, content-addressed storage
+    pub media_hash: Option<Base64VecU8>, // Base64-encoded sha256 hash of content referenced by the `media` field. Required if `media` is included.
+    pub copies: Option<u64>, // number of copies of this set of metadata in existence when token was minted.
+    pub issued_at: Option<String>, // ISO 8601 datetime when token was issued or minted
+    pub expires_at: Option<String>, // ISO 8601 datetime when token expires
+    pub starts_at: Option<String>, // ISO 8601 datetime when token starts being valid
+    pub updated_at: Option<String>, // ISO 8601 datetime when token was last updated
+    pub extra: Option<String>, // anything extra the NFT wants to store on-chain. Can be stringified JSON.
+    pub reference: Option<String>, // URL to an off-chain JSON file with more info.
+    pub reference_hash: Option<Base64VecU8>, // Base64-encoded sha256 hash of JSON from reference field. Required if `reference` is included.
 }
-
-/// Metadata on the individual token level.
-// #[derive(Debug, Clone, Default, PartialEq, Eq)]
-// #[near(serializers=[borsh, json])]
-// pub struct TokenMetadata {
-//     pub title: Option<String>, // ex. "Arch Nemesis: Mail Carrier" or "Parcel #5055"
-//     pub description: Option<String>, // free-form description
-//     pub media: Option<String>, // URL to associated media, preferably to decentralized, content-addressed storage
-//     pub media_hash: Option<Base64VecU8>, // Base64-encoded sha256 hash of content referenced by the `media` field. Required if `media` is included.
-//     pub copies: Option<u64>, // number of copies of this set of metadata in existence when token was minted.
-//     pub issued_at: Option<String>, // ISO 8601 datetime when token was issued or minted
-//     pub expires_at: Option<String>, // ISO 8601 datetime when token expires
-//     pub starts_at: Option<String>, // ISO 8601 datetime when token starts being valid
-//     pub updated_at: Option<String>, // ISO 8601 datetime when token was last updated
-//     pub extra: Option<String>, // anything extra the NFT wants to store on-chain. Can be stringified JSON.
-//     pub reference: Option<String>, // URL to an off-chain JSON file with more info.
-//     pub reference_hash: Option<Base64VecU8>, // Base64-encoded sha256 hash of JSON from reference field. Required if `reference` is included.
-// }
 
 /// Offers details on the contract-level metadata.
 pub trait NonFungibleTokenMetadataProvider {

--- a/near-contract-standards/src/non_fungible_token/metadata.rs
+++ b/near-contract-standards/src/non_fungible_token/metadata.rs
@@ -1,14 +1,16 @@
 use near_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::json_types::Base64VecU8;
 use near_sdk::serde::{Deserialize, Serialize};
-use near_sdk::{require, near, NearSchema, MyNearSchema};
+use near_sdk::{require, near, NearSchema};
 
 /// This spec can be treated like a version of the standard.
 pub const NFT_METADATA_SPEC: &str = "nft-1.0.0";
 
 /// Metadata for the NFT contract itself.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[near(serializers=[borsh, json])]
+#[derive(Serialize, Deserialize, BorshDeserialize, BorshSerialize)]
+#[serde(crate = "near_sdk::serde")]
+#[borsh(crate = "near_sdk::borsh")]
 pub struct NFTContractMetadata {
     pub spec: String,              // required, essentially a version like "nft-1.0.0"
     pub name: String,              // required, ex. "Mosaics"
@@ -19,37 +21,7 @@ pub struct NFTContractMetadata {
     pub reference_hash: Option<Base64VecU8>, // Base64-encoded sha256 hash of JSON from reference field. Required if `reference` is included.
 }
 
-#[cfg(feature = "abi")]
-#[derive(
-    Debug,
-    Clone,
-    Default,
-    PartialEq,
-    Eq,
-    Serialize,
-    Deserialize,
-    BorshDeserialize,
-    BorshSerialize,
-    MyNearSchema,
-)]
-#[serde(crate = "near_sdk::serde")]
-#[borsh(crate = "near_sdk::borsh")]
-pub struct TokenMetadata {
-    pub title: Option<String>,
-    pub description: Option<String>,
-    pub media: Option<String>,
-    pub media_hash: Option<Base64VecU8>,
-    pub copies: Option<u64>,
-    pub issued_at: Option<String>,
-    pub expires_at: Option<String>,
-    pub starts_at: Option<String>,
-    pub updated_at: Option<String>,
-    pub extra: Option<String>,
-    pub reference: Option<String>,
-    pub reference_hash: Option<Base64VecU8>,
-}
-
-#[cfg(not(feature = "abi"))]
+#[cfg_attr(feature = "abi", derive(JsonSchema))]
 #[derive(
     Debug,
     Clone,

--- a/near-contract-standards/src/non_fungible_token/metadata.rs
+++ b/near-contract-standards/src/non_fungible_token/metadata.rs
@@ -1,7 +1,7 @@
 use near_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::json_types::Base64VecU8;
 use near_sdk::serde::{Deserialize, Serialize};
-use near_sdk::{my_tmp_macro, near, require};
+use near_sdk::{near, require};
 
 /// This spec can be treated like a version of the standard.
 pub const NFT_METADATA_SPEC: &str = "nft-1.0.0";
@@ -21,7 +21,7 @@ pub struct NFTContractMetadata {
     pub reference_hash: Option<Base64VecU8>, // Base64-encoded sha256 hash of JSON from reference field. Required if `reference` is included.
 }
 
-#[my_tmp_macro]
+#[near(serializers=[borsh, json])]
 #[derive(
     Debug,
     Clone,
@@ -43,6 +43,7 @@ pub struct TokenMetadata {
     pub reference: Option<String>,
     pub reference_hash: Option<Base64VecU8>,
 }
+
 
 /// Metadata on the individual token level.
 // #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/near-contract-standards/src/non_fungible_token/metadata.rs
+++ b/near-contract-standards/src/non_fungible_token/metadata.rs
@@ -7,8 +7,7 @@ use near_sdk::{near, require};
 pub const NFT_METADATA_SPEC: &str = "nft-1.0.0";
 
 /// Metadata for the NFT contract itself.
-#[derive(Clone, Debug, PartialEq, Eq)]
-#[derive(Serialize, Deserialize, BorshDeserialize, BorshSerialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, BorshDeserialize, BorshSerialize)]
 #[serde(crate = "near_sdk::serde")]
 #[borsh(crate = "near_sdk::borsh")]
 pub struct NFTContractMetadata {
@@ -22,13 +21,7 @@ pub struct NFTContractMetadata {
 }
 
 #[near(serializers=[borsh, json])]
-#[derive(
-    Debug,
-    Clone,
-    Default,
-    PartialEq,
-    Eq,
-)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TokenMetadata {
     pub title: Option<String>,
     pub description: Option<String>,
@@ -43,7 +36,6 @@ pub struct TokenMetadata {
     pub reference: Option<String>,
     pub reference_hash: Option<Base64VecU8>,
 }
-
 
 /// Metadata on the individual token level.
 // #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/near-contract-standards/src/non_fungible_token/metadata.rs
+++ b/near-contract-standards/src/non_fungible_token/metadata.rs
@@ -1,7 +1,7 @@
 use near_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::json_types::Base64VecU8;
 use near_sdk::serde::{Deserialize, Serialize};
-use near_sdk::{require, near, NearSchema};
+use near_sdk::{require, near};
 
 /// This spec can be treated like a version of the standard.
 pub const NFT_METADATA_SPEC: &str = "nft-1.0.0";
@@ -21,20 +21,14 @@ pub struct NFTContractMetadata {
     pub reference_hash: Option<Base64VecU8>, // Base64-encoded sha256 hash of JSON from reference field. Required if `reference` is included.
 }
 
-#[cfg_attr(feature = "abi", derive(JsonSchema))]
 #[derive(
     Debug,
     Clone,
     Default,
     PartialEq,
     Eq,
-    Serialize,
-    Deserialize,
-    BorshDeserialize,
-    BorshSerialize,
 )]
-#[serde(crate = "near_sdk::serde")]
-#[borsh(crate = "near_sdk::borsh")]
+#[near(serializers=[borsh, json])]
 pub struct TokenMetadata {
     pub title: Option<String>,
     pub description: Option<String>,

--- a/near-contract-standards/src/non_fungible_token/metadata.rs
+++ b/near-contract-standards/src/non_fungible_token/metadata.rs
@@ -1,7 +1,7 @@
 use near_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::json_types::Base64VecU8;
 use near_sdk::serde::{Deserialize, Serialize};
-use near_sdk::{require, near};
+use near_sdk::{my_tmp_macro, near, require};
 
 /// This spec can be treated like a version of the standard.
 pub const NFT_METADATA_SPEC: &str = "nft-1.0.0";
@@ -21,6 +21,7 @@ pub struct NFTContractMetadata {
     pub reference_hash: Option<Base64VecU8>, // Base64-encoded sha256 hash of JSON from reference field. Required if `reference` is included.
 }
 
+#[my_tmp_macro]
 #[derive(
     Debug,
     Clone,
@@ -28,7 +29,6 @@ pub struct NFTContractMetadata {
     PartialEq,
     Eq,
 )]
-#[near(serializers=[borsh, json])]
 pub struct TokenMetadata {
     pub title: Option<String>,
     pub description: Option<String>,

--- a/near-contract-standards/src/non_fungible_token/metadata.rs
+++ b/near-contract-standards/src/non_fungible_token/metadata.rs
@@ -1,5 +1,7 @@
+use near_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::json_types::Base64VecU8;
-use near_sdk::{near, require};
+use near_sdk::serde::{Deserialize, Serialize};
+use near_sdk::{require, near, NearSchema, MyNearSchema};
 
 /// This spec can be treated like a version of the standard.
 pub const NFT_METADATA_SPEC: &str = "nft-1.0.0";
@@ -17,23 +19,82 @@ pub struct NFTContractMetadata {
     pub reference_hash: Option<Base64VecU8>, // Base64-encoded sha256 hash of JSON from reference field. Required if `reference` is included.
 }
 
-/// Metadata on the individual token level.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-#[near(serializers=[borsh, json])]
+#[cfg(feature = "abi")]
+#[derive(
+    Debug,
+    Clone,
+    Default,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    BorshDeserialize,
+    BorshSerialize,
+    MyNearSchema,
+)]
+#[serde(crate = "near_sdk::serde")]
+#[borsh(crate = "near_sdk::borsh")]
 pub struct TokenMetadata {
-    pub title: Option<String>, // ex. "Arch Nemesis: Mail Carrier" or "Parcel #5055"
-    pub description: Option<String>, // free-form description
-    pub media: Option<String>, // URL to associated media, preferably to decentralized, content-addressed storage
-    pub media_hash: Option<Base64VecU8>, // Base64-encoded sha256 hash of content referenced by the `media` field. Required if `media` is included.
-    pub copies: Option<u64>, // number of copies of this set of metadata in existence when token was minted.
-    pub issued_at: Option<String>, // ISO 8601 datetime when token was issued or minted
-    pub expires_at: Option<String>, // ISO 8601 datetime when token expires
-    pub starts_at: Option<String>, // ISO 8601 datetime when token starts being valid
-    pub updated_at: Option<String>, // ISO 8601 datetime when token was last updated
-    pub extra: Option<String>, // anything extra the NFT wants to store on-chain. Can be stringified JSON.
-    pub reference: Option<String>, // URL to an off-chain JSON file with more info.
-    pub reference_hash: Option<Base64VecU8>, // Base64-encoded sha256 hash of JSON from reference field. Required if `reference` is included.
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub media: Option<String>,
+    pub media_hash: Option<Base64VecU8>,
+    pub copies: Option<u64>,
+    pub issued_at: Option<String>,
+    pub expires_at: Option<String>,
+    pub starts_at: Option<String>,
+    pub updated_at: Option<String>,
+    pub extra: Option<String>,
+    pub reference: Option<String>,
+    pub reference_hash: Option<Base64VecU8>,
 }
+
+#[cfg(not(feature = "abi"))]
+#[derive(
+    Debug,
+    Clone,
+    Default,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    BorshDeserialize,
+    BorshSerialize,
+)]
+#[serde(crate = "near_sdk::serde")]
+#[borsh(crate = "near_sdk::borsh")]
+pub struct TokenMetadata {
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub media: Option<String>,
+    pub media_hash: Option<Base64VecU8>,
+    pub copies: Option<u64>,
+    pub issued_at: Option<String>,
+    pub expires_at: Option<String>,
+    pub starts_at: Option<String>,
+    pub updated_at: Option<String>,
+    pub extra: Option<String>,
+    pub reference: Option<String>,
+    pub reference_hash: Option<Base64VecU8>,
+}
+
+/// Metadata on the individual token level.
+// #[derive(Debug, Clone, Default, PartialEq, Eq)]
+// #[near(serializers=[borsh, json])]
+// pub struct TokenMetadata {
+//     pub title: Option<String>, // ex. "Arch Nemesis: Mail Carrier" or "Parcel #5055"
+//     pub description: Option<String>, // free-form description
+//     pub media: Option<String>, // URL to associated media, preferably to decentralized, content-addressed storage
+//     pub media_hash: Option<Base64VecU8>, // Base64-encoded sha256 hash of content referenced by the `media` field. Required if `media` is included.
+//     pub copies: Option<u64>, // number of copies of this set of metadata in existence when token was minted.
+//     pub issued_at: Option<String>, // ISO 8601 datetime when token was issued or minted
+//     pub expires_at: Option<String>, // ISO 8601 datetime when token expires
+//     pub starts_at: Option<String>, // ISO 8601 datetime when token starts being valid
+//     pub updated_at: Option<String>, // ISO 8601 datetime when token was last updated
+//     pub extra: Option<String>, // anything extra the NFT wants to store on-chain. Can be stringified JSON.
+//     pub reference: Option<String>, // URL to an off-chain JSON file with more info.
+//     pub reference_hash: Option<Base64VecU8>, // Base64-encoded sha256 hash of JSON from reference field. Required if `reference` is included.
+// }
 
 /// Offers details on the contract-level metadata.
 pub trait NonFungibleTokenMetadataProvider {

--- a/near-contract-standards/src/non_fungible_token/token.rs
+++ b/near-contract-standards/src/non_fungible_token/token.rs
@@ -1,5 +1,8 @@
 use crate::non_fungible_token::metadata::TokenMetadata;
-use near_sdk::{serde::{Deserialize, Serialize}, AccountId, NearSchema};
+use near_sdk::{
+    serde::{Deserialize, Serialize},
+    AccountId, NearSchema,
+};
 use std::collections::HashMap;
 /// Note that token IDs for NFTs are strings on NEAR. It's still fine to use autoincrementing numbers as unique IDs if desired, but they should be stringified. This is to make IDs more future-proof as chain-agnostic conventions and standards arise, and allows for more flexibility with considerations like bridging NFTs across chains, etc.
 pub type TokenId = String;

--- a/near-contract-standards/src/non_fungible_token/token.rs
+++ b/near-contract-standards/src/non_fungible_token/token.rs
@@ -1,14 +1,12 @@
 use crate::non_fungible_token::metadata::TokenMetadata;
-use near_sdk::serde::{Deserialize, Serialize};
-use near_sdk::{AccountId, NearSchema};
+use near_sdk::{AccountId, near};
 use std::collections::HashMap;
 /// Note that token IDs for NFTs are strings on NEAR. It's still fine to use autoincrementing numbers as unique IDs if desired, but they should be stringified. This is to make IDs more future-proof as chain-agnostic conventions and standards arise, and allows for more flexibility with considerations like bridging NFTs across chains, etc.
 pub type TokenId = String;
 
 /// In this implementation, the Token struct takes two extensions standards (metadata and approval) as optional fields, as they are frequently used in modern NFTs.
-#[cfg_attr(feature = "abi", derive(JsonSchema))]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(crate = "near_sdk::serde")]
+#[near(serializers=[json])]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Token {
     pub token_id: TokenId,
     pub owner_id: AccountId,

--- a/near-contract-standards/src/non_fungible_token/token.rs
+++ b/near-contract-standards/src/non_fungible_token/token.rs
@@ -6,7 +6,8 @@ use std::collections::HashMap;
 pub type TokenId = String;
 
 /// In this implementation, the Token struct takes two extensions standards (metadata and approval) as optional fields, as they are frequently used in modern NFTs.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, NearSchema)]
+#[cfg_attr(feature = "abi", derive(JsonSchema))]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(crate = "near_sdk::serde")]
 pub struct Token {
     pub token_id: TokenId,

--- a/near-contract-standards/src/non_fungible_token/token.rs
+++ b/near-contract-standards/src/non_fungible_token/token.rs
@@ -1,12 +1,12 @@
 use crate::non_fungible_token::metadata::TokenMetadata;
-use near_sdk::{AccountId, near};
+use near_sdk::{serde::{Deserialize, Serialize}, AccountId, NearSchema};
 use std::collections::HashMap;
 /// Note that token IDs for NFTs are strings on NEAR. It's still fine to use autoincrementing numbers as unique IDs if desired, but they should be stringified. This is to make IDs more future-proof as chain-agnostic conventions and standards arise, and allows for more flexibility with considerations like bridging NFTs across chains, etc.
 pub type TokenId = String;
 
 /// In this implementation, the Token struct takes two extensions standards (metadata and approval) as optional fields, as they are frequently used in modern NFTs.
-#[near(serializers=[json])]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(NearSchema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(crate = "near_sdk::serde")]
 pub struct Token {
     pub token_id: TokenId,
     pub owner_id: AccountId,

--- a/near-sdk-macros/src/lib.rs
+++ b/near-sdk-macros/src/lib.rs
@@ -190,7 +190,7 @@ pub fn near(attr: TokenStream, item: TokenStream) -> TokenStream {
         abis = quote! { #[abi(json)] };
     }
 
-    // let schema_derive = get_schema_derive(has_json, has_borsh, near_sdk_crate.clone(), false);
+    let schema_derive = get_schema_derive(has_json, has_borsh, near_sdk_crate.clone(), false);
 
     let expanded;
     if let Ok(input) = syn::parse::<ItemStruct>(item.clone()) {
@@ -665,23 +665,7 @@ pub fn derive_near_schema(#[allow(unused)] input: TokenStream) -> TokenStream {
         // <unspecified> or #[abi(json)]
         let json_schema = json_schema || !borsh_schema;
 
-        let derive = {
-            let mut derive = quote! {};
-            if borsh_schema {
-                derive = quote! {
-                    #[derive(#near_sdk_crate::borsh::BorshSchema)]
-                    #[borsh(crate = #string_borsh_crate)]
-                };
-            }
-            if json_schema {
-                derive = quote! {
-                    #derive
-                    #[derive(#near_sdk_crate::schemars::JsonSchema)]
-                    #[schemars(crate = #string_schemars_crate)]
-                };
-            }
-            derive
-        };
+        let derive = get_schema_derive(json_schema, borsh_schema, near_sdk_crate.clone(), true);
 
         let input_ident = &input.ident;
 

--- a/near-sdk-macros/src/lib.rs
+++ b/near-sdk-macros/src/lib.rs
@@ -830,7 +830,7 @@ pub fn derive_no_default(item: TokenStream) -> TokenStream {
             .to_compile_error(),
         )
     }
-}
+} 
 
 /// `BorshStorageKey` generates implementation for `BorshIntoStorageKey` trait.
 /// It allows the type to be passed as a unique prefix for persistent collections.

--- a/near-sdk-macros/src/lib.rs
+++ b/near-sdk-macros/src/lib.rs
@@ -830,7 +830,7 @@ pub fn derive_no_default(item: TokenStream) -> TokenStream {
             .to_compile_error(),
         )
     }
-} 
+}
 
 /// `BorshStorageKey` generates implementation for `BorshIntoStorageKey` trait.
 /// It allows the type to be passed as a unique prefix for persistent collections.

--- a/near-sdk-macros/src/lib.rs
+++ b/near-sdk-macros/src/lib.rs
@@ -181,6 +181,15 @@ pub fn near(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     }
 
+    #[cfg(feature = "abi")]
+    {
+        let schema_derive: proc_macro2::TokenStream = get_schema_derive(has_json, has_borsh, near_sdk_crate.clone(), false);
+        expanded = quote! {
+            #expanded
+            #schema_derive
+        };
+    }
+
     if has_borsh {
         expanded = quote! {
             #expanded
@@ -194,16 +203,6 @@ pub fn near(attr: TokenStream, item: TokenStream) -> TokenStream {
             #expanded
             #[derive(#near_sdk_crate::serde::Serialize, #near_sdk_crate::serde::Deserialize)]
             #[serde(crate = #string_serde_crate)]
-        };
-    }
-
-    #[cfg(feature = "abi")]
-    {
-        let schema_derive: proc_macro2::TokenStream =
-            get_schema_derive(has_json, has_borsh, near_sdk_crate.clone(), false);
-        expanded = quote! {
-            #schema_derive
-            #expanded
         };
     }
 

--- a/near-sdk-macros/src/lib.rs
+++ b/near-sdk-macros/src/lib.rs
@@ -188,10 +188,6 @@ pub fn near(attr: TokenStream, item: TokenStream) -> TokenStream {
         };
     }
 
-    prev = quote! {
-        #prev
-    };
-
     let near_bindgen_annotation = if near_macro_args.contract_state.unwrap_or(false) {
         if let Some(metadata) = near_macro_args.contract_metadata {
             quote! {#[#near_sdk_crate::near_bindgen(#metadata)]}
@@ -210,17 +206,10 @@ pub fn near(attr: TokenStream, item: TokenStream) -> TokenStream {
         #[cfg(feature = "abi")]
         {
             expanded = quote! {
-                #[cfg(not(target_arch = "wasm32"))]
                 #near_bindgen_annotation
                 #schema_derive
                 #prev
                 #input
-
-                #[cfg(target_arch = "wasm32")]
-                #near_bindgen_annotation
-                #prev
-                #input
-
             };
         }
 
@@ -764,20 +753,20 @@ fn get_schema_derive(
     let mut derive = quote! {};
     if borsh_schema {
         derive = quote! {
-            #[derive(#near_sdk_crate::borsh::BorshSchema)]
+            #[cfg_attr(not(target_arch = "wasm32"), derive(#near_sdk_crate::borsh::BorshSchema))]
         };
         if need_borsh_crate {
             derive = quote! {
                 #derive
-                #[borsh(crate = #string_borsh_crate)]
+                #[cfg_attr(not(target_arch = "wasm32"), borsh(crate = #string_borsh_crate))]
             };
         }
     }
     if json_schema {
         derive = quote! {
             #derive
-            #[derive(#near_sdk_crate::schemars::JsonSchema)]
-            #[schemars(crate = #string_schemars_crate)]
+            #[cfg_attr(not(target_arch = "wasm32"), derive(#near_sdk_crate::schemars::JsonSchema))]
+            #[cfg_attr(not(target_arch = "wasm32"), schemars(crate = #string_schemars_crate))]
         };
     }
     derive

--- a/near-sdk-macros/src/lib.rs
+++ b/near-sdk-macros/src/lib.rs
@@ -232,8 +232,6 @@ pub fn near(attr: TokenStream, item: TokenStream) -> TokenStream {
         );
     }
 
-    // eprintln!("expanded: {}", expanded.to_string());
-
     TokenStream::from(expanded)
 }
 
@@ -690,7 +688,7 @@ pub fn derive_near_schema(#[allow(unused)] input: TokenStream) -> TokenStream {
             quote! {}
         };
 
-        let x = quote! {
+        TokenStream::from(quote! {
             #[cfg(not(target_arch = "wasm32"))]
             const _: () = {
                 #[allow(non_camel_case_types)]
@@ -704,9 +702,7 @@ pub fn derive_near_schema(#[allow(unused)] input: TokenStream) -> TokenStream {
                     #borsh_impl
                 };
             };
-        };
-        // eprintln!("x: {}", x.to_string());
-        TokenStream::from(x)
+        })
     }
 }
 

--- a/near-sdk-macros/src/lib.rs
+++ b/near-sdk-macros/src/lib.rs
@@ -122,7 +122,7 @@ pub fn near(attr: TokenStream, item: TokenStream) -> TokenStream {
     let string_borsh_crate = quote! {#near_sdk_crate::borsh}.to_string();
     let string_serde_crate = quote! {#near_sdk_crate::serde}.to_string();
 
-    let mut expanded: proc_macro2::TokenStream = quote!{};
+    let mut expanded: proc_macro2::TokenStream = quote! {};
 
     if near_macro_args.contract_state.unwrap_or(false) {
         if let Some(metadata) = near_macro_args.contract_metadata {
@@ -199,7 +199,8 @@ pub fn near(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     #[cfg(feature = "abi")]
     {
-        let schema_derive: proc_macro2::TokenStream = get_schema_derive(has_json, has_borsh, near_sdk_crate.clone(), false);
+        let schema_derive: proc_macro2::TokenStream =
+            get_schema_derive(has_json, has_borsh, near_sdk_crate.clone(), false);
         expanded = quote! {
             #schema_derive
             #expanded
@@ -207,12 +208,12 @@ pub fn near(attr: TokenStream, item: TokenStream) -> TokenStream {
     }
 
     if let Ok(input) = syn::parse::<ItemStruct>(item.clone()) {
-        expanded = quote!{
+        expanded = quote! {
             #expanded
             #input
         };
     } else if let Ok(input) = syn::parse::<ItemEnum>(item.clone()) {
-        expanded = quote!{
+        expanded = quote! {
             #expanded
             #input
         };

--- a/near-sdk-macros/src/lib.rs
+++ b/near-sdk-macros/src/lib.rs
@@ -190,10 +190,31 @@ pub fn near(attr: TokenStream, item: TokenStream) -> TokenStream {
         abis = quote! { #[abi(json)] };
     }
 
-    let expanded;
+    let schema_derive = get_schema_derive(has_json, has_borsh, near_sdk_crate.clone(), false);
+    // eprintln!("schema_derive: {}", schema_derive.to_string()); ////
+
+    let mut expanded;
     if let Ok(input) = syn::parse::<ItemStruct>(item.clone()) {
         expanded = quote! {
+            #[cfg(feature = "abi")]
             #near_bindgen_annotation
+            #schema_derive
+            #borsh
+            #json
+            #input
+
+            #[cfg(not(feature = "abi"))]
+            #near_bindgen_annotation
+            #borsh
+            #json
+            #input
+        };
+
+        // eprintln!("expanded: {}", expanded.to_string());
+
+        expanded = quote! {
+            #near_bindgen_annotation
+            // #schema_derive
             #[derive(#near_sdk_crate::NearSchema)]
             #inside_nearsdk_attr
             #borsh
@@ -201,9 +222,14 @@ pub fn near(attr: TokenStream, item: TokenStream) -> TokenStream {
             #abis
             #input
         };
+
+        // eprintln!("expanded: {}", expanded.to_string());
+
+
     } else if let Ok(input) = syn::parse::<ItemEnum>(item.clone()) {
         expanded = quote! {
             #near_bindgen_annotation
+            // #schema_derive
             #[derive(#near_sdk_crate::NearSchema)]
             #inside_nearsdk_attr
             #borsh
@@ -225,6 +251,8 @@ pub fn near(attr: TokenStream, item: TokenStream) -> TokenStream {
             .to_compile_error(),
         );
     }
+
+    // eprintln!("expanded: {}", expanded.to_string());
 
     TokenStream::from(expanded)
 }
@@ -546,13 +574,163 @@ struct DeriveNearSchema {
     borsh: Option<bool>,
 }
 
+#[proc_macro_derive(MyNearSchema, attributes(abi, serde, borsh, schemars, validate))]
+pub fn derive_my_near_schema(#[allow(unused)] input: TokenStream) -> TokenStream {
+    #[cfg(not(feature = "abi"))]
+    {
+        TokenStream::from(quote! {})
+    }
+
+    #[cfg(feature = "abi")]
+    {
+        use darling::FromDeriveInput;
+
+        let derive_input = syn::parse_macro_input!(input as syn::DeriveInput);
+        let args = match DeriveNearSchema::from_derive_input(&derive_input) {
+            Ok(v) => v,
+            Err(e) => {
+                return TokenStream::from(e.write_errors());
+            }
+        };
+
+        if args.borsh.is_none()
+            && args.json.is_none()
+            && derive_input.attrs.iter().any(|attr| attr.path().is_ident("abi"))
+        {
+            return TokenStream::from(
+                syn::Error::new_spanned(
+                    derive_input.to_token_stream(),
+                    "At least one of `json` or `borsh` inside of `#[abi(...)]` must be specified",
+                )
+                .to_compile_error(),
+            );
+        }
+
+        // #[abi(json, borsh)]
+        let (json_schema, borsh_schema) = (args.json.unwrap_or(false), args.borsh.unwrap_or(false));
+        let mut input = derive_input;
+        input.attrs = args.attrs;
+
+        let strip_unknown_attr = |attrs: &mut Vec<syn::Attribute>| {
+            attrs.retain(|attr| {
+                ["serde", "schemars", "validate", "borsh"]
+                    .iter()
+                    .any(|&path| attr.path().is_ident(path))
+            });
+        };
+
+        match &mut input.data {
+            syn::Data::Struct(data) => {
+                for field in &mut data.fields {
+                    strip_unknown_attr(&mut field.attrs);
+                }
+            }
+            syn::Data::Enum(data) => {
+                for variant in &mut data.variants {
+                    strip_unknown_attr(&mut variant.attrs);
+                    for field in &mut variant.fields {
+                        strip_unknown_attr(&mut field.attrs);
+                    }
+                }
+            }
+            syn::Data::Union(_) => {
+                return TokenStream::from(
+                    syn::Error::new_spanned(
+                        input.to_token_stream(),
+                        "`NearSchema` does not support derive for unions",
+                    )
+                    .to_compile_error(),
+                )
+            }
+        }
+
+        // <unspecified> or #[abi(json)]
+        let json_schema = json_schema || !borsh_schema;
+
+        let derive = {
+            let mut derive = quote! {};
+            if borsh_schema {
+                derive = quote! {
+                    #[derive(::near_sdk::borsh::BorshSchema)]
+                    #[borsh(crate = "::near_sdk::borsh")]
+                };
+            }
+            if json_schema {
+                derive = quote! {
+                    #derive
+                    #[derive(::near_sdk::schemars::JsonSchema)]
+                    #[schemars(crate = "::near_sdk::schemars")]
+                };
+            }
+            derive
+        };
+
+        let input_ident = &input.ident;
+
+        let input_ident_proxy = quote::format_ident!("{}__NEAR_SCHEMA_PROXY", input_ident);
+
+        let json_impl = if json_schema {
+            quote! {
+                #[automatically_derived]
+                impl ::near_sdk::schemars::JsonSchema for #input_ident_proxy {
+                    fn schema_name() -> ::std::string::String {
+                        stringify!(#input_ident).to_string()
+                    }
+
+                    fn json_schema(gen: &mut ::near_sdk::schemars::gen::SchemaGenerator) -> ::near_sdk::schemars::schema::Schema {
+                        <#input_ident as ::near_sdk::schemars::JsonSchema>::json_schema(gen)
+                    }
+                }
+            }
+        } else {
+            quote! {}
+        };
+
+        let borsh_impl = if borsh_schema {
+            quote! {
+                #[automatically_derived]
+                impl ::near_sdk::borsh::BorshSchema for #input_ident_proxy {
+                    fn declaration() -> ::near_sdk::borsh::schema::Declaration {
+                        stringify!(#input_ident).to_string()
+                    }
+
+                    fn add_definitions_recursively(
+                        definitions: &mut ::near_sdk::borsh::__private::maybestd::collections::BTreeMap<
+                            ::near_sdk::borsh::schema::Declaration,
+                            ::near_sdk::borsh::schema::Definition
+                        >,
+                    ) {
+                        <#input_ident as ::near_sdk::borsh::BorshSchema>::add_definitions_recursively(definitions);
+                    }
+                }
+            }
+        } else {
+            quote! {}
+        };
+
+        TokenStream::from(quote! {
+            #[cfg(not(target_arch = "wasm32"))]
+            const _: () = {
+                #[allow(non_camel_case_types)]
+                type #input_ident_proxy = #input_ident;
+                {
+                    #derive
+                    #input
+
+                    #json_impl
+                    #borsh_impl
+                };
+            };
+        })
+    }
+}
+
 #[proc_macro_derive(NearSchema, attributes(abi, serde, borsh, schemars, validate, inside_nearsdk))]
 pub fn derive_near_schema(#[allow(unused)] input: TokenStream) -> TokenStream {
     #[cfg(not(feature = "abi"))]
     {
         TokenStream::from(quote! {})
     }
-
     #[cfg(feature = "abi")]
     {
         use darling::FromDeriveInput;
@@ -623,29 +801,10 @@ pub fn derive_near_schema(#[allow(unused)] input: TokenStream) -> TokenStream {
             } else {
                 quote! {::near_sdk}
             };
-        let string_borsh_crate = quote! {#near_sdk_crate::borsh}.to_string();
-        let string_schemars_crate = quote! {#near_sdk_crate::schemars}.to_string();
 
         // <unspecified> or #[abi(json)]
         let json_schema = json_schema || !borsh_schema;
-
-        let derive = {
-            let mut derive = quote! {};
-            if borsh_schema {
-                derive = quote! {
-                    #[derive(#near_sdk_crate::borsh::BorshSchema)]
-                    #[borsh(crate = #string_borsh_crate)]
-                };
-            }
-            if json_schema {
-                derive = quote! {
-                    #derive
-                    #[derive(#near_sdk_crate::schemars::JsonSchema)]
-                    #[schemars(crate = #string_schemars_crate)]
-                };
-            }
-            derive
-        };
+        let derive = get_schema_derive(json_schema, borsh_schema, near_sdk_crate.clone(), true);
 
         let input_ident = &input.ident;
 
@@ -700,7 +859,7 @@ pub fn derive_near_schema(#[allow(unused)] input: TokenStream) -> TokenStream {
             quote! {}
         };
 
-        TokenStream::from(quote! {
+        let x = quote! {
             #[cfg(not(target_arch = "wasm32"))]
             const _: () = {
                 #[allow(non_camel_case_types)]
@@ -714,8 +873,44 @@ pub fn derive_near_schema(#[allow(unused)] input: TokenStream) -> TokenStream {
                     #borsh_impl
                 };
             };
-        })
+        };
+
+        eprintln!("x: {}", x.to_string());
+
+        TokenStream::from(x)
     }
+}
+
+fn get_schema_derive(json_schema: bool, borsh_schema: bool, near_sdk_crate: proc_macro2::TokenStream, need_borsh_crate: bool) -> proc_macro2::TokenStream {
+    let string_borsh_crate = quote! {#near_sdk_crate::borsh}.to_string();
+    let string_schemars_crate = quote! {#near_sdk_crate::schemars}.to_string();
+
+    let borsh_crate_derive = if need_borsh_crate {
+        quote! {#[borsh(crate = #string_borsh_crate)]}
+    } else {
+        // quote! {#[borsh(crate = #string_borsh_crate)]}
+
+        quote! {}
+    };
+
+    let derive = {
+        let mut derive = quote! {};
+        if borsh_schema {
+            derive = quote! {
+                #[derive(#near_sdk_crate::borsh::BorshSchema)]
+                #borsh_crate_derive
+            };
+        }
+        if json_schema {
+            derive = quote! {
+                #derive
+                #[derive(#near_sdk_crate::schemars::JsonSchema)]
+                #[schemars(crate = #string_schemars_crate)]
+            };
+        }
+        derive
+    };
+    derive
 }
 
 #[cfg(feature = "abi")]

--- a/near-sdk-macros/src/lib.rs
+++ b/near-sdk-macros/src/lib.rs
@@ -43,7 +43,6 @@ struct NearMacroArgs {
     contract_state: Option<bool>,
     contract_metadata: Option<core_impl::ContractMetadata>,
     inside_nearsdk: Option<bool>,
-    use_borsh_crate: Option<bool>,
 }
 
 /// This attribute macro is used to enhance the near_bindgen macro.
@@ -203,18 +202,10 @@ pub fn near(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     }
 
-    let use_borsh_crate = near_macro_args.use_borsh_crate.unwrap_or(true);
-
     let borsh = if has_borsh {
-        if use_borsh_crate {
-            quote! {
-                #[derive(#near_sdk_crate::borsh::BorshSerialize, #near_sdk_crate::borsh::BorshDeserialize)]
-                #borsh_attr
-            }
-        } else {
-            quote! {
-                #[derive(#near_sdk_crate::borsh::BorshSerialize, #near_sdk_crate::borsh::BorshDeserialize)]
-            }
+        quote! {
+            #[derive(#near_sdk_crate::borsh::BorshSerialize, #near_sdk_crate::borsh::BorshDeserialize)]
+            #borsh_attr
         }
     } else {
         quote! {}

--- a/near-sdk-macros/src/lib.rs
+++ b/near-sdk-macros/src/lib.rs
@@ -199,54 +199,27 @@ pub fn near(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     #[cfg(feature = "abi")]
-    let schema_derive = get_schema_derive(has_json, has_borsh, near_sdk_crate.clone(), false);
+    {
+        let schema_derive: proc_macro2::TokenStream = get_schema_derive(has_json, has_borsh, near_sdk_crate.clone(), false);
+        prev = quote! {
+            #schema_derive
+            #prev
+        };
+    }
 
     let expanded;
     if let Ok(input) = syn::parse::<ItemStruct>(item.clone()) {
-        #[cfg(feature = "abi")]
-        {
-            expanded = quote! {
-                #near_bindgen_annotation
-                #schema_derive
-                #prev
-                #input
-            };
-        }
-
-        #[cfg(not(feature = "abi"))]
-        {
-            expanded = quote! {
-                #near_bindgen_annotation
-                #prev
-                #input
-            };
-        }
+        expanded = quote!{
+            #near_bindgen_annotation
+            #prev
+            #input
+        };
     } else if let Ok(input) = syn::parse::<ItemEnum>(item.clone()) {
-        #[cfg(feature = "abi")]
-        {
-            expanded = quote! {
-                #[cfg(not(target_arch = "wasm32"))]
-                #near_bindgen_annotation
-                #schema_derive
-                #prev
-                #input
-
-                #[cfg(target_arch = "wasm32")]
-                #near_bindgen_annotation
-                #prev
-                #input
-
-            };
-        }
-
-        #[cfg(not(feature = "abi"))]
-        {
-            expanded = quote! {
-                #near_bindgen_annotation
-                #prev
-                #input
-            };
-        }
+        expanded = quote!{
+            #near_bindgen_annotation
+            #prev
+            #input
+        };
     } else if let Ok(input) = syn::parse::<ItemImpl>(item) {
         expanded = quote! {
             #[#near_sdk_crate::near_bindgen]

--- a/near-sdk-macros/src/lib.rs
+++ b/near-sdk-macros/src/lib.rs
@@ -183,7 +183,8 @@ pub fn near(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     #[cfg(feature = "abi")]
     {
-        let schema_derive: proc_macro2::TokenStream = get_schema_derive(has_json, has_borsh, near_sdk_crate.clone(), false);
+        let schema_derive: proc_macro2::TokenStream =
+            get_schema_derive(has_json, has_borsh, near_sdk_crate.clone(), false);
         expanded = quote! {
             #expanded
             #schema_derive

--- a/near-sdk/compilation_tests/all.rs
+++ b/near-sdk/compilation_tests/all.rs
@@ -36,4 +36,5 @@ fn compilation_tests() {
     t.pass("compilation_tests/contract_metadata.rs");
     t.compile_fail("compilation_tests/contract_metadata_fn_name.rs");
     t.pass("compilation_tests/contract_metadata_bindgen.rs");
+    t.pass("compilation_tests/types.rs");
 }

--- a/near-sdk/compilation_tests/types.rs
+++ b/near-sdk/compilation_tests/types.rs
@@ -1,0 +1,25 @@
+//! Check types from near_sdk.
+
+use near_sdk::near;
+use near_sdk::collections::{LookupMap, LookupSet, TreeMap, UnorderedMap, UnorderedSet, Vector};
+use near_sdk::json_types::Base58CryptoHash;
+use near_sdk::store::{Lazy, LazyOption};
+use near_sdk::CurveType;
+
+#[near(contract_state)]
+struct TypesContainer {
+    lookup_map: LookupMap<u32, u64>,
+    lookup_set: LookupSet<u32>,
+    tree_map: TreeMap<u32, u64>,
+    unordered_map: UnorderedMap<u32, u64>,
+    unordered_set: UnorderedSet<u32>,
+    vector: Vector<u32>,
+    base58_crypto_hash: Base58CryptoHash,
+    u64_type: near_sdk::json_types::U64,
+    base64_vec_u8: near_sdk::json_types::Base64VecU8,
+    lazy: Lazy<u64>,
+    lazy_option: LazyOption<u64>,
+    curve_type: CurveType,
+}
+
+fn main() {}

--- a/near-sdk/src/collections/legacy_tree_map.rs
+++ b/near-sdk/src/collections/legacy_tree_map.rs
@@ -30,7 +30,6 @@ pub struct LegacyTreeMap<K, V> {
 }
 
 #[near(inside_nearsdk)]
-#[derive(Clone)]
 pub struct Node<K> {
     id: u64,
     key: K,           // key stored in a node

--- a/near-sdk/src/collections/legacy_tree_map.rs
+++ b/near-sdk/src/collections/legacy_tree_map.rs
@@ -5,6 +5,7 @@
 #![allow(deprecated)]
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use near_sdk_macros::near;
 use std::ops::Bound;
 
 use crate::collections::UnorderedMap;
@@ -21,14 +22,15 @@ use crate::IntoStorageKey;
 /// - `range` of K elements:    O(Klog(N))
 ///
 #[deprecated(since = "4.1.0", note = "Use near_sdk::collections::TreeMap")]
-#[derive(BorshSerialize, BorshDeserialize)]
+#[near(inside_nearsdk)]
 pub struct LegacyTreeMap<K, V> {
     root: u64,
     val: UnorderedMap<K, V>,
     tree: Vector<Node<K>>,
 }
 
-#[derive(Clone, BorshSerialize, BorshDeserialize)]
+#[near(inside_nearsdk)]
+#[derive(Clone)]
 pub struct Node<K> {
     id: u64,
     key: K,           // key stored in a node

--- a/near-sdk/src/collections/lookup_map.rs
+++ b/near-sdk/src/collections/lookup_map.rs
@@ -4,6 +4,7 @@
 use std::marker::PhantomData;
 
 use borsh::{to_vec, BorshDeserialize, BorshSerialize};
+use borsh;
 
 use crate::collections::append_slice;
 use crate::{env, IntoStorageKey};
@@ -15,12 +16,59 @@ const ERR_VALUE_SERIALIZATION: &str = "Cannot serialize value with Borsh";
 
 /// An non-iterable implementation of a map that stores its content directly on the trie.
 
+// #[cfg(feature = "abi")]
+// #[derive(crate::borsh::BorshSchema)]
+// #[derive(crate::borsh::BorshSerialize,crate::borsh::BorshDeserialize)]
+// #[borsh(crate = "crate :: borsh")]
+// pub struct LookupMap<K, V> {
+//     key_prefix: Vec<u8>,
+//     #[borsh(skip)]
+//     el: PhantomData<(K, V)>,
+// }
+
+// #[cfg(not(feature = "abi"))]
+// #[derive(BorshSerialize,BorshDeserialize)]
+// #[borsh(crate = "crate :: borsh")]
+
 #[near(inside_nearsdk)]
 pub struct LookupMap<K, V> {
     key_prefix: Vec<u8>,
     #[borsh(skip)]
     el: PhantomData<(K, V)>,
 }
+
+
+// #[derive(crate :: NearSchema)]
+// #[derive(
+//     crate :: borsh :: BorshSerialize,
+//     crate :: borsh ::
+//  BorshDeserialize,
+// )]
+// #[inside_nearsdk]
+// #[borsh(crate = "crate :: borsh")]
+// #[abi(borsh)]
+// #[doc = " An non-iterable implementation of a map that stores its content directly on the trie."]
+// pub struct LookupMap<K, V> {
+//     key_prefix: Vec<u8>,
+//     #[borsh(skip)]
+//     el: PhantomData<(K, V)>,
+// }
+
+// #[derive(crate :: borsh :: BorshSchema)]
+// #[borsh(crate = "crate :: borsh")]
+// #[allow(dead_code)]
+// pub struct LookupMap<K, V> {
+//     key_prefix: Vec<u8>,
+//     #[borsh(skip)]
+//     el: PhantomData<(K, V)>,
+// }
+
+// #[near(inside_nearsdk)]
+// pub struct LookupMap<K, V> {
+//     key_prefix: Vec<u8>,
+//     #[borsh(skip)]
+//     el: PhantomData<(K, V)>,
+// }
 
 impl<K, V> LookupMap<K, V> {
     /// Create a new map. Use `key_prefix` as a unique prefix for keys.

--- a/near-sdk/src/collections/lookup_map.rs
+++ b/near-sdk/src/collections/lookup_map.rs
@@ -3,7 +3,6 @@
 //! makes this map more efficient in the number of reads and writes.
 use std::marker::PhantomData;
 
-use borsh;
 use borsh::{to_vec, BorshDeserialize, BorshSerialize};
 
 use crate::collections::append_slice;

--- a/near-sdk/src/collections/lookup_map.rs
+++ b/near-sdk/src/collections/lookup_map.rs
@@ -3,8 +3,8 @@
 //! makes this map more efficient in the number of reads and writes.
 use std::marker::PhantomData;
 
-use borsh::{to_vec, BorshDeserialize, BorshSerialize};
 use borsh;
+use borsh::{to_vec, BorshDeserialize, BorshSerialize};
 
 use crate::collections::append_slice;
 use crate::{env, IntoStorageKey};
@@ -36,7 +36,6 @@ pub struct LookupMap<K, V> {
     #[borsh(skip)]
     el: PhantomData<(K, V)>,
 }
-
 
 // #[derive(crate :: NearSchema)]
 // #[derive(

--- a/near-sdk/src/collections/lookup_map.rs
+++ b/near-sdk/src/collections/lookup_map.rs
@@ -15,59 +15,12 @@ const ERR_VALUE_DESERIALIZATION: &str = "Cannot deserialize value with Borsh";
 const ERR_VALUE_SERIALIZATION: &str = "Cannot serialize value with Borsh";
 
 /// An non-iterable implementation of a map that stores its content directly on the trie.
-
-// #[cfg(feature = "abi")]
-// #[derive(crate::borsh::BorshSchema)]
-// #[derive(crate::borsh::BorshSerialize,crate::borsh::BorshDeserialize)]
-// #[borsh(crate = "crate :: borsh")]
-// pub struct LookupMap<K, V> {
-//     key_prefix: Vec<u8>,
-//     #[borsh(skip)]
-//     el: PhantomData<(K, V)>,
-// }
-
-// #[cfg(not(feature = "abi"))]
-// #[derive(BorshSerialize,BorshDeserialize)]
-// #[borsh(crate = "crate :: borsh")]
-
 #[near(inside_nearsdk)]
 pub struct LookupMap<K, V> {
     key_prefix: Vec<u8>,
     #[borsh(skip)]
     el: PhantomData<(K, V)>,
 }
-
-// #[derive(crate :: NearSchema)]
-// #[derive(
-//     crate :: borsh :: BorshSerialize,
-//     crate :: borsh ::
-//  BorshDeserialize,
-// )]
-// #[inside_nearsdk]
-// #[borsh(crate = "crate :: borsh")]
-// #[abi(borsh)]
-// #[doc = " An non-iterable implementation of a map that stores its content directly on the trie."]
-// pub struct LookupMap<K, V> {
-//     key_prefix: Vec<u8>,
-//     #[borsh(skip)]
-//     el: PhantomData<(K, V)>,
-// }
-
-// #[derive(crate :: borsh :: BorshSchema)]
-// #[borsh(crate = "crate :: borsh")]
-// #[allow(dead_code)]
-// pub struct LookupMap<K, V> {
-//     key_prefix: Vec<u8>,
-//     #[borsh(skip)]
-//     el: PhantomData<(K, V)>,
-// }
-
-// #[near(inside_nearsdk)]
-// pub struct LookupMap<K, V> {
-//     key_prefix: Vec<u8>,
-//     #[borsh(skip)]
-//     el: PhantomData<(K, V)>,
-// }
 
 impl<K, V> LookupMap<K, V> {
     /// Create a new map. Use `key_prefix` as a unique prefix for keys.

--- a/near-sdk/src/collections/lookup_set.rs
+++ b/near-sdk/src/collections/lookup_set.rs
@@ -3,7 +3,8 @@
 //! makes this implementation more efficient in the number of reads and writes.
 use std::marker::PhantomData;
 
-use borsh::{to_vec, BorshDeserialize, BorshSerialize};
+use borsh::{to_vec, BorshSerialize};
+use near_sdk_macros::near;
 
 use crate::collections::append_slice;
 use crate::{env, IntoStorageKey};
@@ -14,7 +15,7 @@ const ERR_ELEMENT_SERIALIZATION: &str = "Cannot serialize element with Borsh";
 ///
 /// This set stores the values under a hash of the set's `prefix` and [`BorshSerialize`] of the
 /// value.
-#[derive(BorshSerialize, BorshDeserialize)]
+#[near(inside_nearsdk)]
 pub struct LookupSet<T> {
     element_prefix: Vec<u8>,
     #[borsh(skip)]

--- a/near-sdk/src/collections/tree_map.rs
+++ b/near-sdk/src/collections/tree_map.rs
@@ -23,7 +23,8 @@ pub struct TreeMap<K, V> {
     tree: Vector<Node<K>>,
 }
 
-#[derive(Clone, BorshSerialize, BorshDeserialize, Debug)]
+#[near(inside_nearsdk)]
+#[derive(Clone, Debug)]
 pub struct Node<K> {
     id: u64,
     key: K,           // key stored in a node

--- a/near-sdk/src/collections/unordered_map/mod.rs
+++ b/near-sdk/src/collections/unordered_map/mod.rs
@@ -6,8 +6,8 @@ pub use iter::Iter;
 
 use crate::collections::{append, append_slice, Vector};
 use crate::{env, IntoStorageKey};
-use near_sdk_macros::near;
 use borsh::{to_vec, BorshDeserialize, BorshSerialize};
+use near_sdk_macros::near;
 use std::mem::size_of;
 
 const ERR_INCONSISTENT_STATE: &str = "The collection is an inconsistent state. Did previous smart contract execution terminate unexpectedly?";

--- a/near-sdk/src/collections/unordered_map/mod.rs
+++ b/near-sdk/src/collections/unordered_map/mod.rs
@@ -6,6 +6,7 @@ pub use iter::Iter;
 
 use crate::collections::{append, append_slice, Vector};
 use crate::{env, IntoStorageKey};
+use near_sdk_macros::near;
 use borsh::{to_vec, BorshDeserialize, BorshSerialize};
 use std::mem::size_of;
 
@@ -15,7 +16,7 @@ const ERR_VALUE_DESERIALIZATION: &str = "Cannot deserialize value with Borsh";
 const ERR_VALUE_SERIALIZATION: &str = "Cannot serialize value with Borsh";
 
 /// An iterable implementation of a map that stores its content directly on the trie.
-#[derive(BorshSerialize, BorshDeserialize)]
+#[near(inside_nearsdk)]
 pub struct UnorderedMap<K, V> {
     key_index_prefix: Vec<u8>,
     keys: Vector<K>,

--- a/near-sdk/src/collections/unordered_set.rs
+++ b/near-sdk/src/collections/unordered_set.rs
@@ -2,6 +2,7 @@
 //! hashed but are instead serialized.
 use crate::collections::{append, append_slice, Vector};
 use crate::{env, IntoStorageKey};
+use near_sdk_macros::near;
 use borsh::{to_vec, BorshDeserialize, BorshSerialize};
 use std::mem::size_of;
 
@@ -9,7 +10,7 @@ const ERR_INCONSISTENT_STATE: &str = "The collection is an inconsistent state. D
 const ERR_ELEMENT_SERIALIZATION: &str = "Cannot serialize element with Borsh";
 
 /// An iterable implementation of a set that stores its content directly on the trie.
-#[derive(BorshSerialize, BorshDeserialize)]
+#[near(inside_nearsdk)]
 pub struct UnorderedSet<T> {
     element_index_prefix: Vec<u8>,
     elements: Vector<T>,

--- a/near-sdk/src/collections/unordered_set.rs
+++ b/near-sdk/src/collections/unordered_set.rs
@@ -2,8 +2,8 @@
 //! hashed but are instead serialized.
 use crate::collections::{append, append_slice, Vector};
 use crate::{env, IntoStorageKey};
-use near_sdk_macros::near;
 use borsh::{to_vec, BorshDeserialize, BorshSerialize};
+use near_sdk_macros::near;
 use std::mem::size_of;
 
 const ERR_INCONSISTENT_STATE: &str = "The collection is an inconsistent state. Did previous smart contract execution terminate unexpectedly?";

--- a/near-sdk/src/collections/vector.rs
+++ b/near-sdk/src/collections/vector.rs
@@ -511,6 +511,7 @@ mod tests {
         }
 
         #[derive(Debug, BorshDeserialize)]
+        #[allow(dead_code)]
         struct WithoutBorshSerialize(u64);
 
         let deserialize_only_vec =

--- a/near-sdk/src/json_types/hash.rs
+++ b/near-sdk/src/json_types/hash.rs
@@ -1,11 +1,12 @@
 use crate::CryptoHash;
-use borsh::{BorshDeserialize, BorshSerialize};
+use near_sdk_macros::near;
 use bs58::decode::Error as B58Error;
 use serde::{de, ser, Deserialize};
 use std::convert::TryFrom;
 
+#[near(inside_nearsdk)]
 #[derive(
-    Debug, Copy, Clone, PartialEq, PartialOrd, Ord, Eq, BorshDeserialize, BorshSerialize, Default,
+    Debug, Copy, Clone, PartialEq, PartialOrd, Ord, Eq, Default,
 )]
 pub struct Base58CryptoHash(CryptoHash);
 

--- a/near-sdk/src/json_types/hash.rs
+++ b/near-sdk/src/json_types/hash.rs
@@ -1,13 +1,11 @@
 use crate::CryptoHash;
-use near_sdk_macros::near;
 use bs58::decode::Error as B58Error;
+use near_sdk_macros::near;
 use serde::{de, ser, Deserialize};
 use std::convert::TryFrom;
 
 #[near(inside_nearsdk)]
-#[derive(
-    Debug, Copy, Clone, PartialEq, PartialOrd, Ord, Eq, Default,
-)]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Ord, Eq, Default)]
 pub struct Base58CryptoHash(CryptoHash);
 
 impl From<Base58CryptoHash> for CryptoHash {

--- a/near-sdk/src/json_types/integers.rs
+++ b/near-sdk/src/json_types/integers.rs
@@ -3,11 +3,12 @@
 //! NOTE: JSON standard can only work with integer up to 53 bits. So we need helper classes for
 //! 64-bit and 128-bit integers.
 
-use borsh::{BorshDeserialize, BorshSerialize};
+use near_sdk_macros::near;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 macro_rules! impl_str_type {
     ($iden: ident, $ty: tt) => {
+        #[near(inside_nearsdk)]
         #[derive(
             Debug,
             Clone,
@@ -16,8 +17,6 @@ macro_rules! impl_str_type {
             Eq,
             PartialOrd,
             Ord,
-            BorshDeserialize,
-            BorshSerialize,
             Default,
         )]
         pub struct $iden(pub $ty);

--- a/near-sdk/src/json_types/integers.rs
+++ b/near-sdk/src/json_types/integers.rs
@@ -9,16 +9,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 macro_rules! impl_str_type {
     ($iden: ident, $ty: tt) => {
         #[near(inside_nearsdk)]
-        #[derive(
-            Debug,
-            Clone,
-            Copy,
-            PartialEq,
-            Eq,
-            PartialOrd,
-            Ord,
-            Default,
-        )]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
         pub struct $iden(pub $ty);
 
         impl From<$ty> for $iden {

--- a/near-sdk/src/json_types/vector.rs
+++ b/near-sdk/src/json_types/vector.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Deserializer, Serializer};
 
 /// Helper class to serialize/deserialize `Vec<u8>` to base64 string.
 
-#[derive(Debug, Clone, PartialEq, Eq)]
 #[near(inside_nearsdk, serializers=[borsh, json])]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Base64VecU8(
     #[serde(
         serialize_with = "base64_bytes::serialize",

--- a/near-sdk/src/lib.rs
+++ b/near-sdk/src/lib.rs
@@ -8,7 +8,7 @@
 extern crate quickcheck;
 
 pub use near_sdk_macros::{
-    ext_contract, near, my_tmp_macro, near_bindgen, BorshStorageKey, EventMetadata, FunctionError, NearSchema,
+    ext_contract, near, near_bindgen, BorshStorageKey, EventMetadata, FunctionError, NearSchema,
     PanicOnDefault,
 };
 

--- a/near-sdk/src/lib.rs
+++ b/near-sdk/src/lib.rs
@@ -8,7 +8,7 @@
 extern crate quickcheck;
 
 pub use near_sdk_macros::{
-    ext_contract, near, near_bindgen, BorshStorageKey, EventMetadata, FunctionError, NearSchema,
+    ext_contract, near, near_bindgen, BorshStorageKey, EventMetadata, FunctionError, MyNearSchema, NearSchema,
     PanicOnDefault,
 };
 

--- a/near-sdk/src/lib.rs
+++ b/near-sdk/src/lib.rs
@@ -8,7 +8,7 @@
 extern crate quickcheck;
 
 pub use near_sdk_macros::{
-    ext_contract, near, near_bindgen, BorshStorageKey, EventMetadata, FunctionError, NearSchema,
+    ext_contract, near, my_tmp_macro, near_bindgen, BorshStorageKey, EventMetadata, FunctionError, NearSchema,
     PanicOnDefault,
 };
 

--- a/near-sdk/src/lib.rs
+++ b/near-sdk/src/lib.rs
@@ -8,7 +8,7 @@
 extern crate quickcheck;
 
 pub use near_sdk_macros::{
-    ext_contract, near, near_bindgen, BorshStorageKey, EventMetadata, FunctionError, MyNearSchema, NearSchema,
+    ext_contract, near, near_bindgen, BorshStorageKey, EventMetadata, FunctionError, NearSchema,
     PanicOnDefault,
 };
 

--- a/near-sdk/src/store/free_list/mod.rs
+++ b/near-sdk/src/store/free_list/mod.rs
@@ -3,18 +3,23 @@ pub use self::iter::{Drain, Iter, IterMut};
 
 use super::{Vector, ERR_INCONSISTENT_STATE};
 use crate::{env, IntoStorageKey};
+use near_sdk_macros::{near, NearSchema};
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
 use std::{fmt, mem};
 
 /// Index for value within a bucket.
-#[derive(BorshSerialize, BorshDeserialize, Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[near(inside_nearsdk)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub struct FreeListIndex(pub(crate) u32);
 
 /// Unordered container of values. This is similar to [`Vector`] except that values are not
 /// re-arranged on removal, keeping the indices consistent. When an element is removed, it will
 /// be replaced with an empty cell which will be populated on the next insertion.
+#[derive(NearSchema)]
+#[inside_nearsdk]
+#[abi(borsh)]
 pub(crate) struct FreeList<T>
 where
     T: BorshSerialize,
@@ -51,7 +56,8 @@ where
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize, Debug)]
+#[near(inside_nearsdk)]
+#[derive(Debug)]
 enum Slot<T> {
     /// Represents a filled cell of a value in the collection.
     Occupied(T),

--- a/near-sdk/src/store/index_map.rs
+++ b/near-sdk/src/store/index_map.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use near_sdk_macros::near;
 use once_cell::unsync::OnceCell;
 
 use crate::utils::StableMap;
@@ -9,7 +10,7 @@ use crate::{env, CacheEntry, EntryState, IntoStorageKey};
 const ERR_ELEMENT_DESERIALIZATION: &str = "Cannot deserialize element";
 const ERR_ELEMENT_SERIALIZATION: &str = "Cannot serialize element";
 
-#[derive(BorshSerialize, BorshDeserialize)]
+#[near(inside_nearsdk)]
 pub(crate) struct IndexMap<T>
 where
     T: BorshSerialize,

--- a/near-sdk/src/store/lazy/mod.rs
+++ b/near-sdk/src/store/lazy/mod.rs
@@ -59,7 +59,7 @@ where
 /// *a = "new string".to_string();
 /// assert_eq!(a.get(), "new string");
 /// ```
-#[derive(BorshSerialize, BorshDeserialize)]
+#[near(inside_nearsdk)]
 pub struct Lazy<T>
 where
     T: BorshSerialize,

--- a/near-sdk/src/store/lazy/mod.rs
+++ b/near-sdk/src/store/lazy/mod.rs
@@ -9,6 +9,8 @@ mod impls;
 use borsh::{to_vec, BorshDeserialize, BorshSerialize};
 use once_cell::unsync::OnceCell;
 
+use near_sdk_macros::near;
+
 use crate::env;
 use crate::store::ERR_INCONSISTENT_STATE;
 use crate::utils::{CacheEntry, EntryState};

--- a/near-sdk/src/store/lazy_option/mod.rs
+++ b/near-sdk/src/store/lazy_option/mod.rs
@@ -1,6 +1,7 @@
 mod impls;
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use near_sdk_macros::near;
 use once_cell::unsync::OnceCell;
 
 use crate::env;

--- a/near-sdk/src/store/lazy_option/mod.rs
+++ b/near-sdk/src/store/lazy_option/mod.rs
@@ -31,7 +31,7 @@ use crate::IntoStorageKey;
 /// assert_eq!(a.get(), &Some("new new value".to_owned()));
 /// ```
 /// [`Deref`]: std::ops::Deref
-#[derive(BorshSerialize, BorshDeserialize)]
+#[near(inside_nearsdk)]
 pub struct LazyOption<T>
 where
     T: BorshSerialize,

--- a/near-sdk/src/store/lookup_map/mod.rs
+++ b/near-sdk/src/store/lookup_map/mod.rs
@@ -6,6 +6,7 @@ use std::fmt;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use once_cell::unsync::OnceCell;
+use near_sdk_macros::near;
 
 use super::ERR_NOT_EXIST;
 use crate::store::key::{Identity, ToKey};
@@ -76,7 +77,7 @@ const ERR_ELEMENT_SERIALIZATION: &str = "Cannot serialize element";
 ///
 /// [`with_hasher`]: Self::with_hasher
 
-#[derive(BorshSerialize, BorshDeserialize)]
+#[near(inside_nearsdk)]
 pub struct LookupMap<K, V, H = Identity>
 where
     K: BorshSerialize + Ord,

--- a/near-sdk/src/store/lookup_map/mod.rs
+++ b/near-sdk/src/store/lookup_map/mod.rs
@@ -5,8 +5,8 @@ use std::borrow::Borrow;
 use std::fmt;
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use once_cell::unsync::OnceCell;
 use near_sdk_macros::near;
+use once_cell::unsync::OnceCell;
 
 use super::ERR_NOT_EXIST;
 use crate::store::key::{Identity, ToKey};

--- a/near-sdk/src/store/lookup_set/mod.rs
+++ b/near-sdk/src/store/lookup_set/mod.rs
@@ -2,10 +2,12 @@ mod impls;
 
 use crate::store::key::{Identity, ToKey};
 use crate::{env, IntoStorageKey};
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::BorshSerialize;
 use std::borrow::Borrow;
 use std::fmt;
 use std::marker::PhantomData;
+
+use near_sdk_macros::near;
 
 /// A non-iterable implementation of a set that stores its content directly on the storage trie.
 ///
@@ -44,7 +46,7 @@ use std::marker::PhantomData;
 /// ```
 ///
 /// [`with_hasher`]: Self::with_hasher
-#[derive(BorshSerialize, BorshDeserialize)]
+#[near(inside_nearsdk)]
 pub struct LookupSet<T, H = Identity>
 where
     T: BorshSerialize,

--- a/near-sdk/src/store/tree_map/iter.rs
+++ b/near-sdk/src/store/tree_map/iter.rs
@@ -998,7 +998,8 @@ impl<K> Find<K> {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize, Debug, Copy, Clone)]
+#[near(inside_nearsdk)]
+#[derive(Debug, Copy, Clone)]
 enum FindUnbounded {
     /// Find the first element in the given root
     First,

--- a/near-sdk/src/store/tree_map/iter.rs
+++ b/near-sdk/src/store/tree_map/iter.rs
@@ -1,3 +1,4 @@
+use near_sdk_macros::near;
 use std::ops::Bound;
 use std::vec::Vec;
 use std::{borrow::Borrow, iter::FusedIterator};

--- a/near-sdk/src/store/tree_map/mod.rs
+++ b/near-sdk/src/store/tree_map/mod.rs
@@ -92,7 +92,7 @@ where
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[near(inside_nearsdk)]
 struct Tree<K>
 where
     K: BorshSerialize,
@@ -114,7 +114,8 @@ where
     }
 }
 
-#[derive(Clone, BorshSerialize, BorshDeserialize, Debug)]
+#[near(inside_nearsdk)]
+#[derive(Clone, Debug)]
 struct Node<K> {
     key: K,                     // key stored in a node
     lft: Option<FreeListIndex>, // left link of a node

--- a/near-sdk/src/store/tree_map/mod.rs
+++ b/near-sdk/src/store/tree_map/mod.rs
@@ -14,6 +14,8 @@ use std::borrow::Borrow;
 use std::fmt;
 use std::ops::RangeBounds;
 
+use near_sdk_macros::near;
+
 type NodeAndIndex<'a, K> = (FreeListIndex, &'a Node<K>);
 
 fn expect<T>(val: Option<T>) -> T {

--- a/near-sdk/src/store/unordered_map/mod.rs
+++ b/near-sdk/src/store/unordered_map/mod.rs
@@ -11,6 +11,8 @@ use std::{fmt, mem};
 use borsh::{BorshDeserialize, BorshSerialize};
 
 use near_sdk_macros::near;
+use near_sdk_macros::NearSchema;
+use near_sdk_macros::my_tmp_macro;
 
 use crate::store::key::{Sha256, ToKey};
 use crate::{env, IntoStorageKey};
@@ -100,11 +102,40 @@ where
     values: LookupMap<K, ValueAndIndex<V>, H>,
 }
 
-#[near(inside_nearsdk)]
+#[my_tmp_macro]
 struct ValueAndIndex<V> {
     value: V,
     key_index: FreeListIndex,
 }
+
+// #[cfg(feature = "abi")]
+// #[derive(crate::borsh::BorshSchema)]              
+// #[derive(crate :: borsh :: BorshSerialize, crate::borsh::BorshDeserialize)] 
+// #[borsh(crate = "crate :: borsh")]
+// // #[derive(crate :: borsh :: BorshSerialize, crate :: borsh :: BorshDeserialize)] 
+// struct ValueAndIndex<V> {
+//     value: V,
+//     key_index: FreeListIndex,
+// }
+
+// #[cfg(not(feature = "abi"))]             
+// #[derive(crate :: borsh :: BorshSerialize, crate::borsh::BorshDeserialize)] 
+// #[borsh(crate = "crate :: borsh")]
+// // #[derive(crate :: borsh :: BorshSerialize, crate :: borsh :: BorshDeserialize)] 
+// struct ValueAndIndex<V> {
+//     value: V,
+//     key_index: FreeListIndex,
+// }
+
+// #[cfg(not(feature = "abi"))]
+// // #[derive(crate :: borsh :: BorshSchema)]
+// // #[derive(crate::borsh::BorshSchema, crate :: borsh :: BorshSerialize, crate :: borsh ::BorshDeserialize)] 
+// // #[borsh(crate = "crate::borsh")]
+// #[derive(BorshSerialize, BorshDeserialize)] 
+// struct ValueAndIndex<V> {
+//     value: V,
+//     key_index: FreeListIndex,
+// }
 
 //? Manual implementations needed only because borsh derive is leaking field types
 // https://github.com/near/borsh-rs/issues/41

--- a/near-sdk/src/store/unordered_map/mod.rs
+++ b/near-sdk/src/store/unordered_map/mod.rs
@@ -106,35 +106,6 @@ struct ValueAndIndex<V> {
     key_index: FreeListIndex,
 }
 
-// #[cfg(feature = "abi")]
-// #[derive(crate::borsh::BorshSchema)]
-// #[derive(crate :: borsh :: BorshSerialize, crate::borsh::BorshDeserialize)]
-// #[borsh(crate = "crate :: borsh")]
-// // #[derive(crate :: borsh :: BorshSerialize, crate :: borsh :: BorshDeserialize)]
-// struct ValueAndIndex<V> {
-//     value: V,
-//     key_index: FreeListIndex,
-// }
-
-// #[cfg(not(feature = "abi"))]
-// #[derive(crate :: borsh :: BorshSerialize, crate::borsh::BorshDeserialize)]
-// #[borsh(crate = "crate :: borsh")]
-// // #[derive(crate :: borsh :: BorshSerialize, crate :: borsh :: BorshDeserialize)]
-// struct ValueAndIndex<V> {
-//     value: V,
-//     key_index: FreeListIndex,
-// }
-
-// #[cfg(not(feature = "abi"))]
-// // #[derive(crate :: borsh :: BorshSchema)]
-// // #[derive(crate::borsh::BorshSchema, crate :: borsh :: BorshSerialize, crate :: borsh ::BorshDeserialize)]
-// // #[borsh(crate = "crate::borsh")]
-// #[derive(BorshSerialize, BorshDeserialize)]
-// struct ValueAndIndex<V> {
-//     value: V,
-//     key_index: FreeListIndex,
-// }
-
 //? Manual implementations needed only because borsh derive is leaking field types
 // https://github.com/near/borsh-rs/issues/41
 impl<K, V, H> BorshSerialize for UnorderedMap<K, V, H>

--- a/near-sdk/src/store/unordered_map/mod.rs
+++ b/near-sdk/src/store/unordered_map/mod.rs
@@ -107,19 +107,19 @@ struct ValueAndIndex<V> {
 }
 
 // #[cfg(feature = "abi")]
-// #[derive(crate::borsh::BorshSchema)]              
-// #[derive(crate :: borsh :: BorshSerialize, crate::borsh::BorshDeserialize)] 
+// #[derive(crate::borsh::BorshSchema)]
+// #[derive(crate :: borsh :: BorshSerialize, crate::borsh::BorshDeserialize)]
 // #[borsh(crate = "crate :: borsh")]
-// // #[derive(crate :: borsh :: BorshSerialize, crate :: borsh :: BorshDeserialize)] 
+// // #[derive(crate :: borsh :: BorshSerialize, crate :: borsh :: BorshDeserialize)]
 // struct ValueAndIndex<V> {
 //     value: V,
 //     key_index: FreeListIndex,
 // }
 
-// #[cfg(not(feature = "abi"))]             
-// #[derive(crate :: borsh :: BorshSerialize, crate::borsh::BorshDeserialize)] 
+// #[cfg(not(feature = "abi"))]
+// #[derive(crate :: borsh :: BorshSerialize, crate::borsh::BorshDeserialize)]
 // #[borsh(crate = "crate :: borsh")]
-// // #[derive(crate :: borsh :: BorshSerialize, crate :: borsh :: BorshDeserialize)] 
+// // #[derive(crate :: borsh :: BorshSerialize, crate :: borsh :: BorshDeserialize)]
 // struct ValueAndIndex<V> {
 //     value: V,
 //     key_index: FreeListIndex,
@@ -127,9 +127,9 @@ struct ValueAndIndex<V> {
 
 // #[cfg(not(feature = "abi"))]
 // // #[derive(crate :: borsh :: BorshSchema)]
-// // #[derive(crate::borsh::BorshSchema, crate :: borsh :: BorshSerialize, crate :: borsh ::BorshDeserialize)] 
+// // #[derive(crate::borsh::BorshSchema, crate :: borsh :: BorshSerialize, crate :: borsh ::BorshDeserialize)]
 // // #[borsh(crate = "crate::borsh")]
-// #[derive(BorshSerialize, BorshDeserialize)] 
+// #[derive(BorshSerialize, BorshDeserialize)]
 // struct ValueAndIndex<V> {
 //     value: V,
 //     key_index: FreeListIndex,

--- a/near-sdk/src/store/unordered_map/mod.rs
+++ b/near-sdk/src/store/unordered_map/mod.rs
@@ -11,8 +11,6 @@ use std::{fmt, mem};
 use borsh::{BorshDeserialize, BorshSerialize};
 
 use near_sdk_macros::near;
-use near_sdk_macros::NearSchema;
-use near_sdk_macros::my_tmp_macro;
 
 use crate::store::key::{Sha256, ToKey};
 use crate::{env, IntoStorageKey};
@@ -102,7 +100,7 @@ where
     values: LookupMap<K, ValueAndIndex<V>, H>,
 }
 
-#[my_tmp_macro]
+#[near(inside_nearsdk)]
 struct ValueAndIndex<V> {
     value: V,
     key_index: FreeListIndex,

--- a/near-sdk/src/store/unordered_map/mod.rs
+++ b/near-sdk/src/store/unordered_map/mod.rs
@@ -10,6 +10,8 @@ use std::{fmt, mem};
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
+use near_sdk_macros::near;
+
 use crate::store::key::{Sha256, ToKey};
 use crate::{env, IntoStorageKey};
 
@@ -98,7 +100,7 @@ where
     values: LookupMap<K, ValueAndIndex<V>, H>,
 }
 
-#[derive(BorshSerialize, BorshDeserialize)]
+#[near(inside_nearsdk)]
 struct ValueAndIndex<V> {
     value: V,
     key_index: FreeListIndex,

--- a/near-sdk/src/store/vec/mod.rs
+++ b/near-sdk/src/store/vec/mod.rs
@@ -547,7 +547,7 @@ where
 #[cfg(test)]
 mod tests {
     use arbitrary::{Arbitrary, Unstructured};
-    use borsh::{to_vec, BorshDeserialize, BorshSerialize};
+    use borsh::{to_vec, BorshDeserialize};
     use rand::{Rng, RngCore, SeedableRng};
 
     use super::Vector;
@@ -686,8 +686,10 @@ mod tests {
         // * The storage is reused in the second part of this test, need to flush
         vec.flush();
 
-        use borsh::{BorshDeserialize, BorshSerialize};
-        #[derive(Debug, BorshSerialize, BorshDeserialize)]
+        use near_sdk_macros::near;
+
+        #[near(inside_nearsdk)]
+        #[derive(Debug)]
         struct TestType(u64);
 
         let deserialize_only_vec =

--- a/near-sdk/src/store/vec/mod.rs
+++ b/near-sdk/src/store/vec/mod.rs
@@ -61,6 +61,7 @@ use std::{
 };
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use near_sdk_macros::NearSchema;
 
 pub use self::iter::{Drain, Iter, IterMut};
 use super::ERR_INCONSISTENT_STATE;
@@ -111,6 +112,9 @@ fn expect_consistent_state<T>(val: Option<T>) -> T {
 /// vec.extend([1, 2, 3].iter().copied());
 /// assert!(Iterator::eq(vec.into_iter(), [7, 1, 2, 3].iter()));
 /// ```
+#[derive(NearSchema)]
+#[inside_nearsdk]
+#[abi(borsh)]
 pub struct Vector<T>
 where
     T: BorshSerialize,

--- a/near-sdk/src/types/public_key.rs
+++ b/near-sdk/src/types/public_key.rs
@@ -310,7 +310,7 @@ mod tests {
     #[test]
     fn test_public_key_borsh_format_change() {
         // Original struct to reference Borsh serialization from
-        #[derive(BorshSerialize, BorshDeserialize)]
+        #[near]
         struct PublicKeyRef(Vec<u8>);
 
         let mut data = vec![CurveType::ED25519 as u8];

--- a/near-sdk/src/types/public_key.rs
+++ b/near-sdk/src/types/public_key.rs
@@ -4,7 +4,7 @@ use std::{convert::TryFrom, io};
 use near_sdk_macros::near;
 
 /// PublicKey curve
-#[near(inside_nearsdk)]
+#[near(inside_nearsdk, use_borsh_crate=false)]
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, Eq, PartialEq)]
 #[repr(u8)]
 #[borsh(use_discriminant = true)]

--- a/near-sdk/src/types/public_key.rs
+++ b/near-sdk/src/types/public_key.rs
@@ -1,7 +1,7 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use bs58::decode::Error as B58Error;
-use std::{convert::TryFrom, io};
 use near_sdk_macros::near;
+use std::{convert::TryFrom, io};
 
 /// PublicKey curve
 #[near(inside_nearsdk, serializers=[borsh(use_discriminant = true)])]

--- a/near-sdk/src/types/public_key.rs
+++ b/near-sdk/src/types/public_key.rs
@@ -1,9 +1,11 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use bs58::decode::Error as B58Error;
 use std::{convert::TryFrom, io};
+use near_sdk_macros::near;
 
 /// PublicKey curve
-#[derive(Debug, Clone, Copy, PartialOrd, Ord, Eq, PartialEq, BorshDeserialize, BorshSerialize)]
+#[near(inside_nearsdk)]
+#[derive(Debug, Clone, Copy, PartialOrd, Ord, Eq, PartialEq)]
 #[repr(u8)]
 #[borsh(use_discriminant = true)]
 pub enum CurveType {

--- a/near-sdk/src/types/public_key.rs
+++ b/near-sdk/src/types/public_key.rs
@@ -4,10 +4,9 @@ use std::{convert::TryFrom, io};
 use near_sdk_macros::near;
 
 /// PublicKey curve
-#[near(inside_nearsdk, use_borsh_crate=false)]
+#[near(inside_nearsdk, use_borsh_crate=true, serializers=[borsh(use_discriminant = true)])]
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, Eq, PartialEq)]
 #[repr(u8)]
-#[borsh(use_discriminant = true)]
 pub enum CurveType {
     ED25519 = 0,
     SECP256K1 = 1,

--- a/near-sdk/src/types/public_key.rs
+++ b/near-sdk/src/types/public_key.rs
@@ -310,7 +310,7 @@ mod tests {
     #[test]
     fn test_public_key_borsh_format_change() {
         // Original struct to reference Borsh serialization from
-        #[near]
+        #[derive(BorshSerialize, BorshDeserialize)]
         struct PublicKeyRef(Vec<u8>);
 
         let mut data = vec![CurveType::ED25519 as u8];

--- a/near-sdk/src/types/public_key.rs
+++ b/near-sdk/src/types/public_key.rs
@@ -4,7 +4,7 @@ use std::{convert::TryFrom, io};
 use near_sdk_macros::near;
 
 /// PublicKey curve
-#[near(inside_nearsdk, use_borsh_crate=true, serializers=[borsh(use_discriminant = true)])]
+#[near(inside_nearsdk, serializers=[borsh(use_discriminant = true)])]
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, Eq, PartialEq)]
 #[repr(u8)]
 pub enum CurveType {


### PR DESCRIPTION
Adds ability to set borsh attributes as `#[near(serializers=[borsh(use_discriminant=false), json])`
Adds near macro which contain borsh/json schema for all the types