### PR TITLE
docs: Fix dead links in markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,4 +325,4 @@ The minimum supported Rust version is currently `1.72`. There are no guarantees 
 
 ## Contributing
 
-If you are interested in contributing, please look at the [contributing guidelines](CONTRIBUTING.md).
+If you are interested in contributing, please look at the [contributing guidelines](https://github.com/near/near-sdk-rs/blob/master/CONTRIBUTING.md).

--- a/examples/fungible-token/README.md
+++ b/examples/fungible-token/README.md
@@ -3,7 +3,7 @@ Fungible Token (FT)
 
 Example implementation of a [Fungible Token] contract which uses [near-contract-standards].
 
-  [Fungible Token]: https://nomicon.io/Standards/Tokens/FungibleTokenCore.html
+  [Fungible Token]: https://nomicon.io/Standards/Tokens/FungibleToken
   [near-contract-standards]: https://github.com/near/near-sdk-rs/tree/master/near-contract-standards
 
 NOTES:

--- a/examples/non-fungible-token/README.md
+++ b/examples/non-fungible-token/README.md
@@ -1,9 +1,9 @@
 Non-fungible Token (NFT)
 ===================
 
-Example implementation of a [non-fungible token] contract which uses [near-contract-standards].
+Example implementation of a [Non-Fungible Token] contract which uses [near-contract-standards].
 
-  [non-fungible token]: https://nomicon.io/Standards/NonFungibleToken/README.html
+  [Non-Fungible Token]: https://nomicon.io/Standards/NonFungibleToken
   [near-contract-standards]: https://github.com/near/near-sdk-rs/tree/master/near-contract-standards
 
 NOTES:


### PR DESCRIPTION
- Replaced a relative link to `CONTRIBUTING.md` with an absolute link to this file on github, to make this link work on https://crates.io/crates/near-sdk. It didn't work because crates.io uses README from `/near-sdk/README.md`, which is a symlink to `/README.md`. I replaced it with an absolute link because I'm not sure if it's possible to get relative links to work in both `/README.md` and `near-sdk/README.md` without maintaining 2 copies of the same file.
- Replaced `FungibleTokenCore` (moved to `FungibleToken/Core`) nomicon link with `FungibleToken`. The example implements all Fungible Token standards, so no reason to link to `FungibleToken/Core`, and now it's consistent with the Non-Fungible Token example.
- Replaced `NonFungibleToken/README.html` link with `NonFungibleToken`, and changed the link text from `non-fungible token` to `Non-Fungible Token` to be consistent with the Fungible Token example.