### PR TITLE
1160: Fix storage management error message with proper amount

### DIFF
--- a/near-contract-standards/src/non_fungible_token/utils.rs
+++ b/near-contract-standards/src/non_fungible_token/utils.rs
@@ -33,7 +33,7 @@ pub fn refund_deposit_to_account(storage_used: u64, account_id: AccountId) {
 
     require!(
         required_cost <= attached_deposit,
-        format!("Must attach {} yoctoNEAR to cover storage", required_cost.exact_amount_display())
+        format!("Must attach {} to cover storage", required_cost.exact_amount_display())
     );
 
     let refund = attached_deposit.saturating_sub(required_cost);

--- a/near-contract-standards/src/non_fungible_token/utils.rs
+++ b/near-contract-standards/src/non_fungible_token/utils.rs
@@ -33,7 +33,7 @@ pub fn refund_deposit_to_account(storage_used: u64, account_id: AccountId) {
 
     require!(
         required_cost <= attached_deposit,
-        format!("Must attach {} yoctoNEAR to cover storage", required_cost)
+        format!("Must attach {} yoctoNEAR to cover storage", required_cost.exact_amount_display())
     );
 
     let refund = attached_deposit.saturating_sub(required_cost);

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -32,7 +32,7 @@ once_cell = { version = "1.17", default-features = false }
 
 near-account-id = { version = "1.0.0", features = ["serde", "borsh"] }
 near-gas = { version = "0.2.3", features = ["serde", "borsh"] }
-near-token = { version = "0.2.0", features = ["serde", "borsh"] }
+near-token = { version = "0.2.1", features = ["serde", "borsh"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wee_alloc = { version = "0.4.5", default-features = false, optional = true }


### PR DESCRIPTION
### Description 

- This PR fix issue [#1160 ](https://github.com/near/near-sdk-rs/issues/1160)from [near-sdk ]( https://github.com/near/near-sdk-rs/)

- Need to add the `exact_amount_display` method to format `yoctoNEAR` values for clearer error message 
- This requires the [Near-token pull request](https://github.com/near/near-token-rs/pull/9) to be merged first.

### Implementation 

- Added `exact_amount_display`  to format `NearToken` values
