### PR TITLE
chore: updates near-* dependencies to 0.24.0

### DIFF
--- a/examples/adder/Cargo.toml
+++ b/examples/adder/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 near-sdk = { path = "../../near-sdk" }
 
 [dev-dependencies]
-near-workspaces = "0.11.0"
+near-workspaces = "0.11.1"
 tokio = { version = "1.14", features = ["full"] }
 anyhow = "1.0"
 near-abi = "0.4.0"

--- a/examples/callback-results/Cargo.toml
+++ b/examples/callback-results/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 near-sdk = { path = "../../near-sdk" }
 
 [dev-dependencies]
-near-workspaces = "0.11.0"
+near-workspaces = "0.11.1"
 tokio = { version = "1.14", features = ["full"] }
 anyhow = "1.0"
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }

--- a/examples/cross-contract-calls/Cargo.toml
+++ b/examples/cross-contract-calls/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1.0"
 near-sdk = { path = "../../near-sdk", features = ["default", "unit-testing"] }
 test-case = "2.0"
 tokio = { version = "1.14", features = ["full"] }
-near-workspaces = "0.11.0"
+near-workspaces = "0.11.1"
 
 cross-contract-high-level = { path = "./high-level" }
 cross-contract-low-level = { path = "./low-level" }

--- a/examples/factory-contract/Cargo.toml
+++ b/examples/factory-contract/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 anyhow = "1.0"
 test-case = "2.0"
 tokio = { version = "1.14", features = ["full"] }
-near-workspaces = "0.11.0"
+near-workspaces = "0.11.1"
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
 
 [profile.release]

--- a/examples/fungible-token/Cargo.toml
+++ b/examples/fungible-token/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 anyhow = "1.0"
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
 tokio = { version = "1.14", features = ["full"] }
-near-workspaces = "0.11.0"
+near-workspaces = "0.11.1"
 
 [profile.release]
 codegen-units = 1

--- a/examples/lockable-fungible-token/Cargo.toml
+++ b/examples/lockable-fungible-token/Cargo.toml
@@ -14,7 +14,7 @@ near-sdk = { path = "../../near-sdk", features = ["legacy"] }
 anyhow = "1.0"
 tokio = { version = "1.14", features = ["full"] }
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
-near-workspaces = "0.11.0"
+near-workspaces = "0.11.1"
 
 [profile.release]
 codegen-units = 1

--- a/examples/non-fungible-token/Cargo.toml
+++ b/examples/non-fungible-token/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 [dev-dependencies]
 anyhow = "1.0"
 near-contract-standards = { path = "../../near-contract-standards" }
-near-sdk = { path = "../../near-sdk", features = ["unit-testing"]  }
+near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
 tokio = { version = "1.14", features = ["full"] }
-near-workspaces = "0.11.0"
+near-workspaces = "0.11.1"
 
 [profile.release]
 codegen-units = 1

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -42,11 +42,11 @@ schemars = { version = "0.8.8", optional = true }
 near-abi = { version = "0.4.0", features = [
     "__chunked-entries",
 ], optional = true }
-near-vm-runner = { version = "0.23", optional = true }
-near-primitives-core = { version = "0.23", optional = true }
-near-primitives = { version = "0.23", optional = true }
-near-crypto = { version = "0.23", default-features = false, optional = true }
-near-parameters = { version = "0.23", optional = true }
+near-vm-runner = { version = "0.24", optional = true }
+near-primitives-core = { version = "0.24", optional = true }
+near-primitives = { version = "0.24", optional = true }
+near-crypto = { version = "0.24", default-features = false, optional = true }
+near-parameters = { version = "0.24", optional = true }
 
 [dev-dependencies]
 near-sdk = { path = ".", features = ["legacy", "unit-testing"] }
@@ -63,7 +63,7 @@ rand_chacha = "0.3.1"
 near-rng = "0.1.1"
 near-abi = { version = "0.4.0", features = ["__chunked-entries"] }
 symbolic-debuginfo = "12"
-near-workspaces = { version = "0.10.1", features = ["unstable"] }
+near-workspaces = { version = "0.11.1", features = ["unstable"] }
 anyhow = "1.0"
 tokio = { version = "1", features = ["full"] }
 strum = "0.25.0"

--- a/near-sdk/tests/store_performance_tests.rs
+++ b/near-sdk/tests/store_performance_tests.rs
@@ -118,14 +118,14 @@ async fn insert_and_remove() -> anyhow::Result<()> {
     // insert test, max_iterations here is the number of elements to insert. It's used to measure
     // relative performance.
     for (col, max_iterations) in collection_types.map(|col| match col {
-        Collection::TreeMap => (col, 340),
-        Collection::IterableSet => (col, 340),
-        Collection::IterableMap => (col, 350),
-        Collection::UnorderedSet => (col, 340),
-        Collection::UnorderedMap => (col, 350),
-        Collection::LookupMap => (col, 600),
-        Collection::LookupSet => (col, 970),
-        Collection::Vector => (col, 1000),
+        Collection::TreeMap => (col, 350),
+        Collection::IterableSet => (col, 350),
+        Collection::IterableMap => (col, 360),
+        Collection::UnorderedSet => (col, 350),
+        Collection::UnorderedMap => (col, 360),
+        Collection::LookupMap => (col, 610),
+        Collection::LookupSet => (col, 980),
+        Collection::Vector => (col, 1010),
     }) {
         let total_gas = account
             .call(&contract_id, "insert")
@@ -138,19 +138,20 @@ async fn insert_and_remove() -> anyhow::Result<()> {
             .as_gas();
 
         perform_asserts(total_gas, &col);
+        println!("{}: {}", col, NearGas::from_gas(total_gas).as_tgas());
     }
 
     // remove test, max_iterations here is the number of elements to remove. It's used to measure
     // relative performance.
     for (col, max_iterations) in collection_types.map(|col| match col {
-        Collection::TreeMap => (col, 220),
-        Collection::IterableSet => (col, 120),
-        Collection::IterableMap => (col, 115),
-        Collection::UnorderedSet => (col, 220),
-        Collection::UnorderedMap => (col, 220),
-        Collection::LookupMap => (col, 480),
-        Collection::LookupSet => (col, 970),
-        Collection::Vector => (col, 500),
+        Collection::TreeMap => (col, 230),
+        Collection::IterableSet => (col, 130),
+        Collection::IterableMap => (col, 125),
+        Collection::UnorderedSet => (col, 230),
+        Collection::UnorderedMap => (col, 230),
+        Collection::LookupMap => (col, 490),
+        Collection::LookupSet => (col, 980),
+        Collection::Vector => (col, 510),
     }) {
         let total_gas = account
             .call(&contract_id, "remove")
@@ -163,6 +164,7 @@ async fn insert_and_remove() -> anyhow::Result<()> {
             .as_gas();
 
         perform_asserts(total_gas, &col);
+        println!("{}: {}", col, NearGas::from_gas(total_gas).as_tgas());
     }
 
     Ok(())

--- a/near-sdk/tests/store_performance_tests.rs
+++ b/near-sdk/tests/store_performance_tests.rs
@@ -138,7 +138,6 @@ async fn insert_and_remove() -> anyhow::Result<()> {
             .as_gas();
 
         perform_asserts(total_gas, &col);
-        println!("{}: {}", col, NearGas::from_gas(total_gas).as_tgas());
     }
 
     // remove test, max_iterations here is the number of elements to remove. It's used to measure
@@ -164,7 +163,6 @@ async fn insert_and_remove() -> anyhow::Result<()> {
             .as_gas();
 
         perform_asserts(total_gas, &col);
-        println!("{}: {}", col, NearGas::from_gas(total_gas).as_tgas());
     }
 
     Ok(())

--- a/near-sdk/tests/store_performance_tests.rs
+++ b/near-sdk/tests/store_performance_tests.rs
@@ -118,14 +118,14 @@ async fn insert_and_remove() -> anyhow::Result<()> {
     // insert test, max_iterations here is the number of elements to insert. It's used to measure
     // relative performance.
     for (col, max_iterations) in collection_types.map(|col| match col {
-        Collection::TreeMap => (col, 350),
-        Collection::IterableSet => (col, 350),
-        Collection::IterableMap => (col, 360),
-        Collection::UnorderedSet => (col, 350),
-        Collection::UnorderedMap => (col, 360),
-        Collection::LookupMap => (col, 610),
-        Collection::LookupSet => (col, 980),
-        Collection::Vector => (col, 1010),
+        Collection::TreeMap => (col, 365),
+        Collection::IterableSet => (col, 370),
+        Collection::IterableMap => (col, 370),
+        Collection::UnorderedSet => (col, 360),
+        Collection::UnorderedMap => (col, 365),
+        Collection::LookupMap => (col, 650),
+        Collection::LookupSet => (col, 1020),
+        Collection::Vector => (col, 1080),
     }) {
         let total_gas = account
             .call(&contract_id, "insert")
@@ -145,12 +145,12 @@ async fn insert_and_remove() -> anyhow::Result<()> {
     for (col, max_iterations) in collection_types.map(|col| match col {
         Collection::TreeMap => (col, 230),
         Collection::IterableSet => (col, 130),
-        Collection::IterableMap => (col, 125),
-        Collection::UnorderedSet => (col, 230),
-        Collection::UnorderedMap => (col, 230),
-        Collection::LookupMap => (col, 490),
-        Collection::LookupSet => (col, 980),
-        Collection::Vector => (col, 510),
+        Collection::IterableMap => (col, 120),
+        Collection::UnorderedSet => (col, 240),
+        Collection::UnorderedMap => (col, 250),
+        Collection::LookupMap => (col, 520),
+        Collection::LookupSet => (col, 1050),
+        Collection::Vector => (col, 530),
     }) {
         let total_gas = account
             .call(&contract_id, "remove")
@@ -198,11 +198,11 @@ async fn iter() -> anyhow::Result<()> {
     // It's used to measure relative performance.
     for (col, repeat) in collection_types.map(|col| match col {
         Collection::TreeMap => (col, 5),
-        Collection::IterableSet => (col, 20),
-        Collection::IterableMap => (col, 9),
-        Collection::UnorderedSet => (col, 18),
-        Collection::UnorderedMap => (col, 8),
-        Collection::Vector => (col, 19),
+        Collection::IterableSet => (col, 22),
+        Collection::IterableMap => (col, 10),
+        Collection::UnorderedSet => (col, 20),
+        Collection::UnorderedMap => (col, 9),
+        Collection::Vector => (col, 22),
         _ => (col, 0),
     }) {
         let total_gas = account
@@ -249,12 +249,12 @@ async fn random_access() -> anyhow::Result<()> {
     // iter, repeat here is the number that reflects how many times we retrieve a random element.
     // It's used to measure relative performance.
     for (col, repeat) in collection_types.map(|col| match col {
-        Collection::TreeMap => (col, 14),
-        Collection::IterableSet => (col, 1600),
-        Collection::IterableMap => (col, 720),
-        Collection::UnorderedSet => (col, 37),
-        Collection::UnorderedMap => (col, 33),
-        Collection::Vector => (col, 1600),
+        Collection::TreeMap => (col, 15),
+        Collection::IterableSet => (col, 1750),
+        Collection::IterableMap => (col, 745),
+        Collection::UnorderedSet => (col, 41),
+        Collection::UnorderedMap => (col, 36),
+        Collection::Vector => (col, 1700),
         _ => (col, 0),
     }) {
         let total_gas = account
@@ -303,13 +303,13 @@ async fn contains() -> anyhow::Result<()> {
     // contains test, repeat here is the number of times we check all the elements in each collection.
     // It's used to measure relative performance.
     for (col, repeat) in collection_types.map(|col| match col {
-        Collection::TreeMap => (col, 12),
-        Collection::IterableSet => (col, 11),
-        Collection::IterableMap => (col, 12),
-        Collection::UnorderedSet => (col, 11),
-        Collection::UnorderedMap => (col, 12),
-        Collection::LookupMap => (col, 16),
-        Collection::LookupSet => (col, 14),
+        Collection::TreeMap => (col, 13),
+        Collection::IterableSet => (col, 12),
+        Collection::IterableMap => (col, 13),
+        Collection::UnorderedSet => (col, 12),
+        Collection::UnorderedMap => (col, 13),
+        Collection::LookupMap => (col, 17),
+        Collection::LookupSet => (col, 15),
         _ => (col, 0),
     }) {
         let total_gas = account
@@ -369,10 +369,10 @@ async fn iterable_vs_unordered() -> anyhow::Result<()> {
     // iter, repeat here is the number of times we iterate through the whole collection. It's used to
     // measure relative performance.
     for (col, repeat) in collection_types.map(|col| match col {
-        Collection::IterableSet => (col, 240000),
-        Collection::IterableMap => (col, 130000),
-        Collection::UnorderedSet => (col, 260),
-        Collection::UnorderedMap => (col, 260),
+        Collection::IterableSet => (col, 260000),
+        Collection::IterableMap => (col, 135000),
+        Collection::UnorderedSet => (col, 280),
+        Collection::UnorderedMap => (col, 270),
         _ => (col, 0),
     }) {
         let total_gas = account
@@ -391,10 +391,10 @@ async fn iterable_vs_unordered() -> anyhow::Result<()> {
     // random access, repeat here is the number of times we try to access an element in the
     // collection. It's used to measure relative performance.
     for (col, repeat) in &collection_types.map(|col| match col {
-        Collection::IterableSet => (col, 540000),
-        Collection::IterableMap => (col, 260000),
-        Collection::UnorderedSet => (col, 255),
-        Collection::UnorderedMap => (col, 255),
+        Collection::IterableSet => (col, 600000),
+        Collection::IterableMap => (col, 280000),
+        Collection::UnorderedSet => (col, 280),
+        Collection::UnorderedMap => (col, 260),
         _ => (col, 0),
     }) {
         let total_gas = account


### PR DESCRIPTION
near-workspaces should be updated later. It's not a blocker as it's used in tests and it has cyclic dependency :)

cc @race-of-sloths