### PR TITLE
Fix CI workflow and examples tests

### DIFF
--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -14,7 +14,14 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macos-latest]
         toolchain: [stable]
-        example: [cross-contract-calls, fungible-token]
+        example: [
+          cross-contract-calls, 
+          fungible-token, 
+          non-fungible-token,
+          versioned,
+          oracle,
+          staking-pool
+        ]
     steps:
       - uses: actions/checkout@v3
       - name: "${{ matrix.toolchain }} with rustfmt, and wasm32"

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -16,7 +16,7 @@ jobs:
         toolchain: [stable]
         example: [
           adder,
-          callback-result,
+          callback-results,
           cross-contract-calls,
           factory-contract,
           fungible-token,

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -16,7 +16,7 @@ jobs:
         toolchain: [stable]
         example: [
           adder,
-          callback-result
+          callback-result,
           cross-contract-calls,
           factory-contract,
           fungible-token,

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -15,12 +15,13 @@ jobs:
         platform: [ubuntu-latest, macos-latest]
         toolchain: [stable]
         example: [
-          cross-contract-calls, 
-          fungible-token, 
+          adder,
+          callback-result
+          cross-contract-calls,
+          factory-contract,
+          fungible-token,
           non-fungible-token,
-          versioned,
-          oracle,
-          staking-pool
+          versioned          
         ]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -34,9 +34,18 @@ jobs:
       - uses: Swatinem/rust-cache@v1
         with:
           working-directory: ./examples/${{ matrix.example }}
+      - name: Build status-message
+        if: matrix.example == 'factory-contract'
+        env:
+          RUSTFLAGS: '-C link-arg=-s'
+        run: |
+          cargo +${{ matrix.toolchain }} build --manifest-path="./examples/status-message/Cargo.toml" --target wasm32-unknown-unknown --release --all &&
+          cp ./examples/status-message/target/wasm32-unknown-unknown/release/*.wasm ./examples/status-message/res/
       - name: Build
         env:
           RUSTFLAGS: '-C link-arg=-s'
-        run: cargo +${{ matrix.toolchain }} build --manifest-path=./examples/${{matrix.example}}/Cargo.toml --target wasm32-unknown-unknown --release --all && cp ./examples/${{matrix.example}}/target/wasm32-unknown-unknown/release/*.wasm ./examples/${{matrix.example}}/res/
+        run: |
+          cargo +${{ matrix.toolchain }} build --manifest-path="./examples/${{matrix.example}}/Cargo.toml" --target wasm32-unknown-unknown --release --all &&
+          cp ./examples/${{matrix.example}}/target/wasm32-unknown-unknown/release/*.wasm ./examples/${{matrix.example}}/res/
       - name: Test
-        run: cargo +${{ matrix.toolchain }} test  --manifest-path=./examples/${{ matrix.example }}/Cargo.toml --all
+        run: cargo +${{ matrix.toolchain }} test --manifest-path="./examples/${{ matrix.example }}/Cargo.toml" --all

--- a/.github/workflows/test_examples_small.yml
+++ b/.github/workflows/test_examples_small.yml
@@ -46,4 +46,4 @@ jobs:
           RUSTFLAGS: '-C link-arg=-s'
         run: cargo +${{ matrix.toolchain }} build --manifest-path=./examples/test-contract/Cargo.toml --target wasm32-unknown-unknown --release --all && cp ./examples/test-contract/target/wasm32-unknown-unknown/release/*.wasm ./examples/test-contract/res/
       - name: Test test-contract
-        run: cargo +${{ matrix.toolchain }} test  --manifest-path=./examples/test-contract/Cargo.toml --all      
+        run: cargo +${{ matrix.toolchain }} test  --manifest-path=./examples/test-contract/Cargo.toml --all

--- a/.github/workflows/test_examples_small.yml
+++ b/.github/workflows/test_examples_small.yml
@@ -47,3 +47,9 @@ jobs:
         run: cargo +${{ matrix.toolchain }} build --manifest-path=./examples/test-contract/Cargo.toml --target wasm32-unknown-unknown --release --all && cp ./examples/test-contract/target/wasm32-unknown-unknown/release/*.wasm ./examples/test-contract/res/
       - name: Test test-contract
         run: cargo +${{ matrix.toolchain }} test  --manifest-path=./examples/test-contract/Cargo.toml --all
+      - name: Build guest-book
+        env:
+          RUSTFLAGS: '-C link-arg=-s'
+        run: cargo +${{ matrix.toolchain }} build --manifest-path=./examples/guest-book/Cargo.toml --target wasm32-unknown-unknown --release --all && cp ./examples/guest-book/target/wasm32-unknown-unknown/release/*.wasm ./examples/guest-book/res/
+      - name: Test guest-book
+        run: cargo +${{ matrix.toolchain }} test  --manifest-path=./examples/guest-book/Cargo.toml --all

--- a/.github/workflows/test_examples_small.yml
+++ b/.github/workflows/test_examples_small.yml
@@ -46,10 +46,4 @@ jobs:
           RUSTFLAGS: '-C link-arg=-s'
         run: cargo +${{ matrix.toolchain }} build --manifest-path=./examples/test-contract/Cargo.toml --target wasm32-unknown-unknown --release --all && cp ./examples/test-contract/target/wasm32-unknown-unknown/release/*.wasm ./examples/test-contract/res/
       - name: Test test-contract
-        run: cargo +${{ matrix.toolchain }} test  --manifest-path=./examples/test-contract/Cargo.toml --all
-      - name: Build guest-book
-        env:
-          RUSTFLAGS: '-C link-arg=-s'
-        run: cargo +${{ matrix.toolchain }} build --manifest-path=./examples/guest-book/Cargo.toml --target wasm32-unknown-unknown --release --all && cp ./examples/guest-book/target/wasm32-unknown-unknown/release/*.wasm ./examples/guest-book/res/
-      - name: Test guest-book
-        run: cargo +${{ matrix.toolchain }} test  --manifest-path=./examples/guest-book/Cargo.toml --all
+        run: cargo +${{ matrix.toolchain }} test  --manifest-path=./examples/test-contract/Cargo.toml --all      

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ Ensure the following are satisfied before opening a PR:
 
 - The `git-hooks.sh` script has been run to install the git hooks.
 - Code is formatted with `rustfmt` by running `cargo fmt`
+- Before running the tests, ensure that all example `.wasm` files are built by executing [./examples/build_all.sh](./examples/build_all.sh)
 - Run all tests and linters with [./run-tests.sh](./run-tests.sh)
 - Ensure any new functionality is adequately tested
 - If any new public types or functions are added, ensure they have appropriate [rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) documentation

--- a/examples/factory-contract/tests/workspaces.rs
+++ b/examples/factory-contract/tests/workspaces.rs
@@ -9,9 +9,7 @@ async fn test_deploy_status_message(contract_name: &str) -> anyhow::Result<()> {
     let contract =
         worker.dev_deploy(&std::fs::read(format!("res/{}.wasm", contract_name))?).await?;
 
-    // Needed because of 32 character minimum for TLA
-    // https://docs.near.org/docs/concepts/account#top-level-accounts
-    let status_id: AccountId = "status-top-level-account-long-name".parse()?;
+    let status_id: AccountId = format!("status.{}", contract.id()).parse()?;
     let status_amt = NearToken::from_near(20);
     let res = contract
         .call("deploy_status_message")

--- a/examples/non-fungible-token/Cargo.toml
+++ b/examples/non-fungible-token/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dev-dependencies]
 anyhow = "1.0"
 near-contract-standards = { path = "../../near-contract-standards" }
-near-sdk = { path = "../../near-sdk" }
+near-sdk = { path = "../../near-sdk", features = ["unit-testing"]  }
 tokio = { version = "1.14", features = ["full"] }
 near-workspaces = "0.11.0"
 

--- a/examples/non-fungible-token/test-approval-receiver/src/lib.rs
+++ b/examples/non-fungible-token/test-approval-receiver/src/lib.rs
@@ -15,7 +15,7 @@ pub struct ApprovalReceiver {
 }
 
 // Have to repeat the same trait for our own implementation.
-trait ValueReturnTrait {
+pub trait ValueReturnTrait {
     fn ok_go(&self, msg: String) -> PromiseOrValue<String>;
 }
 

--- a/examples/non-fungible-token/test-token-receiver/src/lib.rs
+++ b/examples/non-fungible-token/test-token-receiver/src/lib.rs
@@ -15,7 +15,7 @@ pub struct TokenReceiver {
 }
 
 // Have to repeat the same trait for our own implementation.
-trait ValueReturnTrait {
+pub trait ValueReturnTrait {
     fn ok_go(&self, return_it: bool) -> PromiseOrValue<bool>;
 }
 

--- a/examples/versioned/Cargo.toml
+++ b/examples/versioned/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = { path = "../../near-sdk", features = ["unstable"] }
+near-sdk = { path = "../../near-sdk", features = ["unstable", "unit-testing"] }
 
 [profile.release]
 codegen-units = 1

--- a/examples/versioned/src/lib.rs
+++ b/examples/versioned/src/lib.rs
@@ -1,4 +1,4 @@
-use near_sdk::store::LookupMap;
+use near_sdk::store::IterableMap;
 use near_sdk::{env, log, near, AccountId, NearToken};
 
 /// An example of a versioned contract. This is a simple contract that tracks how much
@@ -30,7 +30,7 @@ impl VersionedContract {
         }
     }
 
-    fn funders(&self) -> &LookupMap<AccountId, NearToken> {
+    fn funders(&self) -> &IterableMap<AccountId, NearToken> {
         match self {
             Self::V0(contract) => &contract.funders,
             Self::V1(contract) => &contract.funders,
@@ -46,24 +46,24 @@ impl Default for VersionedContract {
 
 #[near]
 pub struct ContractV0 {
-    funders: LookupMap<AccountId, NearToken>,
+    funders: IterableMap<AccountId, NearToken>,
 }
 
 impl Default for ContractV0 {
     fn default() -> Self {
-        Self { funders: LookupMap::new(b"f") }
+        Self { funders: IterableMap::new(b"f") }
     }
 }
 
 #[near]
 pub struct Contract {
-    funders: LookupMap<AccountId, NearToken>,
+    funders: IterableMap<AccountId, NearToken>,
     nonce: u64,
 }
 
 impl Default for Contract {
     fn default() -> Self {
-        Self { funders: LookupMap::new(b"f"), nonce: 0 }
+        Self { funders: IterableMap::new(b"f"), nonce: 0 }
     }
 }
 
@@ -128,7 +128,7 @@ mod tests {
     #[test]
     fn contract_v0_interactions() {
         let mut contract = {
-            let mut funders = LookupMap::new(b"f");
+            let mut funders = IterableMap::new(b"f");
             funders.insert(bob(), NearToken::from_yoctonear(8));
             VersionedContract::V0(ContractV0 { funders })
         };

--- a/examples/versioned/src/lib.rs
+++ b/examples/versioned/src/lib.rs
@@ -1,4 +1,4 @@
-use near_sdk::store::UnorderedMap;
+use near_sdk::store::LookupMap;
 use near_sdk::{env, log, near, AccountId, NearToken};
 
 /// An example of a versioned contract. This is a simple contract that tracks how much
@@ -30,7 +30,7 @@ impl VersionedContract {
         }
     }
 
-    fn funders(&self) -> &UnorderedMap<AccountId, NearToken> {
+    fn funders(&self) -> &LookupMap<AccountId, NearToken> {
         match self {
             Self::V0(contract) => &contract.funders,
             Self::V1(contract) => &contract.funders,
@@ -46,24 +46,24 @@ impl Default for VersionedContract {
 
 #[near]
 pub struct ContractV0 {
-    funders: UnorderedMap<AccountId, NearToken>,
+    funders: LookupMap<AccountId, NearToken>,
 }
 
 impl Default for ContractV0 {
     fn default() -> Self {
-        Self { funders: UnorderedMap::new(b"f") }
+        Self { funders: LookupMap::new(b"f") }
     }
 }
 
 #[near]
 pub struct Contract {
-    funders: UnorderedMap<AccountId, NearToken>,
+    funders: LookupMap<AccountId, NearToken>,
     nonce: u64,
 }
 
 impl Default for Contract {
     fn default() -> Self {
-        Self { funders: UnorderedMap::new(b"f"), nonce: 0 }
+        Self { funders: LookupMap::new(b"f"), nonce: 0 }
     }
 }
 
@@ -128,7 +128,7 @@ mod tests {
     #[test]
     fn contract_v0_interactions() {
         let mut contract = {
-            let mut funders = UnorderedMap::new(b"f");
+            let mut funders = LookupMap::new(b"f");
             funders.insert(bob(), NearToken::from_yoctonear(8));
             VersionedContract::V0(ContractV0 { funders })
         };

--- a/near-sdk/src/store/unordered_map/mod.rs
+++ b/near-sdk/src/store/unordered_map/mod.rs
@@ -88,7 +88,7 @@ use super::{FreeList, LookupMap, ERR_INCONSISTENT_STATE, ERR_NOT_EXIST};
 /// [`with_hasher`]: Self::with_hasher
 #[deprecated(
     since = "5.0.0",
-    note = "Suboptimal iteration performance. See performance considerations doc for details."
+    note = "Suboptimal iteration performance. See performance considerations doc for details. Consider using IterableMap instead (WARNING: manual storage migration is required if contract was previously deployed)"
 )]
 #[near(inside_nearsdk)]
 pub struct UnorderedMap<K, V, H = Sha256>

--- a/near-sdk/src/store/unordered_set/mod.rs
+++ b/near-sdk/src/store/unordered_set/mod.rs
@@ -91,7 +91,7 @@ use std::fmt;
 #[near(inside_nearsdk)]
 #[deprecated(
     since = "5.0.0",
-    note = "Suboptimal iteration performance. See performance considerations doc for details."
+    note = "Suboptimal iteration performance. See performance considerations doc for details. Consider using IterableSet instead (WARNING: manual storage migration is required if contract was previously deployed)"
 )]
 pub struct UnorderedSet<T, H = Sha256>
 where


### PR DESCRIPTION
## Summary

[Issue #1190](https://github.com/near/near-sdk-rs/issues/1190)

This PR addresses the following issues:
- Ensures examples `.wasm` files are built before running tests by updating CONTRIBUTING.md.
- Modifies CI workflow to build and test all examples in exception of factory-contracts.
- Adds missing unit-testing feature for `examples/non-fungible-token` and `examples/versioned`.
- Refactors deprecated features in examples.

## Changes

- Updated CONTRIBUTING.md to include instructions for building examples.
- Modified `.github/workflows/test_examples_small.yml` and `.github/workflows/test_examples.yml` to build and test more examples.
- Added unit-testing feature for `examples/non-fungible-token` and `examples/versioned` in their Cargo.toml.
- Replaced deprecated `UnorderedMap` with `LookupMap` in `examples/versioned`.

## Testing

All tests have been run locally and pass successfully. In exception for the factory-contract tests. Also the CI has been modified and we need to check which errors come up when the pipeline runs.

## LookupMap

Regarding this change I found that LookupMap is a suitable replacement for UnorderedMap based on the NEAR SDK documentation and the NEAR collections overview.

### Key Points from Documentation:

LookupMap Features:

- LookupMap provides efficient key-value storage with O(1) complexity for access, insertion, and deletion operations.
- It is a good alternative for use cases where the order of elements does not matter.

UnorderedMap Deprecation:

- UnorderedMap is deprecated, meaning it's no longer recommended for use in new code.
- The NEAR SDK documentation and source code changes have suggested moving towards other data structures like LookupMap or TreeMap for similar use cases.

