### PR TITLE
add yield execution host functions

### DIFF
--- a/near-sys/src/lib.rs
+++ b/near-sys/src/lib.rs
@@ -146,6 +146,21 @@ extern "C" {
         beneficiary_id_len: u64,
         beneficiary_id_ptr: u64,
     );
+    pub fn promise_yield_create(
+        function_name_len: u64,
+        function_name_ptr: u64,
+        arguments_len: u64,
+        arguments_ptr: u64,
+        gas: u64,
+        gas_weight: u64,
+        register_id: u64,
+    ) -> u64;
+    pub fn promise_yield_resume(
+        data_id_len: u64,
+        data_id_ptr: u64,
+        payload_len: u64,
+        payload_ptr: u64,
+    ) -> u32;
     // #######################
     // # Promise API results #
     // #######################


### PR DESCRIPTION
Yield Execution will be stabilized in nearcore in the 1.40 release.

This PR adds imports for the `promise_yield_create` and `promise_yield_resume` host functions. They have been tested using the smart contract example in #1133.

In the future we can also merge a cleaned-up version of the example contract.

Not sure what's going on with the failing tests; it seems like master is red too if I run them locally?