### PR TITLE
ci: 1.79 fixes (replace `macos-latest stable` with `macos-latest 1.78`)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest]
-        toolchain: [1.78.0, 1.76.0]
+        toolchain: [stable, 1.76.0]
     steps:
       - uses: actions/checkout@v3
       - name: "${{ matrix.toolchain }} with rustfmt, and wasm32"
@@ -23,6 +23,7 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           default: true
           target: wasm32-unknown-unknown
+          components: clippy, rust-docs
       - uses: Swatinem/rust-cache@v1
 #      - name: Downgrade dependencies
 #        run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest]
-        toolchain: [stable, 1.76.0]
+        toolchain: [1.78.0, 1.76.0]
     steps:
       - uses: actions/checkout@v3
       - name: "${{ matrix.toolchain }} with rustfmt, and wasm32"
@@ -23,7 +23,6 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           default: true
           target: wasm32-unknown-unknown
-          components: clippy, rust-docs
       - uses: Swatinem/rust-cache@v1
 #      - name: Downgrade dependencies
 #        run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,8 @@ jobs:
 #        run: |
 #          cargo update -p clap@4.5.4 --precise 4.4.18
 #          cd examples/adder && cargo update -p clap@4.5.4 --precise 4.4.18
+      - name: print rustc && rustdoc version
+        run: rustc --version && rustdoc --version
       - name: test
         run: cargo test --all --features unstable,legacy
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,19 +8,18 @@ env:
   RUSTFLAGS: -D warnings
 jobs:
   test:
-    runs-on: ${{ matrix.platform }}
-    name: "${{ matrix.platform }} ${{ matrix.toolchain }}"
+    runs-on: ${{ matrix.platform.os }}
+    name: "${{ matrix.platform.os }} ${{ matrix.platform.rs }}"
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest]
-        toolchain: [1.78.0, 1.76.0]
+        platform: [{os: ubuntu-latest, rs: 1.76.0}, {os: ubuntu-latest, rs: stable}, {os: macos-latest, rs: 1.76.0}, {os: macos-latest, rs: 1.78.0}]
     steps:
       - uses: actions/checkout@v3
-      - name: "${{ matrix.toolchain }} with rustfmt, and wasm32"
+      - name: "${{ matrix.platform.rs }} with rustfmt, and wasm32"
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.toolchain }}
+          toolchain: ${{ matrix.platform.rs }}
           default: true
           target: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,18 +17,20 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: "${{ matrix.toolchain }} with rustfmt, and wasm32"
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
+          # profile: minimal
           toolchain: ${{ matrix.toolchain }}
-          default: true
-          target: wasm32-unknown-unknown
+          # default: true
+          targets: wasm32-unknown-unknown
           components: clippy, rust-docs
       # - uses: Swatinem/rust-cache@v1
 #      - name: Downgrade dependencies
 #        run: |
 #          cargo update -p clap@4.5.4 --precise 4.4.18
 #          cd examples/adder && cargo update -p clap@4.5.4 --precise 4.4.18
+      - name: print rustc && rustdoc version
+        run: rustc --version && rustdoc --version
       - name: test
         run: cargo test --all --features unstable,legacy
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     name: "${{ matrix.platform }} ${{ matrix.toolchain }}"
     strategy:
       matrix:
-        platform: [ubuntu-latest]
+        platform: [ubuntu-latest, macos-latest]
         toolchain: [stable, 1.76.0]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest]
-        toolchain: [stable, 1.76.0]
+        toolchain: [1.78.0, 1.76.0]
     steps:
       - uses: actions/checkout@v3
       - name: "${{ matrix.toolchain }} with rustfmt, and wasm32"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,15 @@ jobs:
     name: "${{ matrix.platform.os }} ${{ matrix.platform.rs }}"
     strategy:
       matrix:
-        platform: [{os: ubuntu-latest, rs: 1.76.0}, {os: ubuntu-latest, rs: stable}, {os: macos-latest, rs: 1.76.0}, {os: macos-latest, rs: 1.78.0}]
+        platform:
+          - os: ubuntu-latest
+            rs: 1.76.0
+          - os: ubuntu-latest
+            rs: stable
+          - os: macos-latest
+            rs: 1.76.0
+          - os: macos-latest
+            rs: 1.78.0
     steps:
       - uses: actions/checkout@v3
       - name: "${{ matrix.platform.rs }} with rustfmt, and wasm32"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           default: true
           target: wasm32-unknown-unknown
           components: clippy, rust-docs
-      - uses: Swatinem/rust-cache@v1
+      # - uses: Swatinem/rust-cache@v1
 #      - name: Downgrade dependencies
 #        run: |
 #          cargo update -p clap@4.5.4 --precise 4.4.18

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,20 +17,18 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: "${{ matrix.toolchain }} with rustfmt, and wasm32"
-        uses: dtolnay/rust-toolchain@master
+        uses: actions-rs/toolchain@v1
         with:
-          # profile: minimal
+          profile: minimal
           toolchain: ${{ matrix.toolchain }}
-          # default: true
-          targets: wasm32-unknown-unknown
+          default: true
+          target: wasm32-unknown-unknown
           components: clippy, rust-docs
       # - uses: Swatinem/rust-cache@v1
 #      - name: Downgrade dependencies
 #        run: |
 #          cargo update -p clap@4.5.4 --precise 4.4.18
 #          cd examples/adder && cargo update -p clap@4.5.4 --precise 4.4.18
-      - name: print rustc && rustdoc version
-        run: rustc --version && rustdoc --version
       - name: test
         run: cargo test --all --features unstable,legacy
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     name: "${{ matrix.platform }} ${{ matrix.toolchain }}"
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest]
+        platform: [ubuntu-latest]
         toolchain: [stable, 1.76.0]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           default: true
           target: wasm32-unknown-unknown
           components: clippy, rust-docs
-      # - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v1
 #      - name: Downgrade dependencies
 #        run: |
 #          cargo update -p clap@4.5.4 --precise 4.4.18

--- a/near-sdk-macros/src/core_impl/info_extractor/arg_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/arg_info.rs
@@ -18,12 +18,15 @@ pub enum BindgenArgType {
 /// A single argument of a function after it was processed by the bindgen.
 pub struct ArgInfo {
     /// Attributes not related to bindgen.
+    #[allow(unused)]
     pub non_bindgen_attrs: Vec<Attribute>,
     /// The `binding` part of `ref mut binding @ SUBPATTERN: TYPE` argument.
     pub ident: Ident,
     /// Whether pattern has a preceded `ref`.
+    #[allow(unused)]
     pub pat_reference: Option<Token![ref]>,
     /// Whether pattern has a preceded `mut`.
+    #[allow(unused)]
     pub pat_mutability: Option<Token![mut]>,
     /// Whether the `TYPE` starts with `&`.
     pub reference: Option<Token![&]>,

--- a/near-sdk-macros/src/core_impl/info_extractor/trait_item_method_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/trait_item_method_info.rs
@@ -9,8 +9,10 @@ pub struct TraitItemMethodInfo {
     /// Attributes and signature information.
     pub attr_sig_info: AttrSigInfo,
     /// The original AST of the trait item method.
+    #[allow(unused)]
     pub original: TraitItemFn,
     /// String representation of method name, e.g. `"my_method"`.
+    #[allow(unused)]
     pub ident_byte_str: LitStr,
 }
 

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -12,6 +12,9 @@ description = """
 Rust library for writing NEAR smart contracts.
 """
 
+[lib]
+doctest = false
+
 [[test]]
 name = "compilation_tests"
 path = "compilation_tests/all.rs"

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -12,9 +12,6 @@ description = """
 Rust library for writing NEAR smart contracts.
 """
 
-[lib]
-doctest = false
-
 [[test]]
 name = "compilation_tests"
 path = "compilation_tests/all.rs"

--- a/near-sdk/compilation_tests/schema_derive_invalids.stderr
+++ b/near-sdk/compilation_tests/schema_derive_invalids.stderr
@@ -77,14 +77,14 @@ error[E0277]: the trait bound `Inner: JsonSchema` is not satisfied
   |              ^^^^^ the trait `JsonSchema` is not implemented for `Inner`
   |
   = help: the following other types implement trait `JsonSchema`:
-            bool
-            char
-            isize
-            i8
-            i16
-            i32
-            i64
-            i128
+            &'a T
+            &'a mut T
+            ()
+            (T0, T1)
+            (T0, T1, T2)
+            (T0, T1, T2, T3)
+            (T0, T1, T2, T3, T4)
+            (T0, T1, T2, T3, T4, T5)
           and $N others
 note: required by a bound in `SchemaGenerator::subschema_for`
  --> $CARGO/schemars-0.8.21/src/gen.rs

--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -23,9 +23,9 @@ const REGISTER_EXPECTED_ERR: &str =
 /// Register used internally for atomic operations. This register is safe to use by the user,
 /// since it only needs to be untouched while methods of `Environment` execute, which is guaranteed
 /// guest code is not parallel.
-const ATOMIC_OP_REGISTER: u64 = std::u64::MAX - 2;
+const ATOMIC_OP_REGISTER: u64 = u64::MAX - 2;
 /// Register used to record evicted values from the storage.
-const EVICTED_REGISTER: u64 = std::u64::MAX - 1;
+const EVICTED_REGISTER: u64 = u64::MAX - 1;
 
 /// Key used to store the state of the contract.
 const STATE_KEY: &[u8] = b"STATE";
@@ -139,7 +139,7 @@ pub fn read_register(register_id: u64) -> Option<Vec<u8>> {
 /// Returns the size of the register. If register is not used returns `None`.
 pub fn register_len(register_id: u64) -> Option<u64> {
     let len = unsafe { sys::register_len(register_id) };
-    if len == std::u64::MAX {
+    if len == u64::MAX {
         None
     } else {
         Some(len)

--- a/near-sdk/src/json_types/integers.rs
+++ b/near-sdk/src/json_types/integers.rs
@@ -95,8 +95,8 @@ mod tests {
         test_serde!(U128, u128, 123);
         test_serde!(U128, u128, 10u128.pow(18));
         test_serde!(U128, u128, 2u128.pow(100));
-        test_serde!(U128, u128, u128::max_value());
-        assert!(U128::from(u128::min_value()) < U128::from(u128::max_value()));
+        test_serde!(U128, u128, u128::MAX);
+        assert!(U128::from(u128::MIN) < U128::from(u128::MAX));
     }
 
     #[test]
@@ -108,9 +108,9 @@ mod tests {
         test_serde!(I128, i128, 10i128.pow(18));
         test_serde!(I128, i128, 2i128.pow(100));
         test_serde!(I128, i128, -(2i128.pow(100)));
-        test_serde!(I128, i128, i128::max_value());
-        test_serde!(I128, i128, i128::min_value());
-        assert!(I128::from(i128::min_value()) < I128::from(i128::max_value()));
+        test_serde!(I128, i128, i128::MAX);
+        test_serde!(I128, i128, i128::MIN);
+        assert!(I128::from(i128::MIN) < I128::from(i128::MAX));
     }
 
     #[test]
@@ -120,8 +120,8 @@ mod tests {
         test_serde!(U64, u64, 123);
         test_serde!(U64, u64, 10u64.pow(18));
         test_serde!(U64, u64, 2u64.pow(60));
-        test_serde!(U64, u64, u64::max_value());
-        assert!(U64::from(u64::min_value()) < U64::from(u64::max_value()));
+        test_serde!(U64, u64, u64::MAX);
+        assert!(U64::from(u64::MIN) < U64::from(u64::MAX));
     }
 
     #[test]
@@ -133,8 +133,8 @@ mod tests {
         test_serde!(I64, i64, 10i64.pow(18));
         test_serde!(I64, i64, 2i64.pow(60));
         test_serde!(I64, i64, -(2i64.pow(60)));
-        test_serde!(I64, i64, i64::max_value());
-        test_serde!(I64, i64, i64::min_value());
-        assert!(I64::from(i64::min_value()) < I64::from(i64::max_value()));
+        test_serde!(I64, i64, i64::MAX);
+        test_serde!(I64, i64, i64::MIN);
+        assert!(I64::from(i64::MIN) < I64::from(i64::MAX));
     }
 }

--- a/near-sdk/src/store/iterable_map/mod.rs
+++ b/near-sdk/src/store/iterable_map/mod.rs
@@ -791,7 +791,6 @@ mod test_map {
     use borsh::{BorshDeserialize, BorshSerialize};
     use rand::{rngs::SmallRng, Rng, SeedableRng};
     use std::cell::RefCell;
-    use std::usize;
     use std::vec::Vec;
 
     #[test]

--- a/near-sdk/src/store/lookup_map/mod.rs
+++ b/near-sdk/src/store/lookup_map/mod.rs
@@ -734,7 +734,6 @@ mod test_map {
     use crate::store::LookupMap;
     use borsh::{BorshDeserialize, BorshSerialize};
     use std::cell::RefCell;
-    use std::usize;
     use std::vec::Vec;
 
     #[test]


### PR DESCRIPTION
this passes if `macos-latest` is temporarily commented out https://github.com/near/near-sdk-rs/actions/runs/9566693799 ;
otherwise, `macos-latest` is having some serious trouble on 1.79