### PR TITLE
[Enhancement] Cover 'store' collections with tests.

### DIFF
--- a/near-sdk/src/store/index_map.rs
+++ b/near-sdk/src/store/index_map.rs
@@ -163,10 +163,15 @@ where
     }
 }
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "unstable"))]
+#[cfg(all(not(target_arch = "wasm32")))]
 #[cfg(test)]
 mod tests {
     use super::IndexMap;
+    use crate::test_utils::test_env::setup_free;
+    use arbitrary::{Arbitrary, Unstructured};
+    use rand::RngCore;
+    use rand::SeedableRng;
+    use std::collections::HashMap;
 
     #[test]
     fn basic_usage() {
@@ -186,5 +191,272 @@ mod tests {
 
         map.flush();
         assert_eq!(map.get(0), Some(&1));
+    }
+
+    #[derive(Arbitrary, Debug)]
+    enum Op {
+        Insert(u8, u8),
+        Remove(u8),
+        Flush,
+        Get(u8),
+    }
+
+    #[test]
+    fn arbitrary() {
+        setup_free();
+
+        let mut rng = rand_xorshift::XorShiftRng::seed_from_u64(0);
+        let mut buf = vec![0; 4096];
+        for _ in 0..512 {
+            // Clear storage in-between runs
+            crate::mock::with_mocked_blockchain(|b| b.take_storage());
+            rng.fill_bytes(&mut buf);
+
+            let mut im = IndexMap::new(b"l");
+            let mut hm = HashMap::new();
+            let u = Unstructured::new(&buf);
+            if let Ok(ops) = Vec::<Op>::arbitrary_take_rest(u) {
+                for op in ops {
+                    match op {
+                        Op::Insert(k, v) => {
+                            let r1 = im.insert(k as u32, v);
+                            let r2 = hm.insert(k, v);
+                            assert_eq!(r1, r2)
+                        }
+                        Op::Remove(k) => {
+                            let r1 = im.remove(k as u32);
+                            let r2 = hm.remove(&k);
+                            assert_eq!(r1, r2)
+                        }
+                        Op::Flush => {
+                            im.flush();
+                        }
+                        Op::Get(k) => {
+                            let r1 = im.get(k as u32);
+                            let r2 = hm.get(&k);
+                            assert_eq!(r1, r2)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Hashbrown-like tests.
+#[cfg(test)]
+mod test_map {
+    use crate::store::IndexMap;
+    use borsh::{BorshDeserialize, BorshSerialize};
+    use std::cell::RefCell;
+    use std::vec::Vec;
+
+    thread_local! { static DROP_VECTOR: RefCell<Vec<u32>> = const { RefCell::new(Vec::new()) }}
+
+    #[derive(Hash, PartialEq, Eq, BorshSerialize, BorshDeserialize, PartialOrd, Ord)]
+    struct Droppable {
+        k: usize,
+    }
+
+    impl Droppable {
+        fn new(k: usize) -> Droppable {
+            DROP_VECTOR.with(|slot| {
+                slot.borrow_mut()[k] += 1;
+            });
+
+            Droppable { k }
+        }
+    }
+
+    impl Drop for Droppable {
+        fn drop(&mut self) {
+            DROP_VECTOR.with(|slot| {
+                slot.borrow_mut()[self.k] -= 1;
+            });
+        }
+    }
+
+    impl Clone for Droppable {
+        fn clone(&self) -> Self {
+            Droppable::new(self.k)
+        }
+    }
+
+    #[test]
+    fn test_drops() {
+        DROP_VECTOR.with(|slot| {
+            *slot.borrow_mut() = vec![0; 100];
+        });
+
+        {
+            let mut m = IndexMap::new(b"b");
+
+            DROP_VECTOR.with(|v| {
+                for i in 0..100 {
+                    assert_eq!(v.borrow()[i], 0);
+                }
+            });
+
+            for i in 0..100usize {
+                let d1 = Droppable::new(i);
+                m.insert(i as u32, d1);
+            }
+
+            DROP_VECTOR.with(|v| {
+                for i in 0..100 {
+                    assert_eq!(v.borrow()[i], 1);
+                }
+            });
+
+            for i in 0..50 {
+                let v = m.remove(i as u32);
+
+                assert!(v.is_some());
+
+                DROP_VECTOR.with(|v| {
+                    assert_eq!(v.borrow()[i], 1);
+                });
+            }
+
+            DROP_VECTOR.with(|v| {
+                for i in 0..50 {
+                    assert_eq!(v.borrow()[i], 0);
+                }
+
+                for i in 50..100 {
+                    assert_eq!(v.borrow()[i], 1);
+                }
+            });
+        }
+
+        DROP_VECTOR.with(|v| {
+            for i in 0..100 {
+                assert_eq!(v.borrow()[i], 0);
+            }
+        });
+    }
+
+    #[test]
+    fn test_empty_remove() {
+        let mut m: IndexMap<bool> = IndexMap::new(b"b");
+        assert_eq!(m.remove(0), None);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // FIXME: takes too long
+    fn test_lots_of_insertions() {
+        let mut m = IndexMap::new(b"b");
+
+        // Try this a few times to make sure we never screw up the IndexMap's
+        // internal state.
+        for _ in 0..10 {
+            for i in 1..1001 {
+                assert!(m.insert(i, i).is_none());
+
+                for j in 1..=i {
+                    let r = m.get(j);
+                    assert_eq!(r, Some(&j));
+                }
+
+                for j in i + 1..1001 {
+                    let r = m.get(j);
+                    assert!(r.is_none());
+                }
+            }
+
+            for i in 1001..2001 {
+                assert!(m.get(i).is_none());
+            }
+
+            // remove forwards
+            for i in 1..1001 {
+                assert!(m.remove(i).is_some());
+
+                for j in 1..=i {
+                    assert!(m.get(j).is_none());
+                }
+
+                for j in i + 1..1001 {
+                    assert!(m.get(j).is_some());
+                }
+            }
+
+            for i in 1..1001 {
+                assert!(m.get(i).is_none());
+            }
+
+            for i in 1..1001 {
+                assert!(m.insert(i, i).is_none());
+            }
+
+            // remove backwards
+            for i in (1..1001).rev() {
+                assert!(m.remove(i).is_some());
+
+                for j in i..1001 {
+                    assert!(m.get(j).is_none());
+                }
+
+                for j in 1..i {
+                    assert!(m.get(j).is_some());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_find_mut() {
+        let mut m = IndexMap::new(b"b");
+        assert!(m.insert(1, 12).is_none());
+        assert!(m.insert(2, 8).is_none());
+        assert!(m.insert(5, 14).is_none());
+        let new = 100;
+        match m.get_mut(5) {
+            None => panic!(),
+            Some(x) => *x = new,
+        }
+        assert_eq!(m.get(5), Some(&new));
+    }
+
+    #[test]
+    fn test_insert_overwrite() {
+        let mut m = IndexMap::new(b"b");
+        assert!(m.insert(1, 2).is_none());
+        assert_eq!(*m.get(1).unwrap(), 2);
+        assert!(m.insert(1, 3).is_some());
+        assert_eq!(*m.get(1).unwrap(), 3);
+    }
+
+    #[test]
+    fn test_remove() {
+        let mut m = IndexMap::new(b"b");
+        m.insert(1, 2);
+        assert_eq!(m.remove(1), Some(2));
+        assert_eq!(m.remove(1), None);
+    }
+
+    #[test]
+    fn test_find() {
+        let mut m = IndexMap::new(b"b");
+        assert!(m.get(1).is_none());
+        m.insert(1, 2);
+        match m.get(1) {
+            None => panic!(),
+            Some(v) => assert_eq!(*v, 2),
+        }
+    }
+
+    #[test]
+    fn test_show() {
+        let mut map = IndexMap::new(b"b");
+        let empty: IndexMap<i32> = IndexMap::new(b"c");
+
+        map.insert(1, 2);
+        map.insert(3, 4);
+
+        let map_str = format!("{:?}", map);
+
+        assert_eq!(map_str, "IndexMap { prefix: [98] }");
+        assert_eq!(format!("{:?}", empty), "IndexMap { prefix: [99] }");
     }
 }

--- a/near-sdk/src/store/index_map.rs
+++ b/near-sdk/src/store/index_map.rs
@@ -163,7 +163,7 @@ where
     }
 }
 
-#[cfg(all(not(target_arch = "wasm32")))]
+#[cfg(not(target_arch = "wasm32"))]
 #[cfg(test)]
 mod tests {
     use super::IndexMap;

--- a/near-sdk/src/store/lookup_map/mod.rs
+++ b/near-sdk/src/store/lookup_map/mod.rs
@@ -726,3 +726,366 @@ mod tests {
         }
     }
 }
+
+// Hashbrown-like tests.
+#[cfg(test)]
+mod test_map {
+    use super::Entry::{Occupied, Vacant};
+    use crate::store::LookupMap;
+    use borsh::{BorshDeserialize, BorshSerialize};
+    use std::cell::RefCell;
+    use std::usize;
+    use std::vec::Vec;
+
+    #[test]
+    fn test_insert() {
+        let mut m = LookupMap::new(b"b");
+        assert!(m.insert(1, 2).is_none());
+        assert!(m.insert(2, 4).is_none());
+        assert_eq!(*m.get(&1).unwrap(), 2);
+        assert_eq!(*m.get(&2).unwrap(), 4);
+    }
+
+    thread_local! { static DROP_VECTOR: RefCell<Vec<i32>> = const { RefCell::new(Vec::new()) }}
+
+    #[derive(Hash, PartialEq, Eq, BorshSerialize, BorshDeserialize, PartialOrd, Ord)]
+    struct Droppable {
+        k: usize,
+    }
+
+    impl Droppable {
+        fn new(k: usize) -> Droppable {
+            DROP_VECTOR.with(|slot| {
+                slot.borrow_mut()[k] += 1;
+            });
+
+            Droppable { k }
+        }
+    }
+
+    impl Drop for Droppable {
+        fn drop(&mut self) {
+            DROP_VECTOR.with(|slot| {
+                slot.borrow_mut()[self.k] -= 1;
+            });
+        }
+    }
+
+    impl Clone for Droppable {
+        fn clone(&self) -> Self {
+            Droppable::new(self.k)
+        }
+    }
+
+    #[test]
+    fn test_drops() {
+        DROP_VECTOR.with(|slot| {
+            *slot.borrow_mut() = vec![0; 200];
+        });
+
+        {
+            let mut m = LookupMap::new(b"b");
+
+            DROP_VECTOR.with(|v| {
+                for i in 0..200 {
+                    assert_eq!(v.borrow()[i], 0);
+                }
+            });
+
+            for i in 0..100 {
+                let d1 = Droppable::new(i);
+                let d2 = Droppable::new(i + 100);
+                m.insert(d1, d2);
+            }
+
+            DROP_VECTOR.with(|v| {
+                for i in 0..100 {
+                    assert_eq!(v.borrow()[i], 1);
+                }
+            });
+
+            for i in 0..50 {
+                let k = Droppable::new(i);
+                let v = m.remove(&k);
+
+                assert!(v.is_some());
+
+                DROP_VECTOR.with(|v| {
+                    assert_eq!(v.borrow()[i], 2);
+                    assert_eq!(v.borrow()[i + 100], 1);
+                });
+            }
+
+            DROP_VECTOR.with(|v| {
+                for i in 0..50 {
+                    assert_eq!(v.borrow()[i], 1);
+                    assert_eq!(v.borrow()[i + 100], 0);
+                }
+
+                for i in 50..100 {
+                    assert_eq!(v.borrow()[i], 1);
+                    assert_eq!(v.borrow()[i + 100], 1);
+                }
+            });
+        }
+
+        DROP_VECTOR.with(|v| {
+            for i in 0..200 {
+                assert_eq!(v.borrow()[i], 0);
+            }
+        });
+    }
+
+    #[test]
+    fn test_empty_remove() {
+        let mut m: LookupMap<i32, bool> = LookupMap::new(b"b");
+        assert_eq!(m.remove(&0), None);
+    }
+
+    #[test]
+    fn test_empty_entry() {
+        let mut m: LookupMap<i32, bool> = LookupMap::new(b"b");
+        match m.entry(0) {
+            Occupied(_) => panic!(),
+            Vacant(_) => {}
+        }
+        assert!(*m.entry(0).or_insert(true));
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // FIXME: takes too long
+    fn test_lots_of_insertions() {
+        let mut m = LookupMap::new(b"b");
+
+        // Try this a few times to make sure we never screw up the LookupMap's
+        // internal state.
+        for _ in 0..10 {
+            for i in 1..1001 {
+                assert!(m.insert(i, i).is_none());
+
+                for j in 1..=i {
+                    let r = m.get(&j);
+                    assert_eq!(r, Some(&j));
+                }
+
+                for j in i + 1..1001 {
+                    let r = m.get(&j);
+                    assert_eq!(r, None);
+                }
+            }
+
+            for i in 1001..2001 {
+                assert!(!m.contains_key(&i));
+            }
+
+            // remove forwards
+            for i in 1..1001 {
+                assert!(m.remove(&i).is_some());
+
+                for j in 1..=i {
+                    assert!(!m.contains_key(&j));
+                }
+
+                for j in i + 1..1001 {
+                    assert!(m.contains_key(&j));
+                }
+            }
+
+            for i in 1..1001 {
+                assert!(!m.contains_key(&i));
+            }
+
+            for i in 1..1001 {
+                assert!(m.insert(i, i).is_none());
+            }
+
+            // remove backwards
+            for i in (1..1001).rev() {
+                assert!(m.remove(&i).is_some());
+
+                for j in i..1001 {
+                    assert!(!m.contains_key(&j));
+                }
+
+                for j in 1..i {
+                    assert!(m.contains_key(&j));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_find_mut() {
+        let mut m = LookupMap::new(b"b");
+        assert!(m.insert(1, 12).is_none());
+        assert!(m.insert(2, 8).is_none());
+        assert!(m.insert(5, 14).is_none());
+        let new = 100;
+        match m.get_mut(&5) {
+            None => panic!(),
+            Some(x) => *x = new,
+        }
+        assert_eq!(m.get(&5), Some(&new));
+    }
+
+    #[test]
+    fn test_insert_overwrite() {
+        let mut m = LookupMap::new(b"b");
+        assert!(m.insert(1, 2).is_none());
+        assert_eq!(*m.get(&1).unwrap(), 2);
+        assert!(m.insert(1, 3).is_some());
+        assert_eq!(*m.get(&1).unwrap(), 3);
+    }
+
+    #[test]
+    fn test_remove() {
+        let mut m = LookupMap::new(b"b");
+        m.insert(1, 2);
+        assert_eq!(m.remove(&1), Some(2));
+        assert_eq!(m.remove(&1), None);
+    }
+
+    #[test]
+    fn test_find() {
+        let mut m = LookupMap::new(b"b");
+        assert!(m.get(&1).is_none());
+        m.insert(1, 2);
+        match m.get(&1) {
+            None => panic!(),
+            Some(v) => assert_eq!(*v, 2),
+        }
+    }
+
+    #[test]
+    fn test_show() {
+        let mut map = LookupMap::new(b"b");
+        let empty: LookupMap<i32, i32> = LookupMap::new(b"c");
+
+        map.insert(1, 2);
+        map.insert(3, 4);
+
+        let map_str = format!("{:?}", map);
+
+        assert_eq!(map_str, "LookupMap { prefix: [98] }");
+        assert_eq!(format!("{:?}", empty), "LookupMap { prefix: [99] }");
+    }
+
+    #[test]
+    fn test_index() {
+        let mut map = LookupMap::new(b"b");
+
+        map.insert(1, 2);
+        map.insert(2, 1);
+        map.insert(3, 4);
+
+        assert_eq!(map[&2], 1);
+    }
+
+    #[test]
+    #[should_panic]
+    #[allow(clippy::unnecessary_operation)]
+    fn test_index_nonexistent() {
+        let mut map = LookupMap::new(b"b");
+
+        map.insert(1, 2);
+        map.insert(2, 1);
+        map.insert(3, 4);
+
+        #[allow(clippy::no_effect)] // false positive lint
+        map[&4];
+    }
+
+    #[test]
+    fn test_entry() {
+        let mut map = LookupMap::new(b"b");
+
+        let xs = [(1, 10), (2, 20), (3, 30), (4, 40), (5, 50), (6, 60)];
+
+        for v in xs {
+            map.insert(v.0, v.1);
+        }
+
+        // Existing key (insert)
+        match map.entry(1) {
+            Vacant(_) => unreachable!(),
+            Occupied(mut view) => {
+                assert_eq!(view.get(), &10);
+                assert_eq!(view.insert(100), 10);
+            }
+        }
+        assert_eq!(map.get(&1).unwrap(), &100);
+
+        // Existing key (update)
+        match map.entry(2) {
+            Vacant(_) => unreachable!(),
+            Occupied(mut view) => {
+                let v = view.get_mut();
+                let new_v = (*v) * 10;
+                *v = new_v;
+            }
+        }
+        assert_eq!(map.get(&2).unwrap(), &200);
+
+        // Existing key (take)
+        match map.entry(3) {
+            Vacant(_) => unreachable!(),
+            Occupied(view) => {
+                assert_eq!(view.remove(), 30);
+            }
+        }
+        assert_eq!(map.get(&3), None);
+
+        // Inexistent key (insert)
+        match map.entry(10) {
+            Occupied(_) => unreachable!(),
+            Vacant(view) => {
+                assert_eq!(*view.insert(1000), 1000);
+            }
+        }
+        assert_eq!(map.get(&10).unwrap(), &1000);
+    }
+
+    #[test]
+    fn test_extend_ref_kv_tuple() {
+        let mut a = LookupMap::new(b"b");
+        a.insert(0, 0);
+
+        let for_iter: Vec<(i32, i32)> = (0..100).map(|i| (i, i)).collect();
+        a.extend(for_iter);
+
+        for item in 0..100 {
+            assert_eq!(a[&item], item);
+        }
+    }
+
+    #[test]
+    fn test_occupied_entry_key() {
+        let mut a = LookupMap::new(b"b");
+        let key = "hello there";
+        let value = "value goes here";
+        a.insert(key.to_string(), value.to_string());
+        assert_eq!(a[key], value);
+
+        match a.entry(key.to_string()) {
+            Vacant(_) => panic!(),
+            Occupied(e) => assert_eq!(key, *e.key()),
+        }
+        assert_eq!(a[key], value);
+    }
+
+    #[test]
+    fn test_vacant_entry_key() {
+        let mut a = LookupMap::new(b"b");
+        let key = "hello there";
+        let value = "value goes here".to_string();
+
+        match a.entry(key.to_string()) {
+            Occupied(_) => panic!(),
+            Vacant(e) => {
+                assert_eq!(key, *e.key());
+                e.insert(value.clone());
+            }
+        }
+        assert_eq!(a[key], value);
+    }
+}

--- a/near-sdk/src/store/vec/mod.rs
+++ b/near-sdk/src/store/vec/mod.rs
@@ -792,7 +792,7 @@ mod tests {
         let mut x: u32 = 0;
         assert_eq!(v[x], 10);
         assert_eq!(v[x + 1], 20);
-        x = x + 1;
+        x += 1;
         assert_eq!(v[x], 20);
         assert_eq!(v[x - 1], 10);
     }

--- a/near-sdk/src/store/vec/mod.rs
+++ b/near-sdk/src/store/vec/mod.rs
@@ -782,6 +782,21 @@ mod tests {
         crate::mock::with_mocked_blockchain(|m| assert!(m.take_storage().is_empty()));
     }
 
+    #[test]
+    fn test_indexing() {
+        let mut v: Vector<i32> = Vector::new(b"b");
+        v.push(10);
+        v.push(20);
+        assert_eq!(v[0], 10);
+        assert_eq!(v[1], 20);
+        let mut x: u32 = 0;
+        assert_eq!(v[x], 10);
+        assert_eq!(v[x + 1], 20);
+        x = x + 1;
+        assert_eq!(v[x], 20);
+        assert_eq!(v[x - 1], 10);
+    }
+
     #[derive(Arbitrary, Debug)]
     enum Op {
         Push(u8),

--- a/near-sdk/src/utils/stable_map.rs
+++ b/near-sdk/src/utils/stable_map.rs
@@ -53,3 +53,52 @@ impl<K, V> StableMap<K, V> {
         self.map.borrow().get(k).map(|s| f(s))
     }
 }
+#[cfg(test)]
+mod test {
+    use crate::utils::StableMap;
+
+    #[test]
+    fn get() {
+        let mut map: StableMap<i32, i32> = StableMap::default();
+
+        // Vacant entry is being initialized with a default.
+        assert_eq!(map.inner().len(), 0);
+        assert_eq!(map.get(1), &0);
+        assert_eq!(map.inner().len(), 1);
+
+        // Mutated value persisted.
+        *map.get_mut(1) += 1;
+        assert_eq!(map.get(1), &1);
+    }
+
+    #[test]
+    fn get_mut() {
+        let mut map: StableMap<i32, i32> = StableMap::default();
+
+        // Vacant entry is being initialized with a default.
+        assert_eq!(map.inner().len(), 0);
+        assert_eq!(map.get_mut(1), &0);
+        assert_eq!(map.inner().len(), 1);
+
+        // Mutated value persisted.
+        *map.get_mut(1) += 1;
+        assert_eq!(map.get_mut(1), &1);
+
+        // Vacant entry persisted as modified.
+        assert_eq!(map.inner().len(), 1);
+        *map.get_mut(2) += 1;
+        assert_eq!(map.get_mut(2), &1);
+        assert_eq!(map.inner().len(), 2);
+    }
+
+    #[test]
+    fn map_value_ref() {
+        // Returns none if the value does not exist.
+        let mut map: StableMap<i32, i32> = StableMap::default();
+        assert!(map.map_value_ref(&1, |v| v.is_negative()).is_none());
+
+        // Successfully executes a callback if the value is found.
+        *map.get_mut(1) -= 1;
+        assert!(map.map_value_ref(&1, |v| v.is_negative()).unwrap());
+    }
+}


### PR DESCRIPTION
Make sure the new `store::IterableMap` that has been recently introduced is secure and bug-free by covering the collections it relies upon with tests. 