### PR TITLE
fix(nep330): return fallback vals of `CARGO_PKG_REPOSITORY` and `CARGO_PKG_VERSION`

### DIFF
--- a/near-sdk-macros/src/core_impl/contract_metadata/mod.rs
+++ b/near-sdk-macros/src/core_impl/contract_metadata/mod.rs
@@ -56,13 +56,17 @@ struct Standard {
 impl ContractMetadata {
     fn populate(mut self) -> Self {
         if self.link.is_none() {
-            let field_val = std::env::var("NEP330_LINK").unwrap_or(String::from(""));
+            let field_val = std::env::var("NEP330_LINK")
+                .or(std::env::var("CARGO_PKG_REPOSITORY"))
+                .unwrap_or(String::from(""));
             if !field_val.is_empty() {
                 self.link = Some(field_val);
             }
         }
         if self.version.is_none() {
-            let field_val = std::env::var("NEP330_VERSION").unwrap_or(String::from(""));
+            let field_val = std::env::var("NEP330_VERSION")
+                .or(std::env::var("CARGO_PKG_VERSION"))
+                .unwrap_or(String::from(""));
             if !field_val.is_empty() {
                 self.version = Some(field_val);
             }


### PR DESCRIPTION


To avoid problems on older `<0.7.0` `cargo-near` versions

checked on  `cargo-near-near 0.6.2` 
before

```bash
near contract inspect before-cargo-pkg-fix.testnet network-config testnet now  
```
and after 

```bash
near contract inspect after-cargo-pkg-fix.testnet network-config testnet now
```

checked on potential `cargo-near-near 0.7.0` from [branch](https://github.com/near/cargo-near/tree/source-scan-integration)
after

(docker)
```bash
near contract inspect sample-crate-14.testnet network-config testnet now
```

--no-docker
```bash
near contract inspect sample-crate-15.testnet network-config testnet now
```



