### PR TITLE
fix: Make log macro fully compatible with std::format

### DIFF
--- a/near-sdk/src/utils/mod.rs
+++ b/near-sdk/src/utils/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use cache_entry::{CacheEntry, EntryState};
 use crate::{env, NearToken, PromiseResult};
 
 /// Helper macro to log a message through [`env::log_str`].
-/// This macro can be used similar to the [`std::format`] macro in most cases.
+/// This macro can be used similar to the [`std::format`] macro.
 ///
 /// This differs from [`std::format`] because instead of generating a string, it will log the utf8
 /// bytes as a log through [`env::log_str`].
@@ -25,7 +25,7 @@ use crate::{env, NearToken, PromiseResult};
 /// # fn main() {
 /// log!("test");
 /// let world: &str = "world";
-/// log!(world);
+/// log!("{world}");
 /// log!("Hello {}", world);
 /// log!("x = {}, y = {y}", 10, y = 30);
 /// # }
@@ -34,11 +34,8 @@ use crate::{env, NearToken, PromiseResult};
 /// [`env::log_str`]: crate::env::log_str
 #[macro_export]
 macro_rules! log {
-    ($arg:expr) => {
-        $crate::env::log_str($arg.as_ref())
-    };
     ($($arg:tt)*) => {
-        $crate::env::log_str(format!($($arg)*).as_str())
+        $crate::env::log_str(::std::format!($($arg)*).as_str())
     };
 }
 


### PR DESCRIPTION
This PR makes `log!` macro 100% compatible with std `format!`, allowing string interpolation while passing just 1 string literal.

I also noticed that this macro uses `format` from local scope, now it's prefixed with `::std` to make sure it can't be accidentally overridden.

Fixes: #1188 

**BREAKING CHANGE**: `let x = "1"; log!(x)` doesn't work anymore, and `log!("str with no formatting")` now allocates, like `format!`. For logging `&str` with no additional formatting and no allocations, use `env::log_str` method instead.