### PR TITLE
chore: release v5.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [6.0.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.3.0...near-sdk-v6.0.0) - 2024-09-04
+
+### Other
+- [**breaking**] upgrade to 0.25 release ([#1242](https://github.com/near/near-sdk-rs/pull/1242))
+- updated near-workspaces-rs ([#1239](https://github.com/near/near-sdk-rs/pull/1239))
+
 ## [5.3.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.2.1...near-sdk-v5.3.0) - 2024-08-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## [Unreleased]
 
-## [6.0.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.3.0...near-sdk-v6.0.0) - 2024-09-04
+## [5.4.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.3.0...near-sdk-v5.4.0) - 2024-09-04
 
 ### Other
-- [**breaking**] upgrade to 0.25 release ([#1242](https://github.com/near/near-sdk-rs/pull/1242))
-- updated near-workspaces-rs ([#1239](https://github.com/near/near-sdk-rs/pull/1239))
+- updates near-* dependencies to 0.25.0 ([#1242](https://github.com/near/near-sdk-rs/pull/1242))
+- updates near-workspaces-rs ([#1239](https://github.com/near/near-sdk-rs/pull/1239))
 
 ## [5.3.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.2.1...near-sdk-v5.3.0) - 2024-08-13
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.3.0"
+version = "6.0.0"
 
 # Special triple # comment for ci.
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,10 @@
 [workspace]
 resolver = "2"
-members = [
-    "near-sdk",
-    "near-sdk-macros",
-    "near-contract-standards",
-    "near-sys",
-]
+members = ["near-sdk", "near-sdk-macros", "near-contract-standards", "near-sys"]
 exclude = ["examples/"]
 
 [workspace.package]
-version = "6.0.0"
+version = "5.4.0"
 
 # Special triple # comment for ci.
 [patch.crates-io]

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,10 +13,14 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~6.0.0", default-features = false, features = ["legacy"] }
+near-sdk = { path = "../near-sdk", version = "~5.4.0", default-features = false, features = [
+    "legacy",
+] }
 
 [dev-dependencies]
-near-sdk = { path = "../near-sdk", default-features = false, features = ["unit-testing"] }
+near-sdk = { path = "../near-sdk", default-features = false, features = [
+    "unit-testing",
+] }
 
 [features]
 default = []

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.3.0", default-features = false, features = ["legacy"] }
+near-sdk = { path = "../near-sdk", version = "~6.0.0", default-features = false, features = ["legacy"] }
 
 [dev-dependencies]
 near-sdk = { path = "../near-sdk", default-features = false, features = ["unit-testing"] }

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.3.0" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~6.0.0" }
 near-sys = { path = "../near-sys", version = "0.2.2" }
 base64 = "0.22"
 borsh = { version = "1.0.0", features = ["derive"] }

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~6.0.0" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.4.0" }
 near-sys = { path = "../near-sys", version = "0.2.2" }
 base64 = "0.22"
 borsh = { version = "1.0.0", features = ["derive"] }


### PR DESCRIPTION
## 🤖 New release
* `near-sdk`: 5.3.0 -> 5.4.0
* `near-sdk-macros`: 5.3.0 -> 5.4.0
* `near-contract-standards`: 5.3.0 -> 5.4.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-sdk`
<blockquote>

## [5.4.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.3.0...near-sdk-v5.4.0) - 2024-09-04

### Other
- updates near-* dependencies to 0.25.0 ([#1242](https://github.com/near/near-sdk-rs/pull/1242))
- updates near-workspaces-rs ([#1239](https://github.com/near/near-sdk-rs/pull/1239))
</blockquote>

## `near-contract-standards`
<blockquote>

## [5.3.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.2.1...near-contract-standards-v5.3.0) - 2024-08-13

### Fixed
- Fix storage management error message with proper amount ([#1222](https://github.com/near/near-sdk-rs/pull/1222))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).