### PR TITLE
[Fix] Remove manual borsh ser/de implementations from 'store' collections.

### DIFF
--- a/near-sdk/src/store/free_list/mod.rs
+++ b/near-sdk/src/store/free_list/mod.rs
@@ -17,7 +17,7 @@ pub struct FreeListIndex(pub(crate) u32);
 /// Unordered container of values. This is similar to [`Vector`] except that values are not
 /// re-arranged on removal, keeping the indices consistent. When an element is removed, it will
 /// be replaced with an empty cell which will be populated on the next insertion.
-#[derive(NearSchema)]
+#[derive(NearSchema, BorshDeserialize, BorshSerialize)]
 #[inside_nearsdk]
 #[abi(borsh)]
 pub(crate) struct FreeList<T>
@@ -27,33 +27,6 @@ where
     first_free: Option<FreeListIndex>,
     occupied_count: u32,
     elements: Vector<Slot<T>>,
-}
-
-//? Manual implementations needed only because borsh derive is leaking field types
-// https://github.com/near/borsh-rs/issues/41
-impl<T> BorshSerialize for FreeList<T>
-where
-    T: BorshSerialize,
-{
-    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
-        BorshSerialize::serialize(&self.first_free, writer)?;
-        BorshSerialize::serialize(&self.occupied_count, writer)?;
-        BorshSerialize::serialize(&self.elements, writer)?;
-        Ok(())
-    }
-}
-
-impl<T> BorshDeserialize for FreeList<T>
-where
-    T: BorshSerialize,
-{
-    fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, std::io::Error> {
-        Ok(Self {
-            first_free: BorshDeserialize::deserialize_reader(reader)?,
-            occupied_count: BorshDeserialize::deserialize_reader(reader)?,
-            elements: BorshDeserialize::deserialize_reader(reader)?,
-        })
-    }
 }
 
 #[near(inside_nearsdk)]

--- a/near-sdk/src/store/iterable_map/mod.rs
+++ b/near-sdk/src/store/iterable_map/mod.rs
@@ -81,6 +81,7 @@ use super::{LookupMap, ERR_INCONSISTENT_STATE, ERR_NOT_EXIST};
 /// ```
 ///
 /// [`with_hasher`]: Self::with_hasher
+#[derive(BorshDeserialize, BorshSerialize)]
 pub struct IterableMap<K, V, H = Sha256>
 where
     K: BorshSerialize + Ord,
@@ -99,35 +100,6 @@ where
 struct ValueAndIndex<V> {
     value: V,
     key_index: u32,
-}
-
-//? Manual implementations needed only because borsh derive is leaking field types
-// https://github.com/near/borsh-rs/issues/41
-impl<K, V, H> BorshSerialize for IterableMap<K, V, H>
-where
-    K: BorshSerialize + Ord,
-    V: BorshSerialize,
-    H: ToKey,
-{
-    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
-        BorshSerialize::serialize(&self.keys, writer)?;
-        BorshSerialize::serialize(&self.values, writer)?;
-        Ok(())
-    }
-}
-
-impl<K, V, H> BorshDeserialize for IterableMap<K, V, H>
-where
-    K: BorshSerialize + Ord,
-    V: BorshSerialize,
-    H: ToKey,
-{
-    fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, std::io::Error> {
-        Ok(Self {
-            keys: BorshDeserialize::deserialize_reader(reader)?,
-            values: BorshDeserialize::deserialize_reader(reader)?,
-        })
-    }
 }
 
 impl<K, V, H> Drop for IterableMap<K, V, H>

--- a/near-sdk/src/store/tree_map/mod.rs
+++ b/near-sdk/src/store/tree_map/mod.rs
@@ -30,6 +30,7 @@ fn expect<T>(val: Option<T>) -> T {
 /// - `min`/`max`:              O(log(N))
 /// - `above`/`below`:          O(log(N))
 /// - `range` of K elements:    O(Klog(N))
+#[derive(BorshDeserialize, BorshSerialize)]
 pub struct TreeMap<K, V, H = Sha256>
 where
     K: BorshSerialize + Ord,
@@ -62,35 +63,6 @@ where
             .field("root", &self.tree.root)
             .field("tree", &self.tree.nodes)
             .finish()
-    }
-}
-
-//? Manual implementations needed only because borsh derive is leaking field types
-// https://github.com/near/borsh-rs/issues/41
-impl<K, V, H> BorshSerialize for TreeMap<K, V, H>
-where
-    K: BorshSerialize + Ord,
-    V: BorshSerialize,
-    H: ToKey,
-{
-    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
-        BorshSerialize::serialize(&self.values, writer)?;
-        BorshSerialize::serialize(&self.tree, writer)?;
-        Ok(())
-    }
-}
-
-impl<K, V, H> BorshDeserialize for TreeMap<K, V, H>
-where
-    K: BorshSerialize + Ord,
-    V: BorshSerialize,
-    H: ToKey,
-{
-    fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, std::io::Error> {
-        Ok(Self {
-            values: BorshDeserialize::deserialize_reader(reader)?,
-            tree: BorshDeserialize::deserialize_reader(reader)?,
-        })
     }
 }
 

--- a/near-sdk/src/store/unordered_map/mod.rs
+++ b/near-sdk/src/store/unordered_map/mod.rs
@@ -90,6 +90,7 @@ use super::{FreeList, LookupMap, ERR_INCONSISTENT_STATE, ERR_NOT_EXIST};
     since = "5.0.0",
     note = "Suboptimal iteration performance. See performance considerations doc for details."
 )]
+#[derive(BorshDeserialize, BorshSerialize)]
 pub struct UnorderedMap<K, V, H = Sha256>
 where
     K: BorshSerialize + Ord,
@@ -104,35 +105,6 @@ where
 struct ValueAndIndex<V> {
     value: V,
     key_index: FreeListIndex,
-}
-
-//? Manual implementations needed only because borsh derive is leaking field types
-// https://github.com/near/borsh-rs/issues/41
-impl<K, V, H> BorshSerialize for UnorderedMap<K, V, H>
-where
-    K: BorshSerialize + Ord,
-    V: BorshSerialize,
-    H: ToKey,
-{
-    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
-        BorshSerialize::serialize(&self.keys, writer)?;
-        BorshSerialize::serialize(&self.values, writer)?;
-        Ok(())
-    }
-}
-
-impl<K, V, H> BorshDeserialize for UnorderedMap<K, V, H>
-where
-    K: BorshSerialize + Ord,
-    V: BorshSerialize,
-    H: ToKey,
-{
-    fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, std::io::Error> {
-        Ok(Self {
-            keys: BorshDeserialize::deserialize_reader(reader)?,
-            values: BorshDeserialize::deserialize_reader(reader)?,
-        })
-    }
 }
 
 impl<K, V, H> Drop for UnorderedMap<K, V, H>

--- a/near-sdk/src/store/unordered_set/mod.rs
+++ b/near-sdk/src/store/unordered_set/mod.rs
@@ -87,14 +87,14 @@ use std::fmt;
 ///
 /// [`with_hasher`]: Self::with_hasher
 /// [`LookupSet`]: crate::store::LookupSet
-#[derive(BorshDeserialize, BorshSerialize)]
 #[deprecated(
     since = "5.0.0",
     note = "Suboptimal iteration performance. See performance considerations doc for details."
 )]
+#[derive(BorshDeserialize, BorshSerialize)]
 pub struct UnorderedSet<T, H = Sha256>
 where
-    T: BorshSerialize + Ord,
+    T: BorshSerialize + BorshDeserialize + Ord,
     H: ToKey,
 {
     #[borsh(bound(serialize = "", deserialize = ""))]
@@ -105,7 +105,7 @@ where
 
 impl<T, H> Drop for UnorderedSet<T, H>
 where
-    T: BorshSerialize + Ord,
+    T: BorshSerialize + BorshDeserialize + Ord,
     H: ToKey,
 {
     fn drop(&mut self) {
@@ -128,7 +128,7 @@ where
 
 impl<T> UnorderedSet<T, Sha256>
 where
-    T: BorshSerialize + Ord,
+    T: BorshSerialize + BorshDeserialize + Ord,
 {
     /// Create a new iterable set. Use `prefix` as a unique prefix for keys.
     ///
@@ -153,7 +153,7 @@ where
 
 impl<T, H> UnorderedSet<T, H>
 where
-    T: BorshSerialize + Ord,
+    T: BorshSerialize + BorshDeserialize + Ord,
     H: ToKey,
 {
     /// Initialize a [`UnorderedSet`] with a custom hash function.

--- a/near-sdk/src/store/vec/mod.rs
+++ b/near-sdk/src/store/vec/mod.rs
@@ -112,7 +112,7 @@ fn expect_consistent_state<T>(val: Option<T>) -> T {
 /// vec.extend([1, 2, 3].iter().copied());
 /// assert!(Iterator::eq(vec.into_iter(), [7, 1, 2, 3].iter()));
 /// ```
-#[derive(NearSchema)]
+#[derive(NearSchema, BorshDeserialize, BorshSerialize)]
 #[inside_nearsdk]
 #[abi(borsh)]
 pub struct Vector<T>
@@ -121,31 +121,6 @@ where
 {
     pub(crate) len: u32,
     pub(crate) values: IndexMap<T>,
-}
-
-//? Manual implementations needed only because borsh derive is leaking field types
-// https://github.com/near/borsh-rs/issues/41
-impl<T> BorshSerialize for Vector<T>
-where
-    T: BorshSerialize,
-{
-    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
-        BorshSerialize::serialize(&self.len, writer)?;
-        BorshSerialize::serialize(&self.values, writer)?;
-        Ok(())
-    }
-}
-
-impl<T> BorshDeserialize for Vector<T>
-where
-    T: BorshSerialize,
-{
-    fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, std::io::Error> {
-        Ok(Self {
-            len: BorshDeserialize::deserialize_reader(reader)?,
-            values: BorshDeserialize::deserialize_reader(reader)?,
-        })
-    }
 }
 
 #[test]


### PR DESCRIPTION
Fixes #1169 

This needs investigation in terms of bounds to make sure we're not too restrictive, while satisfying the derive requirements. 