### PR TITLE
chore: bump MSRV to 1.73.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest]
-        toolchain: [stable, 1.72.1]
+        toolchain: [stable, 1.73.0]
     steps:
       - uses: actions/checkout@v3
       - name: "${{ matrix.toolchain }} with rustfmt, and wasm32"
@@ -26,8 +26,9 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - name: Downgrade dependencies
         run: |
-          cargo update -p clap@4.5.4 --precise 4.4.18
-          cd examples/adder && cargo update -p clap@4.5.4 --precise 4.4.18
+          cargo update -p clap@4.5.5 --precise 4.4.18
+          cargo update -p symbolic-debuginfo --precise 12.8.0
+          cd examples/adder && cargo update -p clap@4.5.5 --precise 4.4.18
       - name: test
         run: cargo test --all --features unstable,legacy
   lint:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
     <a href="https://crates.io/crates/near-sdk"><img src="https://img.shields.io/crates/v/near-sdk.svg?style=flat-square" alt="Crates.io version" /></a>
     <a href="https://crates.io/crates/near-sdk"><img src="https://img.shields.io/crates/d/near-sdk.svg?style=flat-square" alt="Download" /></a>
     <a href="https://docs.rs/near-sdk"><img src="https://docs.rs/near-sdk/badge.svg" alt="Reference Documentation" /></a>
-    <a href="https://blog.rust-lang.org/2023/08/24/Rust-1.72.0.html"><img src="https://img.shields.io/badge/rustc-1.72+-lightgray.svg" alt="MSRV" /></a>
+    <a href="https://blog.rust-lang.org/2023/10/05/Rust-1.73.0.html"><img src="https://img.shields.io/badge/rustc-1.73+-lightgray.svg" alt="MSRV" /></a>
     <a href="https://discord.gg/gBtUFKR"><img src="https://img.shields.io/discord/490367152054992913.svg" alt="Join the community on Discord" /></a>
     <a href="https://github.com/near/near-sdk-rs/actions"><img src="https://github.com/near/near-sdk-rs/actions/workflows/test.yml/badge.svg" alt="GitHub Actions Build" /></a>
   </p>
@@ -321,7 +321,7 @@ State breaking changes (low-level serialization format of any data type) will be
 
 ### MSRV
 
-The minimum supported Rust version is currently `1.72`. There are no guarantees that this will be upheld if a security patch release needs to come in that requires a Rust toolchain increase.
+The minimum supported Rust version is currently `1.73`. There are no guarantees that this will be upheld if a security patch release needs to come in that requires a Rust toolchain increase.
 
 ## Contributing
 


### PR DESCRIPTION
otherwise was encountering ci error https://github.com/near/near-sdk-rs/actions/runs/9406335158/job/25909553039