### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+## [5.3.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.2.1...near-sdk-v5.3.0) - 2024-08-13
+
+### Added
+- Introduced 'remove' method for 'near_sdk::store::Lazy' collection ([#1238](https://github.com/near/near-sdk-rs/pull/1238))
+- Allow store collection iterators to be cloned (this enables standard Iterator methods like `cycle()`) ([#1224](https://github.com/near/near-sdk-rs/pull/1224))
+
+### Fixed
+- Fix storage management error message with proper amount ([#1222](https://github.com/near/near-sdk-rs/pull/1222))
+- Fixed compilation errors after Rust 1.80 latest stable release ([#1227](https://github.com/near/near-sdk-rs/pull/1227))
+
+### Other
+- updates near-* dependencies to 0.24.0 ([#1237](https://github.com/near/near-sdk-rs/pull/1237))
+- Include all examples into CI testing suite ([#1228](https://github.com/near/near-sdk-rs/pull/1228))
+- Optimized up to 10% contract binary size by using `near_sdk::env::panic_str` instead of `expect` calls ([#1220](https://github.com/near/near-sdk-rs/pull/1220))
+- Fixed Rust 1.80 new warning by adding `cargo:rustc-check-cfg` for `__abi-embed-checked` feature in `near-sdk-macros` build.rs ([#1225](https://github.com/near/near-sdk-rs/pull/1225))
+
 ## [5.2.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.2.0...near-sdk-v5.2.1) - 2024-07-05
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.2.1"
+version = "5.3.0"
 
 # Special triple # comment for ci.
 [patch.crates-io]

--- a/near-contract-standards/CHANGELOG.md
+++ b/near-contract-standards/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.3.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.2.1...near-contract-standards-v5.3.0) - 2024-08-13
+
+### Fixed
+- Fix storage management error message with proper amount ([#1222](https://github.com/near/near-sdk-rs/pull/1222))
+
 ## [5.2.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.1.0...near-contract-standards-v5.2.0) - 2024-07-04
 
 ### Added

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.2.1", default-features = false, features = ["legacy"] }
+near-sdk = { path = "../near-sdk", version = "~5.3.0", default-features = false, features = ["legacy"] }
 
 [dev-dependencies]
 near-sdk = { path = "../near-sdk", default-features = false, features = ["unit-testing"] }

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.2.1" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.3.0" }
 near-sys = { path = "../near-sys", version = "0.2.2" }
 base64 = "0.21"
 borsh = { version = "1.0.0", features = ["derive"] }


### PR DESCRIPTION
## 🤖 New release
* `near-sdk`: 5.2.1 -> 5.3.0
* `near-sdk-macros`: 5.2.1 -> 5.3.0
* `near-contract-standards`: 5.2.1 -> 5.3.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-sdk`
<blockquote>

## [5.3.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.2.1...near-sdk-v5.3.0) - 2024-08-13

### Added
- Introduced 'remove' method for 'near_sdk::store::Lazy' collection ([#1238](https://github.com/near/near-sdk-rs/pull/1238))
- Allow store collection iterators to be cloned (this enables standard Iterator methods like `cycle()`) ([#1224](https://github.com/near/near-sdk-rs/pull/1224))

### Fixed
- Fix storage management error message with proper amount ([#1222](https://github.com/near/near-sdk-rs/pull/1222))
- Fixed compilation errors after Rust 1.80 latest stable release ([#1227](https://github.com/near/near-sdk-rs/pull/1227))

### Other
- updates near-* dependencies to 0.24.0 ([#1237](https://github.com/near/near-sdk-rs/pull/1237))
- Include all examples into CI testing suite ([#1228](https://github.com/near/near-sdk-rs/pull/1228))
- Optimized up to 10% contract binary size by using `near_sdk::env::panic_str` instead of `expect` calls ([#1220](https://github.com/near/near-sdk-rs/pull/1220))
- Fixed Rust 1.80 new warning by adding `cargo:rustc-check-cfg` for `__abi-embed-checked` feature in `near-sdk-macros` build.rs ([#1225](https://github.com/near/near-sdk-rs/pull/1225))
</blockquote>

## `near-contract-standards`
<blockquote>

## [5.3.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.2.1...near-contract-standards-v5.3.0) - 2024-08-13

### Fixed
- Fix storage management error message with proper amount ([#1222](https://github.com/near/near-sdk-rs/pull/1222))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).