### PR TITLE
chore: release v5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## [Unreleased]
 
+## [5.2.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.1.0...near-sdk-v5.2.0) - 2024-07-04
+
+### Added
+- New `near_sdk::store::IterableMap` and `near_sdk::store::IterableSet` that address the iteration performance issue of `store::UnorderedMap` ([#1164](https://github.com/near/near-sdk-rs/pull/1164)) ([#1175](https://github.com/near/near-sdk-rs/pull/1175))
+- Added `BorshSchema` trait impl to all `near_sdk::store` collections!
+  - `store::TreeMap<K, V, H>` and `UnorderedSet<T, H>` ([#1213](https://github.com/near/near-sdk-rs/pull/1213))
+  - `store::IterableSet` and `store::IterableMap` and refactored and added ABI defiintions tests ([#1212](https://github.com/near/near-sdk-rs/pull/1212))
+  - `store::UnorderedMap` ([#1209](https://github.com/near/near-sdk-rs/pull/1209))
+- Added yield execution host functions ([#1183](https://github.com/near/near-sdk-rs/pull/1183))
+- NEP-330 1.2.0 support - added build info field in contract metadata ([#1178](https://github.com/near/near-sdk-rs/pull/1178))
+
+### Fixed
+- [**technically breaking**] Make log macro fully compatible with std::format (string interpolation is now supported) ([#1189](https://github.com/near/near-sdk-rs/pull/1189))
+- use FQDNs when calling contract methods to avoid method names collision ([#1186](https://github.com/near/near-sdk-rs/pull/1186))
+
+### Other
+- Added performance tests for 'store' collections ([#1195](https://github.com/near/near-sdk-rs/pull/1195))
+- Full tests coverage for `store::Vector` + coverage for all the collections relevant to IterableMap implementation ([#1173](https://github.com/near/near-sdk-rs/pull/1173))
+- Full tests coverage for `store` collections ([#1172](https://github.com/near/near-sdk-rs/pull/1172))
+- Documented `#[init]`, `#[payable]`, `#[handle_result]`, `#[private]`, `#[result_serializer]` attributes for docs.rs discoverability ([#1185](https://github.com/near/near-sdk-rs/pull/1185))
+- Enabled `unit-testing` feature for docs.rs
+- Replaced manual `borsh` trait impl-s with derives and correct bounds in `near_sdk::store` and `near_sdk::collections` ([#1176](https://github.com/near/near-sdk-rs/pull/1176))
+- Proxy JsonSchema::schema_name to the original implementation ([#1210](https://github.com/near/near-sdk-rs/pull/1210))
+- Fixed Rust 1.79 linter warnings ([#1202](https://github.com/near/near-sdk-rs/pull/1202))
+- Fixed Rust 1.78 linter warnings ([#1181](https://github.com/near/near-sdk-rs/pull/1181))
+- Updated near-* dependencies to 0.23 version ([#1207](https://github.com/near/near-sdk-rs/pull/1207))
+
 ## [5.1.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.0.0...near-sdk-v5.1.0) - 2024-03-28
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.1.0"
+version = "5.2.0"
 
 # Special triple # comment for ci.
 [patch.crates-io]

--- a/near-contract-standards/CHANGELOG.md
+++ b/near-contract-standards/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.1.0...near-contract-standards-v5.2.0) - 2024-07-04
+
+### Added
+- Exported `ext_storage_management` Promise shortcuts, so Storage Management interfaces can be used in contracts to call external contracts using the high-level cross-contract call interfaces ([#1208](https://github.com/near/near-sdk-rs/pull/1208))
+- Exported `ext_nft_*` Promise shortcuts, so NFT interfaces can be re-used in contracts to call external NFT contracts using the high-level cross-contract call interfaces ([#1206](https://github.com/near/near-sdk-rs/pull/1206))
+
 ## [5.1.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.0.0...near-contract-standards-v5.1.0) - 2024-03-28
 
 ### Added

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.1.0", default-features = false, features = ["legacy"] }
+near-sdk = { path = "../near-sdk", version = "~5.2.0", default-features = false, features = ["legacy"] }
 
 [dev-dependencies]
 near-sdk = { path = "../near-sdk", default-features = false, features = ["unit-testing"] }

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,8 +21,8 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.1.0" }
-near-sys = { path = "../near-sys", version = "0.2.1" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.2.0" }
+near-sys = { path = "../near-sys", version = "0.2.2" }
 base64 = "0.21"
 borsh = { version = "1.0.0", features = ["derive"] }
 bs58 = "0.5"

--- a/near-sdk/tests/test-contracts/store/src/lib.rs
+++ b/near-sdk/tests/test-contracts/store/src/lib.rs
@@ -1,7 +1,6 @@
 #![allow(deprecated)]
 
 use near_sdk::borsh::{BorshDeserialize, BorshSerialize};
-use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::{near, store, PanicOnDefault};
 use Collection::*;
 
@@ -27,8 +26,7 @@ pub struct StoreContract {
     pub vec: store::Vector<Insertable>,
 }
 
-#[derive(Serialize, Deserialize)]
-#[serde(crate = "near_sdk::serde")]
+#[near(serializers=[json])]
 pub enum Collection {
     IterableSet,
     IterableMap,

--- a/near-sys/CHANGELOG.md
+++ b/near-sys/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.1...near-sys-v0.2.2) - 2024-07-04
+
+### Other
+- add yield execution host functions ([#1183](https://github.com/near/near-sdk-rs/pull/1183))
+
 ## [0.2.1](https://github.com/near/near-sdk-rs/compare/4.1.1...near-sys-v0.2.1) - 2023-11-18
 
 ### Other

--- a/near-sys/Cargo.toml
+++ b/near-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sys"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Near Inc <hello@near.org>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `near-sdk`: 5.1.0 -> 5.2.0
* `near-sdk-macros`: 5.1.0 -> 5.2.0
* `near-sys`: 0.2.1 -> 0.2.2
* `near-contract-standards`: 5.1.0 -> 5.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-sdk`
<blockquote>

## [5.2.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.1.0...near-sdk-v5.2.0) - 2024-07-04

### Added
- Added `BorshSchema` impl for `store::TreeMap<K, V, H>` and `UnorderedSet<T, H>` ([#1213](https://github.com/near/near-sdk-rs/pull/1213))
- Added missing `BorshSchema` for IterableSet and IterableMap and refactored and added ABI defiintions tests ([#1212](https://github.com/near/near-sdk-rs/pull/1212))
- Added `BorshSchema` derive for `store::UnorderedMap` ([#1209](https://github.com/near/near-sdk-rs/pull/1209))
- New `near_sdk::store::IterableSet` - a better alternative to `UnorderedSet`, which has performance limitations on iteration over elements ([#1175](https://github.com/near/near-sdk-rs/pull/1175))
- New `near_sdk::store::IterableMap` that addresses the iteration performance issue of `store::UnorderedMap` ([#1164](https://github.com/near/near-sdk-rs/pull/1164))
- nep330 build info field of contract metadata ([#1178](https://github.com/near/near-sdk-rs/pull/1178))

### Fixed
- [**breaking**] Make log macro fully compatible with std::format (string interpolation is now supported) ([#1189](https://github.com/near/near-sdk-rs/pull/1189))
- use FQDNs when calling contract methods to avoid method names collision ([#1186](https://github.com/near/near-sdk-rs/pull/1186))

### Other
- Added performance tests for 'store' collections ([#1195](https://github.com/near/near-sdk-rs/pull/1195))
- Enable `unit-testing` feature for docs.rs
- Documented `#[init]`, `#[payable]`, `#[handle_result]`, `#[private]`, `#[result_serializer]` attributes for docs.rs discoverability ([#1185](https://github.com/near/near-sdk-rs/pull/1185))
- Updated near-* dependencies to 0.23 version ([#1207](https://github.com/near/near-sdk-rs/pull/1207))
- Rust 1.79 fixes ([#1202](https://github.com/near/near-sdk-rs/pull/1202))
- add yield execution host functions ([#1183](https://github.com/near/near-sdk-rs/pull/1183))
- fix new lints, introduced in 1.78 ([#1181](https://github.com/near/near-sdk-rs/pull/1181))
- *(store, collections)* replace manual `borsh` trait impl-s  with derives and correct bounds within ([#1176](https://github.com/near/near-sdk-rs/pull/1176))
- Cover store::Vector fully + coverage for all the collections relevant to IterableMap implementation. ([#1173](https://github.com/near/near-sdk-rs/pull/1173))
- Cover `store` collections with tests. ([#1172](https://github.com/near/near-sdk-rs/pull/1172))
- Proxy JsonSchema::schema_name to the original implementation ([#1210](https://github.com/near/near-sdk-rs/pull/1210))
</blockquote>

## `near-sys`
<blockquote>

## [0.2.2](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.1...near-sys-v0.2.2) - 2024-07-04

### Other
- add yield execution host functions ([#1183](https://github.com/near/near-sdk-rs/pull/1183))
</blockquote>

## `near-contract-standards`
<blockquote>

## [5.2.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.1.0...near-contract-standards-v5.2.0) - 2024-07-04

### Added
- *(near-contract-standards)* export ext_storage_management Promise shortcuts, so Storage Management interfaces can be used in contracts to call external contracts using the high-level cross-contract call interfaces ([#1208](https://github.com/near/near-sdk-rs/pull/1208))
- *(near-contract-standards)* export ext_nft_* Promise shortcuts, so NFT interfaces can be re-used in contracts to call external NFT contracts using the high-level cross-contract call interfaces ([#1206](https://github.com/near/near-sdk-rs/pull/1206))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).