### PR TITLE
chore: replace `NearSchema` with `near(inside_near_sdk)`; add missing `BorshSchema` p2

### DIFF
--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -68,6 +68,7 @@ anyhow = "1.0"
 tokio = { version = "1", features = ["full"] }
 strum = "0.25.0"
 strum_macros = "0.25.3"
+insta = "1.39.0"
 
 [features]
 default = ["wee_alloc"]

--- a/near-sdk/compilation_tests/schema_derive.rs
+++ b/near-sdk/compilation_tests/schema_derive.rs
@@ -247,6 +247,7 @@ pub fn json_borsh_schema_spec() {
     const_assert_impls!(StructNoSchemaSpec: near_sdk::borsh::BorshSchema);
 }
 
+// original comment by @miraclx
 // fixme! this should fail, since A__NEAR_SCHEMA_PROXY does not derive NearSchema
 // fixme! hygeinic macro expansion is required to make this work
 // fixme! or just explicit checks, making sure that no ident is suffixed with
@@ -255,6 +256,25 @@ pub fn json_borsh_schema_spec() {
 #[allow(non_camel_case_types)]
 struct A__NEAR_SCHEMA_PROXY {}
 
+/// additional comment by @dj8yfo
+/// FIXME: VERY LOW PRIORITY, as such a camel case type if unlikely to be used in practice
+/// derive should fail, since the real A__NEAR_SCHEMA_PROXY type does not derive NearSchema 
+/// but it compiles and results in recursive definition
+///
+/// ```
+/// 	definitions: {
+/// 	    "A": Object(
+/// 	        SchemaObject {
+/// 				...
+/// 	            reference: Some(
+/// 	                "#/definitions/A",
+/// 	            ),
+/// 				...			
+/// 	        },
+/// 	    ),
+/// ```
+/// It compiles due to mutually recursive implementations of `NearSchema` for outer `A`,
+/// present in source code, and *hidden* inner `A`, present in derive macro expansion.
 #[derive(NearSchema)]
 struct A(A__NEAR_SCHEMA_PROXY);
 

--- a/near-sdk/src/store/free_list/mod.rs
+++ b/near-sdk/src/store/free_list/mod.rs
@@ -523,4 +523,21 @@ mod tests {
             }
         }
     }
+
+    #[cfg(feature = "abi")]
+    #[test]
+    fn test_borsh_schema() {
+        #[derive(
+            borsh::BorshSerialize, borsh::BorshDeserialize, PartialEq, Eq, PartialOrd, Ord,
+        )]
+        struct NoSchemaStruct;
+
+        assert_eq!(
+            "FreeList".to_string(),
+            <FreeList<NoSchemaStruct> as borsh::BorshSchema>::declaration()
+        );
+        let mut defs = Default::default();
+        <FreeList<NoSchemaStruct> as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+        insta::assert_snapshot!(format!("{:#?}", defs));
+    }
 }

--- a/near-sdk/src/store/free_list/mod.rs
+++ b/near-sdk/src/store/free_list/mod.rs
@@ -3,7 +3,7 @@ pub use self::iter::{Drain, Iter, IterMut};
 
 use super::{Vector, ERR_INCONSISTENT_STATE};
 use crate::{env, IntoStorageKey};
-use near_sdk_macros::{near, NearSchema};
+use near_sdk_macros::near;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
@@ -17,9 +17,7 @@ pub struct FreeListIndex(pub(crate) u32);
 /// Unordered container of values. This is similar to [`Vector`] except that values are not
 /// re-arranged on removal, keeping the indices consistent. When an element is removed, it will
 /// be replaced with an empty cell which will be populated on the next insertion.
-#[derive(NearSchema, BorshSerialize, BorshDeserialize)]
-#[inside_nearsdk]
-#[abi(borsh)]
+#[near(inside_nearsdk)]
 pub(crate) struct FreeList<T>
 where
     T: BorshSerialize,

--- a/near-sdk/src/store/free_list/snapshots/near_sdk__store__free_list__tests__borsh_schema.snap
+++ b/near-sdk/src/store/free_list/snapshots/near_sdk__store__free_list__tests__borsh_schema.snap
@@ -1,0 +1,84 @@
+---
+source: near-sdk/src/store/free_list/mod.rs
+expression: "format!(\"{:#?}\", defs)"
+---
+{
+    "()": Primitive(
+        0,
+    ),
+    "FreeList": Struct {
+        fields: NamedFields(
+            [
+                (
+                    "first_free",
+                    "Option<FreeListIndex>",
+                ),
+                (
+                    "occupied_count",
+                    "u32",
+                ),
+                (
+                    "elements",
+                    "Vector",
+                ),
+            ],
+        ),
+    },
+    "FreeListIndex": Struct {
+        fields: UnnamedFields(
+            [
+                "u32",
+            ],
+        ),
+    },
+    "IndexMap": Struct {
+        fields: NamedFields(
+            [
+                (
+                    "prefix",
+                    "Vec<u8>",
+                ),
+            ],
+        ),
+    },
+    "Option<FreeListIndex>": Enum {
+        tag_width: 1,
+        variants: [
+            (
+                0,
+                "None",
+                "()",
+            ),
+            (
+                1,
+                "Some",
+                "FreeListIndex",
+            ),
+        ],
+    },
+    "Vec<u8>": Sequence {
+        length_width: 4,
+        length_range: 0..=4294967295,
+        elements: "u8",
+    },
+    "Vector": Struct {
+        fields: NamedFields(
+            [
+                (
+                    "len",
+                    "u32",
+                ),
+                (
+                    "values",
+                    "IndexMap",
+                ),
+            ],
+        ),
+    },
+    "u32": Primitive(
+        4,
+    ),
+    "u8": Primitive(
+        1,
+    ),
+}

--- a/near-sdk/src/store/iterable_map/snapshots/near_sdk__store__iterable_map__test_map__borsh_schema.snap
+++ b/near-sdk/src/store/iterable_map/snapshots/near_sdk__store__iterable_map__test_map__borsh_schema.snap
@@ -1,0 +1,65 @@
+---
+source: near-sdk/src/store/iterable_map/mod.rs
+expression: "format!(\"{:#?}\", defs)"
+---
+{
+    "IndexMap": Struct {
+        fields: NamedFields(
+            [
+                (
+                    "prefix",
+                    "Vec<u8>",
+                ),
+            ],
+        ),
+    },
+    "IterableMap": Struct {
+        fields: NamedFields(
+            [
+                (
+                    "keys",
+                    "Vector",
+                ),
+                (
+                    "values",
+                    "LookupMap",
+                ),
+            ],
+        ),
+    },
+    "LookupMap": Struct {
+        fields: NamedFields(
+            [
+                (
+                    "prefix",
+                    "Vec<u8>",
+                ),
+            ],
+        ),
+    },
+    "Vec<u8>": Sequence {
+        length_width: 4,
+        length_range: 0..=4294967295,
+        elements: "u8",
+    },
+    "Vector": Struct {
+        fields: NamedFields(
+            [
+                (
+                    "len",
+                    "u32",
+                ),
+                (
+                    "values",
+                    "IndexMap",
+                ),
+            ],
+        ),
+    },
+    "u32": Primitive(
+        4,
+    ),
+    "u8": Primitive(
+        1,
+    ),
+}

--- a/near-sdk/src/store/iterable_set/snapshots/near_sdk__store__iterable_set__tests__borsh_schema.snap
+++ b/near-sdk/src/store/iterable_set/snapshots/near_sdk__store__iterable_set__tests__borsh_schema.snap
@@ -1,0 +1,65 @@
+---
+source: near-sdk/src/store/iterable_set/mod.rs
+expression: "format!(\"{:#?}\", defs)"
+---
+{
+    "IndexMap": Struct {
+        fields: NamedFields(
+            [
+                (
+                    "prefix",
+                    "Vec<u8>",
+                ),
+            ],
+        ),
+    },
+    "IterableSet": Struct {
+        fields: NamedFields(
+            [
+                (
+                    "elements",
+                    "Vector",
+                ),
+                (
+                    "index",
+                    "LookupMap",
+                ),
+            ],
+        ),
+    },
+    "LookupMap": Struct {
+        fields: NamedFields(
+            [
+                (
+                    "prefix",
+                    "Vec<u8>",
+                ),
+            ],
+        ),
+    },
+    "Vec<u8>": Sequence {
+        length_width: 4,
+        length_range: 0..=4294967295,
+        elements: "u8",
+    },
+    "Vector": Struct {
+        fields: NamedFields(
+            [
+                (
+                    "len",
+                    "u32",
+                ),
+                (
+                    "values",
+                    "IndexMap",
+                ),
+            ],
+        ),
+    },
+    "u32": Primitive(
+        4,
+    ),
+    "u8": Primitive(
+        1,
+    ),
+}

--- a/near-sdk/src/store/unordered_map/mod.rs
+++ b/near-sdk/src/store/unordered_map/mod.rs
@@ -850,26 +850,9 @@ mod tests {
         assert_eq!(map.remove_entry(&3).unwrap(), (3, 3));
     }
 
-    #[allow(unused)]
-    macro_rules! schema_map(
-        () => { BTreeMap::new() };
-        { $($key:expr => $value:expr),+ } => {
-            {
-                let mut m = BTreeMap::new();
-                $(
-                    m.insert($key.to_string(), $value);
-                )+
-                m
-            }
-         };
-    );
-
     #[cfg(feature = "abi")]
     #[test]
     fn test_borsh_schema() {
-        use borsh::schema::{Definition, Fields};
-        use std::collections::BTreeMap;
-
         #[derive(
             borsh::BorshSerialize, borsh::BorshDeserialize, PartialEq, Eq, PartialOrd, Ord,
         )]
@@ -881,102 +864,7 @@ mod tests {
         );
         let mut defs = Default::default();
         <UnorderedMap<NoSchemaStruct, NoSchemaStruct> as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
-        println!("{:#?}", defs);
-        assert_eq!(
-            schema_map! {
-                "UnorderedMap" => Definition::Struct {
-                    fields: Fields::NamedFields(vec![
-                        (
-                            "keys".to_string(),
-                            "FreeList".to_string(),
-                        ),
-                        (
-                            "values".to_string(),
-                            "LookupMap".to_string(),
-                        ),
-                    ]
-                )},
-                "FreeList" => Definition::Struct {
-                    fields: Fields::NamedFields(vec![
-                        (
-                            "first_free".to_string(),
-                            "Option<FreeListIndex>".to_string(),
-                        ),
-                        (
-                            "occupied_count".to_string(),
-                            "u32".to_string(),
-                        ),
-                        (
-                            "elements".to_string(),
-                            "Vector".to_string(),
-                        ),
-                    ]
-                )},
-                "Option<FreeListIndex>" => Definition::Enum {
-                    tag_width: 1,
-                    variants:  vec![
-                        (
-                            0,
-                            "None".to_string(),
-                            "()".to_string(),
-                        ),
-                        (
-                            1,
-                            "Some".to_string(),
-                            "FreeListIndex".to_string(),
-                        ),
-                ]},
-                "()" => Definition::Primitive(0),
-                "FreeListIndex" => Definition::Struct {
-                    fields: Fields::UnnamedFields(
-                        vec![
-                            "u32".to_string(),
-                        ],
-                    ),
-                },
-                "u32" => Definition::Primitive(4 ),
-                "Vector" => Definition::Struct {
-                    fields: Fields::NamedFields(
-                        vec![
-                            (
-                                "len".to_string(),
-                                "u32".to_string(),
-                            ),
-                            (
-                                "values".to_string(),
-                                "IndexMap".to_string(),
-                            ),
-                        ],
-                    ),
-                },
-                "IndexMap" => Definition::Struct {
-                    fields: Fields::NamedFields(
-                        vec![
-                            (
-                                "prefix".to_string(),
-                                "Vec<u8>".to_string(),
-                            ),
-                        ],
-                    ),
-                },
-                "Vec<u8>" => Definition::Sequence {
-                    length_width: 4,
-                    length_range: 0..=4294967295,
-                    elements: "u8".to_string(),
-                },
-                "u8" => Definition::Primitive(1),
-                "LookupMap" => Definition::Struct {
-                    fields: Fields::NamedFields(
-                        vec![
-                            (
-                                "prefix".to_string(),
-                                "Vec<u8>".to_string(),
-                            ),
-                        ],
-                    ),
-                }
-            },
-            defs
-        );
+
+        insta::assert_snapshot!(format!("{:#?}", defs));
     }
 }

--- a/near-sdk/src/store/unordered_map/snapshots/near_sdk__store__unordered_map__tests__borsh_schema.snap
+++ b/near-sdk/src/store/unordered_map/snapshots/near_sdk__store__unordered_map__tests__borsh_schema.snap
@@ -1,0 +1,108 @@
+---
+source: near-sdk/src/store/unordered_map/mod.rs
+expression: "format!(\"{:#?}\", defs)"
+---
+{
+    "()": Primitive(
+        0,
+    ),
+    "FreeList": Struct {
+        fields: NamedFields(
+            [
+                (
+                    "first_free",
+                    "Option<FreeListIndex>",
+                ),
+                (
+                    "occupied_count",
+                    "u32",
+                ),
+                (
+                    "elements",
+                    "Vector",
+                ),
+            ],
+        ),
+    },
+    "FreeListIndex": Struct {
+        fields: UnnamedFields(
+            [
+                "u32",
+            ],
+        ),
+    },
+    "IndexMap": Struct {
+        fields: NamedFields(
+            [
+                (
+                    "prefix",
+                    "Vec<u8>",
+                ),
+            ],
+        ),
+    },
+    "LookupMap": Struct {
+        fields: NamedFields(
+            [
+                (
+                    "prefix",
+                    "Vec<u8>",
+                ),
+            ],
+        ),
+    },
+    "Option<FreeListIndex>": Enum {
+        tag_width: 1,
+        variants: [
+            (
+                0,
+                "None",
+                "()",
+            ),
+            (
+                1,
+                "Some",
+                "FreeListIndex",
+            ),
+        ],
+    },
+    "UnorderedMap": Struct {
+        fields: NamedFields(
+            [
+                (
+                    "keys",
+                    "FreeList",
+                ),
+                (
+                    "values",
+                    "LookupMap",
+                ),
+            ],
+        ),
+    },
+    "Vec<u8>": Sequence {
+        length_width: 4,
+        length_range: 0..=4294967295,
+        elements: "u8",
+    },
+    "Vector": Struct {
+        fields: NamedFields(
+            [
+                (
+                    "len",
+                    "u32",
+                ),
+                (
+                    "values",
+                    "IndexMap",
+                ),
+            ],
+        ),
+    },
+    "u32": Primitive(
+        4,
+    ),
+    "u8": Primitive(
+        1,
+    ),
+}

--- a/near-sdk/src/store/vec/mod.rs
+++ b/near-sdk/src/store/vec/mod.rs
@@ -1003,4 +1003,21 @@ mod tests {
         let vec = Vector::<String>::deserialize(&mut serialized.as_slice()).unwrap();
         assert_eq!(vec[0], "Some data");
     }
+
+    #[cfg(feature = "abi")]
+    #[test]
+    fn test_borsh_schema() {
+        #[derive(
+            borsh::BorshSerialize, borsh::BorshDeserialize, PartialEq, Eq, PartialOrd, Ord,
+        )]
+        struct NoSchemaStruct;
+
+        assert_eq!(
+            "Vector".to_string(),
+            <Vector<NoSchemaStruct> as borsh::BorshSchema>::declaration()
+        );
+        let mut defs = Default::default();
+        <Vector<NoSchemaStruct> as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+        insta::assert_snapshot!(format!("{:#?}", defs));
+    }
 }

--- a/near-sdk/src/store/vec/mod.rs
+++ b/near-sdk/src/store/vec/mod.rs
@@ -61,7 +61,7 @@ use std::{
 };
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use near_sdk_macros::NearSchema;
+use near_sdk_macros::near;
 
 pub use self::iter::{Drain, Iter, IterMut};
 use super::ERR_INCONSISTENT_STATE;
@@ -112,9 +112,7 @@ fn expect_consistent_state<T>(val: Option<T>) -> T {
 /// vec.extend([1, 2, 3].iter().copied());
 /// assert!(Iterator::eq(vec.into_iter(), [7, 1, 2, 3].iter()));
 /// ```
-#[derive(NearSchema, BorshSerialize, BorshDeserialize)]
-#[inside_nearsdk]
-#[abi(borsh)]
+#[near(inside_nearsdk)]
 pub struct Vector<T>
 where
     T: BorshSerialize,

--- a/near-sdk/src/store/vec/snapshots/near_sdk__store__vec__tests__borsh_schema.snap
+++ b/near-sdk/src/store/vec/snapshots/near_sdk__store__vec__tests__borsh_schema.snap
@@ -1,0 +1,41 @@
+---
+source: near-sdk/src/store/vec/mod.rs
+expression: "format!(\"{:#?}\", defs)"
+---
+{
+    "IndexMap": Struct {
+        fields: NamedFields(
+            [
+                (
+                    "prefix",
+                    "Vec<u8>",
+                ),
+            ],
+        ),
+    },
+    "Vec<u8>": Sequence {
+        length_width: 4,
+        length_range: 0..=4294967295,
+        elements: "u8",
+    },
+    "Vector": Struct {
+        fields: NamedFields(
+            [
+                (
+                    "len",
+                    "u32",
+                ),
+                (
+                    "values",
+                    "IndexMap",
+                ),
+            ],
+        ),
+    },
+    "u32": Primitive(
+        4,
+    ),
+    "u8": Primitive(
+        1,
+    ),
+}


### PR DESCRIPTION
## Replace `#[derive(NearSchema)]` with `#[near(inside_nearsdk)]`


<details>
  <summary>for `near_sdk::store::free_list::FreeList<T>`</summary><p>
  
from 

```rust
            impl<T> crate::borsh::BorshSchema for FreeList<T>
            impl<T> crate::borsh::BorshSchema for FreeList__NEAR_SCHEMA_PROXY<T>
    impl<T> borsh::ser::BorshSerialize for FreeList<T>
    impl<T> borsh::de::BorshDeserialize for FreeList<T>
```
to

```rust
    impl<T> crate::borsh::ser::BorshSerialize for FreeList<T>
    impl<T> crate::borsh::de::BorshDeserialize for FreeList<T>
    impl<T> crate::borsh::BorshSchema for FreeList<T>
```

</p></details>

<details>
  <summary>for `near_sdk::store::vec::Vector<T>`</summary><p>
  
from

```rust
            impl<T> crate::borsh::BorshSchema for Vector<T>
            impl<T> crate::borsh::BorshSchema for Vector__NEAR_SCHEMA_PROXY<T>
    impl<T> borsh::ser::BorshSerialize for Vector<T>
    impl<T> borsh::de::BorshDeserialize for Vector<T>
```
to

```rust
    impl<T> crate::borsh::ser::BorshSerialize for Vector<T>
    impl<T> crate::borsh::de::BorshDeserialize for Vector<T>
    impl<T> crate::borsh::BorshSchema for Vector<T>
```

</p></details>

## Add missing `#[derive(BorshSchema)]` via `#[near(inside_nearsdk)]`

1. for `IterableSet<T, H = Sha256>`
2. for `IterableMap<K, V, H = Sha256>`
