### PR TITLE
fix(macro): use FQDNs when calling contract methods

### DIFF
--- a/near-sdk-macros/src/core_impl/abi/abi_generator.rs
+++ b/near-sdk-macros/src/core_impl/abi/abi_generator.rs
@@ -324,7 +324,7 @@ mod tests {
             #[handle_result]
             pub fn f3(&mut self, arg0: FancyStruct, arg1: u64) -> Result<IsOk, Error> { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.abi_struct();
 
         local_insta_assert_snapshot!(pretty_print_fn_body_syn_str(actual));
@@ -339,7 +339,7 @@ mod tests {
             #[handle_result]
             pub fn f3(&mut self, #[serializer(borsh)] arg0: FancyStruct) -> Result<IsOk, Error> { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.abi_struct();
 
         local_insta_assert_snapshot!(pretty_print_fn_body_syn_str(actual));
@@ -355,7 +355,7 @@ mod tests {
                 #[callback_vec] x: Vec<String>, 
             ) -> bool { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.abi_struct();
        
         local_insta_assert_snapshot!(pretty_print_fn_body_syn_str(actual));
@@ -367,7 +367,7 @@ mod tests {
         let mut method = parse_quote! {
             pub fn method(&self, #[callback_unwrap] #[serializer(borsh)] x: &mut u64, #[serializer(borsh)] y: String, #[callback_unwrap] #[serializer(json)] z: Vec<u8>) { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.abi_struct();
 
         local_insta_assert_snapshot!(pretty_print_fn_body_syn_str(actual));
@@ -380,7 +380,7 @@ mod tests {
             #[init(ignore_state)]
             pub fn new() -> u64 { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.abi_struct();
 
         local_insta_assert_snapshot!(pretty_print_fn_body_syn_str(actual));
@@ -392,7 +392,7 @@ mod tests {
         let mut method = parse_quote! {
             pub fn method() { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.abi_struct();
 
         local_insta_assert_snapshot!(pretty_print_fn_body_syn_str(actual));

--- a/near-sdk-macros/src/core_impl/code_generator/ext.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/ext.rs
@@ -177,7 +177,7 @@ mod tests {
             #[warn(unused)]
             pub fn method(&self) { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = generate_ext_function(&method_info.attr_signature_info);
 
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
@@ -189,7 +189,7 @@ mod tests {
         let mut method: ImplItemFn = parse_quote! {
             pub fn method(&self, k: &String) { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = generate_ext_function(&method_info.attr_signature_info);
      
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
@@ -201,7 +201,7 @@ mod tests {
         let mut method: syn::ImplItemFn = parse_quote! {
           pub fn borsh_test(&mut self, #[serializer(borsh)] a: String) {}
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = generate_ext_function(&method_info.attr_signature_info);
        
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());

--- a/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
@@ -28,7 +28,7 @@ impl ItemImplInfo {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use syn::{Type, ImplItemFn, parse_quote};
+    use syn::{parse_quote, parse_str, ImplItemFn, Type};
     use crate::core_impl::info_extractor::ImplItemMethodInfo;
     use crate::core_impl::utils::test_helpers::{local_insta_assert_snapshot, pretty_print_syn_str};
 
@@ -37,7 +37,7 @@ mod tests {
     fn trait_implt() {
         let impl_type: Type = syn::parse_str("Hello").unwrap();
         let mut method: ImplItemFn = syn::parse_str("fn method(&self) { }").unwrap();
-        let method_info = ImplItemMethodInfo::new(&mut method, true, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, Some(parse_str("SomeTrait").unwrap()), impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -46,7 +46,7 @@ mod tests {
     fn no_args_no_return_no_mut() {
         let impl_type: Type = syn::parse_str("Hello").unwrap();
         let mut method: ImplItemFn = syn::parse_str("pub fn method(&self) { }").unwrap();
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -55,7 +55,7 @@ mod tests {
     fn owned_no_args_no_return_no_mut() {
         let impl_type: Type = syn::parse_str("Hello").unwrap();
         let mut method: ImplItemFn = syn::parse_str("pub fn method(self) { }").unwrap();
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -65,7 +65,7 @@ mod tests {
     fn mut_owned_no_args_no_return() {
         let impl_type: Type = syn::parse_str("Hello").unwrap();
         let mut method: ImplItemFn = syn::parse_str("pub fn method(mut self) { }").unwrap();
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -74,7 +74,7 @@ mod tests {
     fn no_args_no_return_mut() {
         let impl_type: Type = syn::parse_str("Hello").unwrap();
         let mut method: ImplItemFn = syn::parse_str("pub fn method(&mut self) { }").unwrap();
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -83,7 +83,7 @@ mod tests {
     fn arg_no_return_no_mut() {
         let impl_type: Type = syn::parse_str("Hello").unwrap();
         let mut method: ImplItemFn = syn::parse_str("pub fn method(&self, k: u64) { }").unwrap();
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -93,7 +93,7 @@ mod tests {
         let impl_type: Type = syn::parse_str("Hello").unwrap();
         let mut method: ImplItemFn =
             syn::parse_str("pub fn method(&mut self, k: u64, m: Bar) { }").unwrap();
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -103,7 +103,7 @@ mod tests {
         let impl_type: Type = syn::parse_str("Hello").unwrap();
         let mut method: ImplItemFn =
             syn::parse_str("pub fn method(&mut self, k: u64, m: Bar) -> Option<u64> { }").unwrap();
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -113,7 +113,7 @@ mod tests {
         let impl_type: Type = syn::parse_str("Hello").unwrap();
         let mut method: ImplItemFn =
             syn::parse_str("pub fn method(&self) -> &Option<u64> { }").unwrap();
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -122,7 +122,7 @@ mod tests {
     fn arg_ref() {
         let impl_type: Type = syn::parse_str("Hello").unwrap();
         let mut method: ImplItemFn = syn::parse_str("pub fn method(&self, k: &u64) { }").unwrap();
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -132,7 +132,7 @@ mod tests {
         let impl_type: Type = syn::parse_str("Hello").unwrap();
         let mut method: ImplItemFn =
             syn::parse_str("pub fn method(&self, k: &mut u64) { }").unwrap();
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -143,7 +143,7 @@ mod tests {
         let mut method: ImplItemFn = parse_quote! {
             #[private] pub fn method(&self, #[callback_unwrap] x: &mut u64, y: ::std::string::String, #[callback_unwrap] z: ::std::vec::Vec<u8>) { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -154,7 +154,7 @@ mod tests {
         let mut method: ImplItemFn = parse_quote! {
             #[private] pub fn method(&self, #[callback_unwrap] x: &mut u64, #[callback_unwrap] y: ::std::string::String) { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -165,7 +165,7 @@ mod tests {
         let mut method: ImplItemFn = parse_quote! {
             #[private] pub fn method(&self, #[callback_result] x: &mut Result<u64, PromiseError>, #[callback_result] y: Result<::std::string::String, PromiseError>) { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -176,7 +176,7 @@ mod tests {
         let mut method: ImplItemFn = parse_quote! {
             #[private] pub fn method(&self, #[callback_vec] x: Vec<String>, y: String) { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -188,7 +188,7 @@ mod tests {
             #[init]
             pub fn method(k: &mut u64) -> Self { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -200,7 +200,7 @@ mod tests {
             #[init]
             pub fn method(k: &mut u64) { }
         };
-        let actual = ImplItemMethodInfo::new(&mut method, false, impl_type).map(|_| ()).unwrap_err();
+        let actual = ImplItemMethodInfo::new(&mut method, None, impl_type).map(|_| ()).unwrap_err();
         let expected = "Init function must return the contract state.";
         assert_eq!(expected, actual.to_string());
     }
@@ -212,7 +212,7 @@ mod tests {
             #[init(ignore_state)]
             pub fn method(k: &mut u64) -> Self { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -225,7 +225,7 @@ mod tests {
             #[payable]
             pub fn method(k: &mut u64) -> Self { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -237,7 +237,7 @@ mod tests {
             #[result_serializer(borsh)]
             pub fn method(&mut self, #[serializer(borsh)] k: u64, #[serializer(borsh)]m: Bar) -> Option<u64> { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -248,7 +248,7 @@ mod tests {
         let mut method: ImplItemFn = parse_quote! {
             #[private] pub fn method(&self, #[callback_unwrap] #[serializer(borsh)] x: &mut u64, #[serializer(borsh)] y: ::std::string::String, #[callback_unwrap] #[serializer(json)] z: ::std::vec::Vec<u8>) { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -257,7 +257,7 @@ mod tests {
     fn no_args_no_return_mut_payable() {
         let impl_type: Type = syn::parse_str("Hello").unwrap();
         let mut method: ImplItemFn = syn::parse_str("#[payable] pub fn method(&mut self) { }").unwrap();
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -266,7 +266,7 @@ mod tests {
     fn private_method() {
         let impl_type: Type = syn::parse_str("Hello").unwrap();
         let mut method: ImplItemFn = syn::parse_str("#[private] pub fn private_method(&mut self) { }").unwrap();
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -278,7 +278,7 @@ mod tests {
             #[handle_result]
             pub fn method(&self) -> Result::<u64, &'static str> { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -290,7 +290,7 @@ mod tests {
             #[handle_result]
             pub fn method(&mut self) -> Result<u64, &'static str> { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -303,7 +303,7 @@ mod tests {
             #[result_serializer(borsh)]
             pub fn method(&self) -> Result<u64, &'static str> { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -316,7 +316,7 @@ mod tests {
             #[handle_result]
             pub fn new() -> Result<Self, &'static str> { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -329,7 +329,7 @@ mod tests {
             #[handle_result]
             pub fn new() -> Result<Self, &'static str> { }
         };
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -338,7 +338,7 @@ mod tests {
     fn handle_no_self() {
         let impl_type: Type = syn::parse_str("Hello").unwrap();
         let mut method: ImplItemFn = syn::parse_str("pub fn method() { }").unwrap();
-        let method_info = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/arg_mut_ref.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/arg_mut_ref.snap
@@ -17,6 +17,6 @@ pub extern "C" fn method() {
         )
         .expect("Failed to deserialize input from JSON.");
     let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
-    contract.method(&mut k);
+    Hello::method(&contract, &mut k);
 }
 

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/arg_no_return_no_mut.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/arg_no_return_no_mut.snap
@@ -17,6 +17,6 @@ pub extern "C" fn method() {
         )
         .expect("Failed to deserialize input from JSON.");
     let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
-    contract.method(k);
+    Hello::method(&contract, k);
 }
 

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/arg_ref.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/arg_ref.snap
@@ -17,6 +17,6 @@ pub extern "C" fn method() {
         )
         .expect("Failed to deserialize input from JSON.");
     let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
-    contract.method(&k);
+    Hello::method(&contract, &k);
 }
 

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/args_no_return_mut.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/args_no_return_mut.snap
@@ -21,7 +21,7 @@ pub extern "C" fn method() {
         )
         .expect("Failed to deserialize input from JSON.");
     let mut contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
-    contract.method(k, m);
+    Hello::method(&mut contract, k, m);
     ::near_sdk::env::state_write(&contract);
 }
 

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/args_return_mut.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/args_return_mut.snap
@@ -21,7 +21,7 @@ pub extern "C" fn method() {
         )
         .expect("Failed to deserialize input from JSON.");
     let mut contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
-    let result = contract.method(k, m);
+    let result = Hello::method(&mut contract, k, m);
     let result = ::near_sdk::serde_json::to_vec(&result)
         .expect("Failed to serialize the return value using JSON.");
     ::near_sdk::env::value_return(&result);

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/args_return_mut_borsh.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/args_return_mut_borsh.snap
@@ -21,7 +21,7 @@ pub extern "C" fn method() {
         )
         .expect("Failed to deserialize input from Borsh.");
     let mut contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
-    let result = contract.method(k, m);
+    let result = Hello::method(&mut contract, k, m);
     let result = ::near_sdk::borsh::to_vec(&result)
         .expect("Failed to serialize the return value using Borsh.");
     ::near_sdk::env::value_return(&result);

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/args_return_ref.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/args_return_ref.snap
@@ -7,7 +7,7 @@ expression: pretty_print_syn_str(&actual).unwrap()
 pub extern "C" fn method() {
     ::near_sdk::env::setup_panic_hook();
     let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
-    let result = contract.method();
+    let result = Hello::method(&contract);
     let result = ::near_sdk::serde_json::to_vec(&result)
         .expect("Failed to serialize the return value using JSON.");
     ::near_sdk::env::value_return(&result);

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/callback_args.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/callback_args.snap
@@ -33,6 +33,6 @@ pub extern "C" fn method() {
     let z: ::std::vec::Vec<u8> = ::near_sdk::serde_json::from_slice(&data)
         .expect("Failed to deserialize callback using JSON");
     let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
-    contract.method(&mut x, y, z);
+    Hello::method(&contract, &mut x, y, z);
 }
 

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/callback_args_mixed_serialization.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/callback_args_mixed_serialization.snap
@@ -33,6 +33,6 @@ pub extern "C" fn method() {
     let z: ::std::vec::Vec<u8> = ::near_sdk::serde_json::from_slice(&data)
         .expect("Failed to deserialize callback using JSON");
     let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
-    contract.method(&mut x, y, z);
+    Hello::method(&contract, &mut x, y, z);
 }
 

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/callback_args_only.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/callback_args_only.snap
@@ -23,6 +23,6 @@ pub extern "C" fn method() {
     let y: ::std::string::String = ::near_sdk::serde_json::from_slice(&data)
         .expect("Failed to deserialize callback using JSON");
     let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
-    contract.method(&mut x, y);
+    Hello::method(&contract, &mut x, y);
 }
 

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/callback_args_results.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/callback_args_results.snap
@@ -35,6 +35,6 @@ pub extern "C" fn method() {
         }
     };
     let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
-    contract.method(&mut x, y);
+    Hello::method(&contract, &mut x, y);
 }
 

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/callback_args_vec.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/callback_args_vec.snap
@@ -42,6 +42,6 @@ pub extern "C" fn method() {
         ),
     );
     let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
-    contract.method(x, y);
+    Hello::method(&contract, x, y);
 }
 

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/handle_result_borsh.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/handle_result_borsh.snap
@@ -7,7 +7,7 @@ expression: pretty_print_syn_str(&actual).unwrap()
 pub extern "C" fn method() {
     ::near_sdk::env::setup_panic_hook();
     let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
-    let result = contract.method();
+    let result = Hello::method(&contract);
     match result {
         ::std::result::Result::Ok(result) => {
             let result = ::near_sdk::borsh::to_vec(&result)

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/handle_result_json.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/handle_result_json.snap
@@ -7,7 +7,7 @@ expression: pretty_print_syn_str(&actual).unwrap()
 pub extern "C" fn method() {
     ::near_sdk::env::setup_panic_hook();
     let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
-    let result = contract.method();
+    let result = Hello::method(&contract);
     match result {
         ::std::result::Result::Ok(result) => {
             let result = ::near_sdk::serde_json::to_vec(&result)

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/handle_result_mut.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/handle_result_mut.snap
@@ -10,7 +10,7 @@ pub extern "C" fn method() {
         ::near_sdk::env::panic_str("Method method doesn't accept deposit");
     }
     let mut contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
-    let result = contract.method();
+    let result = Hello::method(&mut contract);
     match result {
         ::std::result::Result::Ok(result) => {
             let result = ::near_sdk::serde_json::to_vec(&result)

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/mut_owned_no_args_no_return.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/mut_owned_no_args_no_return.snap
@@ -7,6 +7,6 @@ expression: pretty_print_syn_str(&actual).unwrap()
 pub extern "C" fn method() {
     ::near_sdk::env::setup_panic_hook();
     let mut contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
-    contract.method();
+    Hello::method(contract);
 }
 

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/no_args_no_return_mut.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/no_args_no_return_mut.snap
@@ -10,7 +10,7 @@ pub extern "C" fn method() {
         ::near_sdk::env::panic_str("Method method doesn't accept deposit");
     }
     let mut contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
-    contract.method();
+    Hello::method(&mut contract);
     ::near_sdk::env::state_write(&contract);
 }
 

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/no_args_no_return_mut_payable.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/no_args_no_return_mut_payable.snap
@@ -7,7 +7,7 @@ expression: pretty_print_syn_str(&actual).unwrap()
 pub extern "C" fn method() {
     ::near_sdk::env::setup_panic_hook();
     let mut contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
-    contract.method();
+    Hello::method(&mut contract);
     ::near_sdk::env::state_write(&contract);
 }
 

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/no_args_no_return_no_mut.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/no_args_no_return_no_mut.snap
@@ -7,6 +7,6 @@ expression: pretty_print_syn_str(&actual).unwrap()
 pub extern "C" fn method() {
     ::near_sdk::env::setup_panic_hook();
     let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
-    contract.method();
+    Hello::method(&contract);
 }
 

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/owned_no_args_no_return_no_mut.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/owned_no_args_no_return_no_mut.snap
@@ -7,6 +7,6 @@ expression: pretty_print_syn_str(&actual).unwrap()
 pub extern "C" fn method() {
     ::near_sdk::env::setup_panic_hook();
     let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
-    contract.method();
+    Hello::method(contract);
 }
 

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/private_method.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/private_method.snap
@@ -14,7 +14,7 @@ pub extern "C" fn private_method() {
         ::near_sdk::env::panic_str("Method private_method doesn't accept deposit");
     }
     let mut contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
-    contract.private_method();
+    Hello::private_method(&mut contract);
     ::near_sdk::env::state_write(&contract);
 }
 

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/trait_implt.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/trait_implt.snap
@@ -7,6 +7,6 @@ expression: pretty_print_syn_str(&actual).unwrap()
 pub extern "C" fn method() {
     ::near_sdk::env::setup_panic_hook();
     let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();
-    contract.method();
+    <Hello as SomeTrait>::method(&contract);
 }
 

--- a/near-sdk-macros/src/core_impl/info_extractor/impl_item_method_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/impl_item_method_info.rs
@@ -1,7 +1,7 @@
 use crate::core_impl::info_extractor::AttrSigInfo;
 use crate::core_impl::utils;
 use quote::ToTokens;
-use syn::{ImplItemFn as ImplItemMethod, Type, Visibility};
+use syn::{ImplItemFn as ImplItemMethod, Path, Type, Visibility};
 
 /// Information extracted from `ImplItemMethod`.
 pub struct ImplItemMethodInfo {
@@ -9,21 +9,23 @@ pub struct ImplItemMethodInfo {
     pub attr_signature_info: AttrSigInfo,
     /// The type of the contract struct.
     pub struct_type: Type,
+    /// The trait that this method is implemented for.
+    pub impl_trait: Option<Path>,
 }
 
 impl ImplItemMethodInfo {
     /// Process the method and extract information important for near-sdk.
     pub fn new(
         original: &mut ImplItemMethod,
-        is_trait_impl: bool,
+        impl_trait: Option<Path>,
         struct_type: Type,
     ) -> syn::Result<Option<Self>> {
         let ImplItemMethod { attrs, sig, .. } = original;
         utils::sig_is_supported(sig)?;
-        if is_trait_impl || matches!(original.vis, Visibility::Public(_)) {
+        if impl_trait.is_some() || matches!(original.vis, Visibility::Public(_)) {
             let source_type = &struct_type.to_token_stream();
             let attr_signature_info = AttrSigInfo::new(attrs, sig, source_type)?;
-            Ok(Some(Self { attr_signature_info, struct_type }))
+            Ok(Some(Self { attr_signature_info, struct_type, impl_trait }))
         } else {
             Ok(None)
         }
@@ -35,7 +37,7 @@ impl ImplItemMethodInfo {
 #[cfg(test)]
 mod tests {
     use syn::{parse_quote, Type, ImplItemFn as ImplItemMethod , ReturnType};
-    use crate::core_impl::{ImplItemMethodInfo};
+    use crate::core_impl::ImplItemMethodInfo;
 
     #[test]
     fn init_no_return() {
@@ -44,7 +46,7 @@ mod tests {
             #[init]
             pub fn method(k: &mut u64) { }
         };
-        let actual = ImplItemMethodInfo::new(&mut method, false, impl_type).map(|_| ()).unwrap_err();
+        let actual = ImplItemMethodInfo::new(&mut method, None, impl_type).map(|_| ()).unwrap_err();
         let expected = "Init function must return the contract state.";
         assert_eq!(expected, actual.to_string());
     }
@@ -57,7 +59,7 @@ mod tests {
             #[handle_result]
             pub fn method(k: &mut u64) -> Result<Self, Error> { }
         };
-        let method = ImplItemMethodInfo::new(&mut method, false, impl_type).unwrap().unwrap();
+        let method = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = method.attr_signature_info.returns.original;
         let expected: Type = syn::parse_str("Result<Hello, Error>").unwrap();
         assert!(matches!(actual, ReturnType::Type(_, ty) if ty.as_ref() == &expected));
@@ -70,7 +72,7 @@ mod tests {
             #[handle_result]
             pub fn method(&self) -> &'static str { }
         };
-        let actual = ImplItemMethodInfo::new(&mut method, false, impl_type).map(|_| ()).unwrap_err();
+        let actual = ImplItemMethodInfo::new(&mut method, None, impl_type).map(|_| ()).unwrap_err();
         let expected = "Function marked with #[handle_result] should return Result<T, E> (where E implements FunctionError). If you're trying to use a type alias for `Result`, try `#[handle_result(aliased)]`.";
         assert_eq!(expected, actual.to_string());
     }
@@ -81,7 +83,7 @@ mod tests {
         let mut method: ImplItemMethod = parse_quote! {
             pub fn method(&self) -> Result<u64, &'static str> { }
         };
-        let actual = ImplItemMethodInfo::new(&mut method, false, impl_type).map(|_| ()).unwrap_err();
+        let actual = ImplItemMethodInfo::new(&mut method, None, impl_type).map(|_| ()).unwrap_err();
         let expected = "Serializing Result<T, E> has been deprecated. Consider marking your method with #[handle_result] if the second generic represents a panicable error or replacing Result with another two type sum enum otherwise. If you really want to keep the legacy behavior, mark the method with #[handle_result] and make it return Result<Result<T, E>, near_sdk::Abort>.";
         assert_eq!(expected, actual.to_string());
     }
@@ -93,7 +95,7 @@ mod tests {
             #[init]
             pub fn new() -> Result<Self, &'static str> { }
         };
-        let actual = ImplItemMethodInfo::new(&mut method, false, impl_type).map(|_| ()).unwrap_err();
+        let actual = ImplItemMethodInfo::new(&mut method, None, impl_type).map(|_| ()).unwrap_err();
         let expected = "Serializing Result<T, E> has been deprecated. Consider marking your method with #[handle_result] if the second generic represents a panicable error or replacing Result with another two type sum enum otherwise. If you really want to keep the legacy behavior, mark the method with #[handle_result] and make it return Result<Result<T, E>, near_sdk::Abort>.";
         assert_eq!(expected, actual.to_string());
     }
@@ -106,7 +108,7 @@ mod tests {
             #[payable]
             pub fn method(self) -> Self { }
         };
-        let actual = ImplItemMethodInfo::new(&mut method, false, impl_type).map(|_| ()).unwrap_err();
+        let actual = ImplItemMethodInfo::new(&mut method, None, impl_type).map(|_| ()).unwrap_err();
         let expected = "View function can't be payable.";
         assert_eq!(expected.to_string(), actual.to_string());
     }

--- a/near-sdk-macros/src/core_impl/info_extractor/item_impl_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/item_impl_info.rs
@@ -18,14 +18,14 @@ impl ItemImplInfo {
                 "Impl type parameters are not supported for smart contracts.",
             ));
         }
-        let is_trait_impl = original.trait_.is_some();
         let ty = (*original.self_ty.as_ref()).clone();
+        let trait_ = original.trait_.as_ref().map(|(_not, path, _for)| path);
 
         let mut methods = vec![];
         let mut errors = vec![];
         for subitem in &mut original.items {
             if let ImplItem::Fn(m) = subitem {
-                match ImplItemMethodInfo::new(m, is_trait_impl, ty.clone()) {
+                match ImplItemMethodInfo::new(m, trait_.cloned(), ty.clone()) {
                     Ok(Some(method_info)) => methods.push(method_info),
                     Ok(None) => {} // do nothing
                     Err(e) => errors.push(e),

--- a/near-sdk/compilation_tests/schema_derive_invalids.stderr
+++ b/near-sdk/compilation_tests/schema_derive_invalids.stderr
@@ -87,7 +87,7 @@ error[E0277]: the trait bound `Inner: JsonSchema` is not satisfied
             i128
           and $N others
 note: required by a bound in `SchemaGenerator::subschema_for`
- --> $CARGO/schemars-0.8.20/src/gen.rs
+ --> $CARGO/schemars-0.8.21/src/gen.rs
   |
   |     pub fn subschema_for<T: ?Sized + JsonSchema>(&mut self) -> Schema {
   |                                      ^^^^^^^^^^ required by this bound in `SchemaGenerator::subschema_for`


### PR DESCRIPTION
Hey Team!

I've noticed a small inconsistency while working on [`#[access_control]`](https://github.com/Near-One/near-plugins/blob/12d3feec8686a9200173d3c72dbf5159309ded13/near-plugins-derive/src/lib.rs#L54) from [near-plugins](https://github.com/Near-One/near-plugins), which [uses](https://github.com/Near-One/near-plugins/blob/12d3feec8686a9200173d3c72dbf5159309ded13/near-plugins-derive/src/access_controllable.rs#L587-L588) `#[near-sdk::near]` macro internally.

The inconsistency itself can be described as follows:
> The generated code by `#[near_bindgen]`  assumes that all necessary traits were imported into current scope.

To simplify the issue, consider the following example:
```rust
use near_sdk::near;

pub mod other {
    pub trait SomeTrait {
        fn method(&self);
    }
}

#[near(contract_state)]
struct Contract {
    // ..
}

#[near]
impl other::SomeTrait for Contract {
    fn method(&self) {
        // ...
    }
}
```

When you compile it with `cargo build --target wasm32-unknown-unknown`, you get the following error:
```
error[E0599]: no method named `method` found for struct `Contract` in the current scope
  --> controller/src/lib.rs:17:8
   |
5  |         fn method(&self);
   |            ------ the method is available for `Contract` here
...
11 | struct Contract {
   | --------------- method `method` not found for this struct
...
17 |     fn method(&self) {
   |        ^^^^^^ method not found in `Contract`
   |
   = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
   |
1  + use crate::other::SomeTrait;
   |

For more information about this error, try `rustc --explain E0599`.
error: could not compile `defuse-controller-contract` (lib) due to previous error
```

This happens due to `method` is not implemented on `Contract itself` but is a part of `impl other::SomeTrait for Contract`, so it's not visible in the current scope. 
Of course, It can be fixed by adding `use other::SomeTrait` at top of your module, but it's better to avoid it, so it can just work.

The current version of `near-sdk 5.1.0` generates following code:
```rust
#[cfg(target_arch = "wasm32")]
#[no_mangle]
pub extern "C" fn method() {
    ::near_sdk::env::setup_panic_hook();
    let contract: Contract = ::near_sdk::env::state_read().unwrap_or_default();
    contract.method();
}
```

This PR introduces a fix for that by using [fully qualified syntax](https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#fully-qualified-syntax-for-disambiguation-calling-methods-with-the-same-name) for calling methods that are part of trait implementation. 

Here is the code that this PR generates:
```rust
#[cfg(target_arch = "wasm32")]
#[no_mangle]
pub extern "C" fn method() {
    ::near_sdk::env::setup_panic_hook();
    let contract: Contract = ::near_sdk::env::state_read().unwrap_or_default();
    <Contract as other::SomeTrait>::method(&contract);
}
```