### PR TITLE
unit testing feature init

### DIFF
--- a/examples/adder/Cargo.toml
+++ b/examples/adder/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { version = "1.14", features = ["full"] }
 anyhow = "1.0"
 near-abi = "0.4.0"
 zstd = "0.13"
+near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
 
 [profile.release]
 codegen-units = 1

--- a/examples/callback-results/Cargo.toml
+++ b/examples/callback-results/Cargo.toml
@@ -14,6 +14,7 @@ near-sdk = { path = "../../near-sdk" }
 near-workspaces = "0.11.0"
 tokio = { version = "1.14", features = ["full"] }
 anyhow = "1.0"
+near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
 
 [profile.release]
 codegen-units = 1

--- a/examples/cross-contract-calls/Cargo.toml
+++ b/examples/cross-contract-calls/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dev-dependencies]
 anyhow = "1.0"
-near-sdk = { path = "../../near-sdk" }
+near-sdk = { path = "../../near-sdk", features = ["default", "unit-testing"] }
 test-case = "2.0"
 tokio = { version = "1.14", features = ["full"] }
 near-workspaces = "0.11.0"

--- a/examples/cross-contract-calls/high-level/Cargo.toml
+++ b/examples/cross-contract-calls/high-level/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = { path = "../../../near-sdk" }
+near-sdk = { path = "../../../near-sdk" , features = ["default", "unit-testing"] }

--- a/examples/cross-contract-calls/low-level/Cargo.toml
+++ b/examples/cross-contract-calls/low-level/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = { path = "../../../near-sdk" }
+near-sdk = { path = "../../../near-sdk" , features = ["default", "unit-testing"] }

--- a/examples/factory-contract/Cargo.toml
+++ b/examples/factory-contract/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = "1.0"
 test-case = "2.0"
 tokio = { version = "1.14", features = ["full"] }
 near-workspaces = "0.11.0"
+near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
 
 [profile.release]
 codegen-units = 1

--- a/examples/factory-contract/high-level/Cargo.toml
+++ b/examples/factory-contract/high-level/Cargo.toml
@@ -9,3 +9,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 near-sdk = { path = "../../../near-sdk" }
+
+[dev-dependencies]
+near-sdk = { path = "../../../near-sdk", features = ["unit-testing"] }

--- a/examples/factory-contract/low-level/Cargo.toml
+++ b/examples/factory-contract/low-level/Cargo.toml
@@ -9,3 +9,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 near-sdk = { path = "../../../near-sdk" }
+
+[dev-dependencies]
+near-sdk = { path = "../../../near-sdk", features = ["unit-testing"] }

--- a/examples/fungible-token/ft/Cargo.toml
+++ b/examples/fungible-token/ft/Cargo.toml
@@ -10,3 +10,6 @@ crate-type = ["cdylib"]
 [dependencies]
 near-sdk = { path = "../../../near-sdk" }
 near-contract-standards = { path = "../../../near-contract-standards" }
+
+[dev-dependencies] 
+near-sdk = { path = "../../../near-sdk", features = ["unit-testing"] }

--- a/examples/fungible-token/test-contract-defi/Cargo.toml
+++ b/examples/fungible-token/test-contract-defi/Cargo.toml
@@ -10,3 +10,6 @@ crate-type = ["cdylib"]
 [dependencies]
 near-sdk = { path = "../../../near-sdk" }
 near-contract-standards = { path = "../../../near-contract-standards" }
+
+[dev-dependencies]
+near-sdk = { path = "../../../near-sdk", features = ["unit-testing"] }

--- a/examples/non-fungible-token/nft/Cargo.toml
+++ b/examples/non-fungible-token/nft/Cargo.toml
@@ -10,3 +10,6 @@ crate-type = ["cdylib"]
 [dependencies]
 near-sdk = { path = "../../../near-sdk" }
 near-contract-standards = { path = "../../../near-contract-standards" }
+
+[dev-dependencies] 
+near-sdk = { path = "../../../near-sdk", features = ["unit-testing"] } 

--- a/examples/non-fungible-token/test-approval-receiver/Cargo.toml
+++ b/examples/non-fungible-token/test-approval-receiver/Cargo.toml
@@ -10,3 +10,6 @@ crate-type = ["cdylib"]
 [dependencies]
 near-sdk = { path = "../../../near-sdk" }
 near-contract-standards = { path = "../../../near-contract-standards" }
+
+[dev-dependencies]
+near-sdk = { path = "../../../near-sdk", features = ["unit-testing"] }

--- a/examples/non-fungible-token/test-token-receiver/Cargo.toml
+++ b/examples/non-fungible-token/test-token-receiver/Cargo.toml
@@ -10,3 +10,6 @@ crate-type = ["cdylib"]
 [dependencies]
 near-sdk = { path = "../../../near-sdk" }
 near-contract-standards = { path = "../../../near-contract-standards" }
+
+[dev-dependencies]
+near-sdk = { path = "../../../near-sdk", features = ["unit-testing"] }

--- a/examples/test-contract/Cargo.toml
+++ b/examples/test-contract/Cargo.toml
@@ -17,3 +17,6 @@ opt-level = "z"
 lto = true
 debug = false
 panic = "abort"
+
+[dev-dependencies] 
+near-sdk = { path = "../../near-sdk", features = ["unit-testing"] } 

--- a/examples/versioned/Cargo.toml
+++ b/examples/versioned/Cargo.toml
@@ -17,3 +17,6 @@ opt-level = "z"
 lto = true
 debug = false
 panic = "abort"
+
+[dev-dependencies]
+near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }


### PR DESCRIPTION
- Resolves #1168 
- Adds `unit-testing` feature as dev dependencies in examples.
- verifies the working through error recreation method stated at https://github.com/near/near-sdk-rs/issues/1168#issuecomment-2151943980