### PR TITLE
ci: fix new lints, introduced in 1.78

### DIFF
--- a/examples/fungible-token/test-contract-defi/src/lib.rs
+++ b/examples/fungible-token/test-contract-defi/src/lib.rs
@@ -16,6 +16,7 @@ pub struct DeFi {
 }
 
 // Have to repeat the same trait for our own implementation.
+#[allow(dead_code)]
 trait ValueReturnTrait {
     fn value_please(&self, amount_to_return: String) -> PromiseOrValue<U128>;
 }

--- a/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
@@ -165,7 +165,7 @@ impl AttrSigInfo {
 
         self_occurrences.extend(args.iter().flat_map(|arg| arg.self_occurrences.clone()));
 
-        *original_attrs = non_bindgen_attrs.clone();
+        original_attrs.clone_from(&non_bindgen_attrs);
 
         if matches!(method_kind, MethodKind::Call(_) | MethodKind::View(_)) {
             report_spans(

--- a/near-sdk/compilation_tests/schema_derive_invalids.stderr
+++ b/near-sdk/compilation_tests/schema_derive_invalids.stderr
@@ -87,7 +87,7 @@ error[E0277]: the trait bound `Inner: JsonSchema` is not satisfied
             i128
           and $N others
 note: required by a bound in `SchemaGenerator::subschema_for`
- --> $CARGO/schemars-0.8.17/src/gen.rs
+ --> $CARGO/schemars-0.8.19/src/gen.rs
   |
   |     pub fn subschema_for<T: ?Sized + JsonSchema>(&mut self) -> Schema {
   |                                      ^^^^^^^^^^ required by this bound in `SchemaGenerator::subschema_for`

--- a/near-sdk/compilation_tests/schema_derive_invalids.stderr
+++ b/near-sdk/compilation_tests/schema_derive_invalids.stderr
@@ -87,7 +87,7 @@ error[E0277]: the trait bound `Inner: JsonSchema` is not satisfied
             i128
           and $N others
 note: required by a bound in `SchemaGenerator::subschema_for`
- --> $CARGO/schemars-0.8.19/src/gen.rs
+ --> $CARGO/schemars-0.8.20/src/gen.rs
   |
   |     pub fn subschema_for<T: ?Sized + JsonSchema>(&mut self) -> Schema {
   |                                      ^^^^^^^^^^ required by this bound in `SchemaGenerator::subschema_for`

--- a/near-sdk/src/lib.rs
+++ b/near-sdk/src/lib.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::redundant_closure)]
 // We want to enable all clippy lints, but some of them generate false positives.
 #![allow(clippy::missing_const_for_fn, clippy::redundant_pub_crate)]
+#![allow(clippy::multiple_bound_locations)]
 
 #[cfg(test)]
 extern crate quickcheck;


### PR DESCRIPTION
this new lint was silenced , it introduces 30+ locations to fix:  https://rust-lang.github.io/rust-clippy/master/index.html#/multiple_bound_locations ; it has no automatic fix yet with `cargo clippy --fix`