### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [5.2.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.2.0...near-sdk-v5.2.1) - 2024-07-05
+
+### Fixed
+- *(nep330)* Fallback to `CARGO_PKG_REPOSITORY` and `CARGO_PKG_VERSION` when `NEP330_*` variables are not provided ([#1215](https://github.com/near/near-sdk-rs/pull/1215))
+
 ## [5.2.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.1.0...near-sdk-v5.2.0) - 2024-07-04
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.2.0"
+version = "5.2.1"
 
 # Special triple # comment for ci.
 [patch.crates-io]

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.2.0", default-features = false, features = ["legacy"] }
+near-sdk = { path = "../near-sdk", version = "~5.2.1", default-features = false, features = ["legacy"] }
 
 [dev-dependencies]
 near-sdk = { path = "../near-sdk", default-features = false, features = ["unit-testing"] }

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.2.0" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.2.1" }
 near-sys = { path = "../near-sys", version = "0.2.2" }
 base64 = "0.21"
 borsh = { version = "1.0.0", features = ["derive"] }


### PR DESCRIPTION
## 🤖 New release
* `near-sdk`: 5.2.0 -> 5.2.1
* `near-sdk-macros`: 5.2.0 -> 5.2.1
* `near-contract-standards`: 5.2.0 -> 5.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-sdk`
<blockquote>

## [5.2.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.2.0...near-sdk-v5.2.1) - 2024-07-05

### Fixed
- *(nep330)* Fallback to `CARGO_PKG_REPOSITORY` and `CARGO_PKG_VERSION` when `NEP330_*` variables are not provided ([#1215](https://github.com/near/near-sdk-rs/pull/1215))
</blockquote>

## `near-contract-standards`
<blockquote>

## [5.2.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.1.0...near-contract-standards-v5.2.0) - 2024-07-04

### Added
- Exported `ext_storage_management` Promise shortcuts, so Storage Management interfaces can be used in contracts to call external contracts using the high-level cross-contract call interfaces ([#1208](https://github.com/near/near-sdk-rs/pull/1208))
- Exported `ext_nft_*` Promise shortcuts, so NFT interfaces can be re-used in contracts to call external NFT contracts using the high-level cross-contract call interfaces ([#1206](https://github.com/near/near-sdk-rs/pull/1206))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).