### PR TITLE
ci:  test ci 1.80 with macos-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           - os: macos-latest
             rs: 1.76.0
           - os: macos-latest
-            rs: 1.78.0
+            rs: stable
         features: ['', '--features unstable,legacy,__abi-generate']
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/540c84e8-a64f-4ec7-97f5-20ab24fab699)
