### PR TITLE
feat(near-contract-standards): export ext_nft_*

### DIFF
--- a/near-contract-standards/src/non_fungible_token/approval/mod.rs
+++ b/near-contract-standards/src/non_fungible_token/approval/mod.rs
@@ -2,6 +2,7 @@ mod approval_impl;
 mod approval_receiver;
 
 pub use approval_receiver::*;
+use near_sdk::ext_contract;
 
 use crate::non_fungible_token::token::TokenId;
 use near_sdk::AccountId;
@@ -54,6 +55,7 @@ use near_sdk::Promise;
 /// }
 /// ```
 ///
+#[ext_contract(ext_nft_approval)]
 pub trait NonFungibleTokenApproval {
     /// Add an approved account for a specific token.
     ///

--- a/near-contract-standards/src/non_fungible_token/core/mod.rs
+++ b/near-contract-standards/src/non_fungible_token/core/mod.rs
@@ -5,10 +5,11 @@ mod resolver;
 
 pub use self::core_impl::*;
 
-pub use self::receiver::NonFungibleTokenReceiver;
-pub use self::resolver::NonFungibleTokenResolver;
+pub use self::receiver::{ext_nft_receiver, NonFungibleTokenReceiver};
+pub use self::resolver::{ext_nft_resolver, NonFungibleTokenResolver};
 
 use crate::non_fungible_token::token::{Token, TokenId};
+use near_sdk::ext_contract;
 use near_sdk::AccountId;
 use near_sdk::PromiseOrValue;
 
@@ -49,6 +50,7 @@ use near_sdk::PromiseOrValue;
 ///}
 /// ```
 ///
+#[ext_contract(ext_nft_core)]
 pub trait NonFungibleTokenCore {
     /// Simple transfer. Transfer a given `token_id` from current owner to
     /// `receiver_id`.

--- a/near-contract-standards/src/non_fungible_token/enumeration/mod.rs
+++ b/near-contract-standards/src/non_fungible_token/enumeration/mod.rs
@@ -2,7 +2,7 @@ mod enumeration_impl;
 
 use crate::non_fungible_token::token::Token;
 use near_sdk::json_types::U128;
-use near_sdk::AccountId;
+use near_sdk::{ext_contract, AccountId};
 
 /// Offers methods helpful in determining account ownership of NFTs and provides a way to page through NFTs per owner, determine total supply, etc.
 ///
@@ -40,6 +40,7 @@ use near_sdk::AccountId;
 /// }
 /// ```
 ///
+#[ext_contract(ext_nft_enumeration)]
 pub trait NonFungibleTokenEnumeration {
     /// Returns the total supply of non-fungible tokens as a string representing an
     /// unsigned 128-bit integer to avoid JSON number limit of 2^53.

--- a/near-contract-standards/src/non_fungible_token/metadata.rs
+++ b/near-contract-standards/src/non_fungible_token/metadata.rs
@@ -1,5 +1,5 @@
 use near_sdk::json_types::Base64VecU8;
-use near_sdk::{near, require};
+use near_sdk::{ext_contract, near, require};
 
 /// This spec can be treated like a version of the standard.
 pub const NFT_METADATA_SPEC: &str = "nft-1.0.0";
@@ -35,6 +35,7 @@ pub struct TokenMetadata {
 }
 
 /// Offers details on the contract-level metadata.
+#[ext_contract(ext_nft_metadata_provider)]
 pub trait NonFungibleTokenMetadataProvider {
     fn nft_metadata(&self) -> NFTContractMetadata;
 }


### PR DESCRIPTION
This PR exports `ext_nft_*` modules, so NFT interfaces can be re-used in dependent contracts