### PR TITLE
chore: add implicit `BorshSchema` derive for `store::UnorderedMap`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   test:
     runs-on: ${{ matrix.platform.os }}
-    name: "${{ matrix.platform.os }} ${{ matrix.platform.rs }}"
+    name: "${{ matrix.platform.os }} ${{ matrix.platform.rs }} ${{ matrix.features }}"
     strategy:
       matrix:
         platform:
@@ -21,6 +21,7 @@ jobs:
             rs: 1.76.0
           - os: macos-latest
             rs: 1.78.0
+        features: ['', '--features unstable,legacy']
     steps:
       - uses: actions/checkout@v3
       - name: "${{ matrix.platform.rs }} with rustfmt, and wasm32"
@@ -38,7 +39,7 @@ jobs:
       - name: print rustc && rustdoc version
         run: rustc --version && rustdoc --version
       - name: test
-        run: cargo test --all --features unstable,legacy
+        run: cargo test --all ${{ matrix.features }}
   lint:
     name: Clippy and fmt
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
             rs: 1.76.0
           - os: macos-latest
             rs: 1.78.0
-        features: ['', '--features unstable,legacy,abi']
+        features: ['', '--features unstable,legacy,__abi-generate']
     steps:
       - uses: actions/checkout@v3
       - name: "${{ matrix.platform.rs }} with rustfmt, and wasm32"
@@ -69,7 +69,7 @@ jobs:
           default: true
       - uses: Swatinem/rust-cache@v1
       - name: Compilation tests
-        run: cargo test --package near-sdk --test compilation_tests --features abi --features unstable -- compilation_tests --exact --nocapture
+        run: cargo test --package near-sdk --test compilation_tests --features __abi-generate --features unstable -- compilation_tests --exact --nocapture
   windows:
     name: Windows
     runs-on: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
             rs: 1.76.0
           - os: macos-latest
             rs: 1.78.0
-        features: ['', '--features unstable,legacy']
+        features: ['', '--features unstable,legacy,abi']
     steps:
       - uses: actions/checkout@v3
       - name: "${{ matrix.platform.rs }} with rustfmt, and wasm32"

--- a/near-sdk-macros/src/lib.rs
+++ b/near-sdk-macros/src/lib.rs
@@ -649,6 +649,8 @@ pub fn derive_near_schema(#[allow(unused)] input: TokenStream) -> TokenStream {
                 #[automatically_derived]
                 impl #generics #near_sdk_crate::schemars::JsonSchema for #input_ident_proxy #generics #where_clause {
                     fn schema_name() -> ::std::string::String {
+                        // TODO: consider replacing with
+                        // <#input_ident #generics as #near_sdk_crate::schemars::JsonSchema>::schema_name()
                         stringify!(#input_ident #generics).to_string()
                     }
 
@@ -671,7 +673,7 @@ pub fn derive_near_schema(#[allow(unused)] input: TokenStream) -> TokenStream {
                 #[automatically_derived]
                 impl #generics #near_sdk_crate::borsh::BorshSchema for #input_ident_proxy #generics #where_clause {
                     fn declaration() -> #near_sdk_crate::borsh::schema::Declaration {
-                        stringify!(#input_ident #generics).to_string()
+                        <#input_ident #generics as #near_sdk_crate::borsh::BorshSchema>::declaration()
                     }
 
                     fn add_definitions_recursively(

--- a/near-sdk/compilation_tests/all.rs
+++ b/near-sdk/compilation_tests/all.rs
@@ -13,6 +13,8 @@ fn compilation_tests() {
     t.pass("compilation_tests/init_function.rs");
     t.pass("compilation_tests/init_ignore_state.rs");
     t.pass("compilation_tests/no_default.rs");
+    // TODO: unignore upon resolution of https://github.com/near/near-sdk-rs/issues/1211
+    // t.pass("compilation_tests/lifetime_method_result.rs");
     t.pass("compilation_tests/lifetime_method.rs");
     t.pass("compilation_tests/cond_compilation.rs");
     t.compile_fail("compilation_tests/payable_view.rs");

--- a/near-sdk/compilation_tests/all.rs
+++ b/near-sdk/compilation_tests/all.rs
@@ -21,9 +21,9 @@ fn compilation_tests() {
     t.pass("compilation_tests/function_error.rs");
     t.pass("compilation_tests/enum_near_bindgen.rs");
     t.pass("compilation_tests/schema_derive.rs");
-    if rustversion::cfg!(since(1.72)) {
-        // The compilation error output has slightly changed in 1.72, so we
-        // snapshoted this new version
+    if rustversion::cfg!(since(1.78)) && std::env::consts::OS == "linux" {
+        // The compilation error output has slightly changed in 1.7x and between platforms,
+        // so we snapshoted this single version
         t.compile_fail("compilation_tests/schema_derive_invalids.rs");
     }
     t.compile_fail("compilation_tests/generic_function.rs");

--- a/near-sdk/compilation_tests/lifetime_method_result.rs
+++ b/near-sdk/compilation_tests/lifetime_method_result.rs
@@ -10,9 +10,9 @@ struct Ident {
 
 #[near]
 impl Ident {
-    pub fn is_ident<'a>(&self, other: &'a u32) -> Option<u32> {
+    pub fn is_ident<'a>(&self, other: &'a u32) -> Option<&'a u32> {
         if *other == self.value {
-            Some(*other)
+            Some(other)
         } else {
             None
         }

--- a/near-sdk/src/store/unordered_map/mod.rs
+++ b/near-sdk/src/store/unordered_map/mod.rs
@@ -849,4 +849,134 @@ mod tests {
         assert_eq!(map.remove_entry(&1).unwrap(), (1, 1));
         assert_eq!(map.remove_entry(&3).unwrap(), (3, 3));
     }
+
+    #[allow(unused)]
+    macro_rules! schema_map(
+        () => { BTreeMap::new() };
+        { $($key:expr => $value:expr),+ } => {
+            {
+                let mut m = BTreeMap::new();
+                $(
+                    m.insert($key.to_string(), $value);
+                )+
+                m
+            }
+         };
+    );
+
+    #[cfg(feature = "abi")]
+    #[test]
+    fn test_borsh_schema() {
+        use borsh::schema::{Definition, Fields};
+        use std::collections::BTreeMap;
+
+        #[derive(
+            borsh::BorshSerialize, borsh::BorshDeserialize, PartialEq, Eq, PartialOrd, Ord,
+        )]
+        struct NoSchemaStruct;
+
+        assert_eq!(
+            "UnorderedMap".to_string(),
+            <UnorderedMap<NoSchemaStruct, NoSchemaStruct> as borsh::BorshSchema>::declaration()
+        );
+        let mut defs = Default::default();
+        <UnorderedMap<NoSchemaStruct, NoSchemaStruct> as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+        println!("{:#?}", defs);
+        assert_eq!(
+            schema_map! {
+                "UnorderedMap" => Definition::Struct {
+                    fields: Fields::NamedFields(vec![
+                        (
+                            "keys".to_string(),
+                            "FreeList".to_string(),
+                        ),
+                        (
+                            "values".to_string(),
+                            "LookupMap".to_string(),
+                        ),
+                    ]
+                )},
+                "FreeList" => Definition::Struct {
+                    fields: Fields::NamedFields(vec![
+                        (
+                            "first_free".to_string(),
+                            "Option<FreeListIndex>".to_string(),
+                        ),
+                        (
+                            "occupied_count".to_string(),
+                            "u32".to_string(),
+                        ),
+                        (
+                            "elements".to_string(),
+                            "Vector".to_string(),
+                        ),
+                    ]
+                )},
+                "Option<FreeListIndex>" => Definition::Enum {
+                    tag_width: 1,
+                    variants:  vec![
+                        (
+                            0,
+                            "None".to_string(),
+                            "()".to_string(),
+                        ),
+                        (
+                            1,
+                            "Some".to_string(),
+                            "FreeListIndex".to_string(),
+                        ),
+                ]},
+                "()" => Definition::Primitive(0),
+                "FreeListIndex" => Definition::Struct {
+                    fields: Fields::UnnamedFields(
+                        vec![
+                            "u32".to_string(),
+                        ],
+                    ),
+                },
+                "u32" => Definition::Primitive(4 ),
+                "Vector" => Definition::Struct {
+                    fields: Fields::NamedFields(
+                        vec![
+                            (
+                                "len".to_string(),
+                                "u32".to_string(),
+                            ),
+                            (
+                                "values".to_string(),
+                                "IndexMap".to_string(),
+                            ),
+                        ],
+                    ),
+                },
+                "IndexMap" => Definition::Struct {
+                    fields: Fields::NamedFields(
+                        vec![
+                            (
+                                "prefix".to_string(),
+                                "Vec<u8>".to_string(),
+                            ),
+                        ],
+                    ),
+                },
+                "Vec<u8>" => Definition::Sequence {
+                    length_width: 4,
+                    length_range: 0..=4294967295,
+                    elements: "u8".to_string(),
+                },
+                "u8" => Definition::Primitive(1),
+                "LookupMap" => Definition::Struct {
+                    fields: Fields::NamedFields(
+                        vec![
+                            (
+                                "prefix".to_string(),
+                                "Vec<u8>".to_string(),
+                            ),
+                        ],
+                    ),
+                }
+            },
+            defs
+        );
+    }
 }

--- a/near-sdk/src/store/unordered_map/mod.rs
+++ b/near-sdk/src/store/unordered_map/mod.rs
@@ -90,18 +90,26 @@ use super::{FreeList, LookupMap, ERR_INCONSISTENT_STATE, ERR_NOT_EXIST};
     since = "5.0.0",
     note = "Suboptimal iteration performance. See performance considerations doc for details."
 )]
-#[derive(BorshDeserialize, BorshSerialize)]
+#[near(inside_nearsdk)]
 pub struct UnorderedMap<K, V, H = Sha256>
 where
     K: BorshSerialize + Ord,
     V: BorshSerialize,
     H: ToKey,
 {
-    // ser/de is independent of `K` ser/de, `BorshSerialize`/`BorshDeserialize` bounds removed
-    #[borsh(bound(serialize = "", deserialize = ""))]
+    // ser/de is independent of `K` ser/de, `BorshSerialize`/`BorshDeserialize`/`BorshSchema` bounds removed
+    #[cfg_attr(not(feature = "abi"), borsh(bound(serialize = "", deserialize = "")))]
+    #[cfg_attr(
+        feature = "abi",
+        borsh(bound(serialize = "", deserialize = ""), schema(params = ""))
+    )]
     keys: FreeList<K>,
-    // ser/de is independent of `K`, `V`, `H` ser/de, `BorshSerialize`/`BorshDeserialize` bounds removed
-    #[borsh(bound(serialize = "", deserialize = ""))]
+    // ser/de is independent of `K`, `V`, `H` ser/de, `BorshSerialize`/`BorshDeserialize`/`BorshSchema` bounds removed
+    #[cfg_attr(not(feature = "abi"), borsh(bound(serialize = "", deserialize = "")))]
+    #[cfg_attr(
+        feature = "abi",
+        borsh(bound(serialize = "", deserialize = ""), schema(params = ""))
+    )]
     values: LookupMap<K, ValueAndIndex<V>, H>,
 }
 


### PR DESCRIPTION
checked against [test_unord_map_contract](https://github.com/dj8yfo/test_unord_map_contract/tree/master)

```bash
• Building contract
 │    Compiling test_contract v0.1.0 (/home/user/Documents/code/test_contract)
 │ warning: unused import: `log`
 │  --> src/lib.rs:1:16
 │   |
 │ 1 | use near_sdk::{log, near};
 │   |                ^^^
 │   |
 │   = note: `#[warn(unused_imports)]` on by default
 │
 │ warning: use of deprecated struct `near_sdk::store::UnorderedMap`: Suboptimal iteration performance. See performance considerations doc for details.
 │  --> src/lib.rs:5:33
 │   |
 │ 5 |     greetings: near_sdk::store::UnorderedMap<String, String>,
 │   |                                 ^^^^^^^^^^^^
 │   |
 │   = note: `#[warn(deprecated)]` on by default
 │
 │ warning: use of deprecated struct `near_sdk::store::UnorderedMap`: Suboptimal iteration performance. See performance considerations doc for details.
 │   --> src/lib.rs:11:41
 │    |
 │ 11 |             greetings: near_sdk::store::UnorderedMap::new(b"g"),
 │    |                                         ^^^^^^^^^^^^
 │
 │ warning: `test_contract` (lib) generated 3 warnings (run `cargo fix --lib -p test_contract` to apply 1 suggestion)
 │     Finished `release` profile [optimized] target(s) in 0.31s
✓ Contract successfully built! (in CARGO_NEAR_BUILD_ENVIRONMENT=host)
```

