### PR TITLE
chore: updates near-* dependendencies. Migrates testing blockchain mock to C-unwind

### DIFF
--- a/examples/adder/Cargo.toml
+++ b/examples/adder/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 near-sdk = { path = "../../near-sdk" }
 
 [dev-dependencies]
-near-workspaces = "0.12"
+near-workspaces = "0.13"
 tokio = { version = "1.14", features = ["full"] }
 anyhow = "1.0"
 near-abi = "0.4.0"

--- a/examples/callback-results/Cargo.toml
+++ b/examples/callback-results/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 near-sdk = { path = "../../near-sdk" }
 
 [dev-dependencies]
-near-workspaces = "0.12"
+near-workspaces = "0.13"
 tokio = { version = "1.14", features = ["full"] }
 anyhow = "1.0"
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }

--- a/examples/cross-contract-calls/Cargo.toml
+++ b/examples/cross-contract-calls/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1.0"
 near-sdk = { path = "../../near-sdk", features = ["default", "unit-testing"] }
 test-case = "2.0"
 tokio = { version = "1.14", features = ["full"] }
-near-workspaces = "0.12"
+near-workspaces = "0.13"
 
 cross-contract-high-level = { path = "./high-level" }
 cross-contract-low-level = { path = "./low-level" }

--- a/examples/factory-contract/Cargo.toml
+++ b/examples/factory-contract/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 anyhow = "1.0"
 test-case = "2.0"
 tokio = { version = "1.14", features = ["full"] }
-near-workspaces = "0.12"
+near-workspaces = "0.13"
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
 
 [profile.release]

--- a/examples/fungible-token/Cargo.toml
+++ b/examples/fungible-token/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 anyhow = "1.0"
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
 tokio = { version = "1.14", features = ["full"] }
-near-workspaces = "0.12"
+near-workspaces = "0.13"
 
 [profile.release]
 codegen-units = 1

--- a/examples/lockable-fungible-token/Cargo.toml
+++ b/examples/lockable-fungible-token/Cargo.toml
@@ -14,7 +14,7 @@ near-sdk = { path = "../../near-sdk", features = ["legacy"] }
 anyhow = "1.0"
 tokio = { version = "1.14", features = ["full"] }
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
-near-workspaces = "0.12"
+near-workspaces = "0.13"
 
 [profile.release]
 codegen-units = 1

--- a/examples/non-fungible-token/Cargo.toml
+++ b/examples/non-fungible-token/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1.0"
 near-contract-standards = { path = "../../near-contract-standards" }
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
 tokio = { version = "1.14", features = ["full"] }
-near-workspaces = "0.12"
+near-workspaces = "0.13"
 
 [profile.release]
 codegen-units = 1

--- a/near-contract-standards/src/non_fungible_token/core/core_impl.rs
+++ b/near-contract-standards/src/non_fungible_token/core/core_impl.rs
@@ -432,11 +432,7 @@ impl NonFungibleTokenResolver for NonFungibleToken {
         // Get whether token should be returned
         let must_revert = match env::promise_result(0) {
             PromiseResult::Successful(value) => {
-                if let Ok(yes_or_no) = near_sdk::serde_json::from_slice::<bool>(&value) {
-                    yes_or_no
-                } else {
-                    true
-                }
+                near_sdk::serde_json::from_slice::<bool>(&value).unwrap_or(true)
             }
             PromiseResult::Failed => true,
         };

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -42,11 +42,11 @@ schemars = { version = "0.8.8", optional = true }
 near-abi = { version = "0.4.0", features = [
     "__chunked-entries",
 ], optional = true }
-near-vm-runner = { version = "0.25", optional = true }
-near-primitives-core = { version = "0.25", optional = true }
-near-primitives = { version = "0.25", optional = true }
-near-crypto = { version = "0.25", default-features = false, optional = true }
-near-parameters = { version = "0.25", optional = true }
+near-vm-runner = { version = "0.26", optional = true }
+near-primitives-core = { version = "0.26", optional = true }
+near-primitives = { version = "0.26", optional = true }
+near-crypto = { version = "0.26", default-features = false, optional = true }
+near-parameters = { version = "0.26", optional = true }
 
 [dev-dependencies]
 near-sdk = { path = ".", features = ["legacy", "unit-testing"] }

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -63,7 +63,7 @@ rand_chacha = "0.3.1"
 near-rng = "0.1.1"
 near-abi = { version = "0.4.0", features = ["__chunked-entries"] }
 symbolic-debuginfo = "12"
-near-workspaces = { version = "0.12", features = ["unstable"] }
+near-workspaces = { version = "0.13", features = ["unstable"] }
 anyhow = "1.0"
 tokio = { version = "1", features = ["full"] }
 strum = "0.25.0"

--- a/near-sdk/src/environment/mock/mocked_blockchain.rs
+++ b/near-sdk/src/environment/mock/mocked_blockchain.rs
@@ -186,6 +186,7 @@ fn sdk_context_to_vm_context(
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+
 mod mock_chain {
     use near_vm_runner::logic::{errors::VMLogicError, VMLogic};
 
@@ -197,91 +198,91 @@ mod mock_chain {
     }
 
     #[no_mangle]
-    extern "C" fn read_register(register_id: u64, ptr: u64) {
+    extern "C-unwind" fn read_register(register_id: u64, ptr: u64) {
         with_mock_interface(|b| b.read_register(register_id, ptr))
     }
     #[no_mangle]
-    extern "C" fn register_len(register_id: u64) -> u64 {
+    extern "C-unwind" fn register_len(register_id: u64) -> u64 {
         with_mock_interface(|b| b.register_len(register_id))
     }
     #[no_mangle]
-    extern "C" fn current_account_id(register_id: u64) {
+    extern "C-unwind" fn current_account_id(register_id: u64) {
         with_mock_interface(|b| b.current_account_id(register_id))
     }
     #[no_mangle]
-    extern "C" fn signer_account_id(register_id: u64) {
+    extern "C-unwind" fn signer_account_id(register_id: u64) {
         with_mock_interface(|b| b.signer_account_id(register_id))
     }
     #[no_mangle]
-    extern "C" fn signer_account_pk(register_id: u64) {
+    extern "C-unwind" fn signer_account_pk(register_id: u64) {
         with_mock_interface(|b| b.signer_account_pk(register_id))
     }
     #[no_mangle]
-    extern "C" fn predecessor_account_id(register_id: u64) {
+    extern "C-unwind" fn predecessor_account_id(register_id: u64) {
         with_mock_interface(|b| b.predecessor_account_id(register_id))
     }
     #[no_mangle]
-    extern "C" fn input(register_id: u64) {
+    extern "C-unwind" fn input(register_id: u64) {
         with_mock_interface(|b| b.input(register_id))
     }
     #[no_mangle]
-    extern "C" fn block_index() -> u64 {
+    extern "C-unwind" fn block_index() -> u64 {
         with_mock_interface(|b| b.block_index())
     }
     #[no_mangle]
-    extern "C" fn block_timestamp() -> u64 {
+    extern "C-unwind" fn block_timestamp() -> u64 {
         with_mock_interface(|b| b.block_timestamp())
     }
     #[no_mangle]
-    extern "C" fn epoch_height() -> u64 {
+    extern "C-unwind" fn epoch_height() -> u64 {
         with_mock_interface(|b| b.epoch_height())
     }
     #[no_mangle]
-    extern "C" fn storage_usage() -> u64 {
+    extern "C-unwind" fn storage_usage() -> u64 {
         with_mock_interface(|b| b.storage_usage())
     }
     #[no_mangle]
-    extern "C" fn account_balance(balance_ptr: u64) {
+    extern "C-unwind" fn account_balance(balance_ptr: u64) {
         with_mock_interface(|b| b.account_balance(balance_ptr))
     }
     #[no_mangle]
-    extern "C" fn account_locked_balance(balance_ptr: u64) {
+    extern "C-unwind" fn account_locked_balance(balance_ptr: u64) {
         with_mock_interface(|b| b.account_locked_balance(balance_ptr))
     }
     #[no_mangle]
-    extern "C" fn attached_deposit(balance_ptr: u64) {
+    extern "C-unwind" fn attached_deposit(balance_ptr: u64) {
         with_mock_interface(|b| b.attached_deposit(balance_ptr))
     }
     #[no_mangle]
-    extern "C" fn prepaid_gas() -> u64 {
+    extern "C-unwind" fn prepaid_gas() -> u64 {
         with_mock_interface(|b| b.prepaid_gas())
     }
     #[no_mangle]
-    extern "C" fn used_gas() -> u64 {
+    extern "C-unwind" fn used_gas() -> u64 {
         with_mock_interface(|b| b.used_gas())
     }
     #[no_mangle]
-    extern "C" fn random_seed(register_id: u64) {
+    extern "C-unwind" fn random_seed(register_id: u64) {
         with_mock_interface(|b| b.random_seed(register_id))
     }
     #[no_mangle]
-    extern "C" fn sha256(value_len: u64, value_ptr: u64, register_id: u64) {
+    extern "C-unwind" fn sha256(value_len: u64, value_ptr: u64, register_id: u64) {
         with_mock_interface(|b| b.sha256(value_len, value_ptr, register_id))
     }
     #[no_mangle]
-    extern "C" fn keccak256(value_len: u64, value_ptr: u64, register_id: u64) {
+    extern "C-unwind" fn keccak256(value_len: u64, value_ptr: u64, register_id: u64) {
         with_mock_interface(|b| b.keccak256(value_len, value_ptr, register_id))
     }
     #[no_mangle]
-    extern "C" fn keccak512(value_len: u64, value_ptr: u64, register_id: u64) {
+    extern "C-unwind" fn keccak512(value_len: u64, value_ptr: u64, register_id: u64) {
         with_mock_interface(|b| b.keccak512(value_len, value_ptr, register_id))
     }
     #[no_mangle]
-    extern "C" fn ripemd160(value_len: u64, value_ptr: u64, register_id: u64) {
+    extern "C-unwind" fn ripemd160(value_len: u64, value_ptr: u64, register_id: u64) {
         with_mock_interface(|b| b.ripemd160(value_len, value_ptr, register_id))
     }
     #[no_mangle]
-    extern "C" fn ecrecover(
+    extern "C-unwind" fn ecrecover(
         hash_len: u64,
         hash_ptr: u64,
         sig_len: u64,
@@ -295,7 +296,7 @@ mod mock_chain {
         })
     }
     #[no_mangle]
-    extern "C" fn ed25519_verify(
+    extern "C-unwind" fn ed25519_verify(
         signature_len: u64,
         signature_ptr: u64,
         message_len: u64,
@@ -315,29 +316,29 @@ mod mock_chain {
         })
     }
     #[no_mangle]
-    extern "C" fn value_return(value_len: u64, value_ptr: u64) {
+    extern "C-unwind" fn value_return(value_len: u64, value_ptr: u64) {
         with_mock_interface(|b| b.value_return(value_len, value_ptr))
     }
     #[no_mangle]
-    extern "C" fn panic() -> ! {
+    extern "C-unwind" fn panic() -> ! {
         with_mock_interface(|b| b.panic());
         unreachable!()
     }
     #[no_mangle]
-    extern "C" fn panic_utf8(len: u64, ptr: u64) -> ! {
+    extern "C-unwind" fn panic_utf8(len: u64, ptr: u64) -> ! {
         with_mock_interface(|b| b.panic_utf8(len, ptr));
         unreachable!()
     }
     #[no_mangle]
-    extern "C" fn log_utf8(len: u64, ptr: u64) {
+    extern "C-unwind" fn log_utf8(len: u64, ptr: u64) {
         with_mock_interface(|b| b.log_utf8(len, ptr))
     }
     #[no_mangle]
-    extern "C" fn log_utf16(len: u64, ptr: u64) {
+    extern "C-unwind" fn log_utf16(len: u64, ptr: u64) {
         with_mock_interface(|b| b.log_utf16(len, ptr))
     }
     #[no_mangle]
-    extern "C" fn promise_create(
+    extern "C-unwind" fn promise_create(
         account_id_len: u64,
         account_id_ptr: u64,
         function_name_len: u64,
@@ -361,7 +362,7 @@ mod mock_chain {
         })
     }
     #[no_mangle]
-    extern "C" fn promise_then(
+    extern "C-unwind" fn promise_then(
         promise_index: u64,
         account_id_len: u64,
         account_id_ptr: u64,
@@ -387,15 +388,15 @@ mod mock_chain {
         })
     }
     #[no_mangle]
-    extern "C" fn promise_and(promise_idx_ptr: u64, promise_idx_count: u64) -> u64 {
+    extern "C-unwind" fn promise_and(promise_idx_ptr: u64, promise_idx_count: u64) -> u64 {
         with_mock_interface(|b| b.promise_and(promise_idx_ptr, promise_idx_count))
     }
     #[no_mangle]
-    extern "C" fn promise_batch_create(account_id_len: u64, account_id_ptr: u64) -> u64 {
+    extern "C-unwind" fn promise_batch_create(account_id_len: u64, account_id_ptr: u64) -> u64 {
         with_mock_interface(|b| b.promise_batch_create(account_id_len, account_id_ptr))
     }
     #[no_mangle]
-    extern "C" fn promise_batch_then(
+    extern "C-unwind" fn promise_batch_then(
         promise_index: u64,
         account_id_len: u64,
         account_id_ptr: u64,
@@ -403,11 +404,11 @@ mod mock_chain {
         with_mock_interface(|b| b.promise_batch_then(promise_index, account_id_len, account_id_ptr))
     }
     #[no_mangle]
-    extern "C" fn promise_batch_action_create_account(promise_index: u64) {
+    extern "C-unwind" fn promise_batch_action_create_account(promise_index: u64) {
         with_mock_interface(|b| b.promise_batch_action_create_account(promise_index))
     }
     #[no_mangle]
-    extern "C" fn promise_batch_action_deploy_contract(
+    extern "C-unwind" fn promise_batch_action_deploy_contract(
         promise_index: u64,
         code_len: u64,
         code_ptr: u64,
@@ -417,7 +418,7 @@ mod mock_chain {
         })
     }
     #[no_mangle]
-    extern "C" fn promise_batch_action_function_call(
+    extern "C-unwind" fn promise_batch_action_function_call(
         promise_index: u64,
         function_name_len: u64,
         function_name_ptr: u64,
@@ -440,7 +441,7 @@ mod mock_chain {
     }
 
     #[no_mangle]
-    extern "C" fn promise_batch_action_function_call_weight(
+    extern "C-unwind" fn promise_batch_action_function_call_weight(
         promise_index: u64,
         function_name_len: u64,
         function_name_ptr: u64,
@@ -465,11 +466,11 @@ mod mock_chain {
     }
 
     #[no_mangle]
-    extern "C" fn promise_batch_action_transfer(promise_index: u64, amount_ptr: u64) {
+    extern "C-unwind" fn promise_batch_action_transfer(promise_index: u64, amount_ptr: u64) {
         with_mock_interface(|b| b.promise_batch_action_transfer(promise_index, amount_ptr))
     }
     #[no_mangle]
-    extern "C" fn promise_batch_action_stake(
+    extern "C-unwind" fn promise_batch_action_stake(
         promise_index: u64,
         amount_ptr: u64,
         public_key_len: u64,
@@ -480,7 +481,7 @@ mod mock_chain {
         })
     }
     #[no_mangle]
-    extern "C" fn promise_batch_action_add_key_with_full_access(
+    extern "C-unwind" fn promise_batch_action_add_key_with_full_access(
         promise_index: u64,
         public_key_len: u64,
         public_key_ptr: u64,
@@ -496,7 +497,7 @@ mod mock_chain {
         })
     }
     #[no_mangle]
-    extern "C" fn promise_batch_action_add_key_with_function_call(
+    extern "C-unwind" fn promise_batch_action_add_key_with_function_call(
         promise_index: u64,
         public_key_len: u64,
         public_key_ptr: u64,
@@ -522,7 +523,7 @@ mod mock_chain {
         })
     }
     #[no_mangle]
-    extern "C" fn promise_batch_action_delete_key(
+    extern "C-unwind" fn promise_batch_action_delete_key(
         promise_index: u64,
         public_key_len: u64,
         public_key_ptr: u64,
@@ -532,7 +533,7 @@ mod mock_chain {
         })
     }
     #[no_mangle]
-    extern "C" fn promise_batch_action_delete_account(
+    extern "C-unwind" fn promise_batch_action_delete_account(
         promise_index: u64,
         beneficiary_id_len: u64,
         beneficiary_id_ptr: u64,
@@ -546,19 +547,19 @@ mod mock_chain {
         })
     }
     #[no_mangle]
-    extern "C" fn promise_results_count() -> u64 {
+    extern "C-unwind" fn promise_results_count() -> u64 {
         with_mock_interface(|b| b.promise_results_count())
     }
     #[no_mangle]
-    extern "C" fn promise_result(result_idx: u64, register_id: u64) -> u64 {
+    extern "C-unwind" fn promise_result(result_idx: u64, register_id: u64) -> u64 {
         with_mock_interface(|b| b.promise_result(result_idx, register_id))
     }
     #[no_mangle]
-    extern "C" fn promise_return(promise_id: u64) {
+    extern "C-unwind" fn promise_return(promise_id: u64) {
         with_mock_interface(|b| b.promise_return(promise_id))
     }
     #[no_mangle]
-    extern "C" fn storage_write(
+    extern "C-unwind" fn storage_write(
         key_len: u64,
         key_ptr: u64,
         value_len: u64,
@@ -570,35 +571,35 @@ mod mock_chain {
         })
     }
     #[no_mangle]
-    extern "C" fn storage_read(key_len: u64, key_ptr: u64, register_id: u64) -> u64 {
+    extern "C-unwind" fn storage_read(key_len: u64, key_ptr: u64, register_id: u64) -> u64 {
         with_mock_interface(|b| b.storage_read(key_len, key_ptr, register_id))
     }
     #[no_mangle]
-    extern "C" fn storage_remove(key_len: u64, key_ptr: u64, register_id: u64) -> u64 {
+    extern "C-unwind" fn storage_remove(key_len: u64, key_ptr: u64, register_id: u64) -> u64 {
         with_mock_interface(|b| b.storage_remove(key_len, key_ptr, register_id))
     }
     #[no_mangle]
-    extern "C" fn storage_has_key(key_len: u64, key_ptr: u64) -> u64 {
+    extern "C-unwind" fn storage_has_key(key_len: u64, key_ptr: u64) -> u64 {
         with_mock_interface(|b| b.storage_has_key(key_len, key_ptr))
     }
     #[no_mangle]
-    extern "C" fn validator_stake(account_id_len: u64, account_id_ptr: u64, stake_ptr: u64) {
+    extern "C-unwind" fn validator_stake(account_id_len: u64, account_id_ptr: u64, stake_ptr: u64) {
         with_mock_interface(|b| b.validator_stake(account_id_len, account_id_ptr, stake_ptr))
     }
     #[no_mangle]
-    extern "C" fn validator_total_stake(stake_ptr: u64) {
+    extern "C-unwind" fn validator_total_stake(stake_ptr: u64) {
         with_mock_interface(|b| b.validator_total_stake(stake_ptr))
     }
     #[no_mangle]
-    extern "C" fn alt_bn128_g1_multiexp(value_len: u64, value_ptr: u64, register_id: u64) {
+    extern "C-unwind" fn alt_bn128_g1_multiexp(value_len: u64, value_ptr: u64, register_id: u64) {
         with_mock_interface(|b| b.alt_bn128_g1_multiexp(value_len, value_ptr, register_id))
     }
     #[no_mangle]
-    extern "C" fn alt_bn128_g1_sum(value_len: u64, value_ptr: u64, register_id: u64) {
+    extern "C-unwind" fn alt_bn128_g1_sum(value_len: u64, value_ptr: u64, register_id: u64) {
         with_mock_interface(|b| b.alt_bn128_g1_sum(value_len, value_ptr, register_id))
     }
     #[no_mangle]
-    extern "C" fn alt_bn128_pairing_check(value_len: u64, value_ptr: u64) -> u64 {
+    extern "C-unwind" fn alt_bn128_pairing_check(value_len: u64, value_ptr: u64) -> u64 {
         with_mock_interface(|b| b.alt_bn128_pairing_check(value_len, value_ptr))
     }
 }

--- a/near-sdk/src/environment/mock/mocked_blockchain.rs
+++ b/near-sdk/src/environment/mock/mocked_blockchain.rs
@@ -186,7 +186,6 @@ fn sdk_context_to_vm_context(
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-
 mod mock_chain {
     use near_vm_runner::logic::{errors::VMLogicError, VMLogic};
 

--- a/near-sdk/tests/store_performance_tests.rs
+++ b/near-sdk/tests/store_performance_tests.rs
@@ -246,6 +246,9 @@ async fn random_access() -> anyhow::Result<()> {
             .unwrap();
     }
 
+    // Rust 1.81 improved performance of unordered collections.
+    let unordered_map = if cfg!(rustversion::since(1.81)) { 42 } else { 36 };
+
     // iter, repeat here is the number that reflects how many times we retrieve a random element.
     // It's used to measure relative performance.
     for (col, repeat) in collection_types.map(|col| match col {
@@ -253,7 +256,7 @@ async fn random_access() -> anyhow::Result<()> {
         Collection::IterableSet => (col, 1750),
         Collection::IterableMap => (col, 745),
         Collection::UnorderedSet => (col, 41),
-        Collection::UnorderedMap => (col, 42),
+        Collection::UnorderedMap => (col, unordered_map),
         Collection::Vector => (col, 1700),
         _ => (col, 0),
     }) {

--- a/near-sdk/tests/store_performance_tests.rs
+++ b/near-sdk/tests/store_performance_tests.rs
@@ -247,7 +247,7 @@ async fn random_access() -> anyhow::Result<()> {
     }
 
     // Rust 1.81 improved performance of unordered collections.
-    let unordered_map = if cfg!(rustversion::since(1.81)) { 42 } else { 36 };
+    let unordered_map = if rustversion::cfg!(since(1.81)) { 42 } else { 36 };
 
     // iter, repeat here is the number that reflects how many times we retrieve a random element.
     // It's used to measure relative performance.

--- a/near-sdk/tests/store_performance_tests.rs
+++ b/near-sdk/tests/store_performance_tests.rs
@@ -253,7 +253,7 @@ async fn random_access() -> anyhow::Result<()> {
         Collection::IterableSet => (col, 1750),
         Collection::IterableMap => (col, 745),
         Collection::UnorderedSet => (col, 41),
-        Collection::UnorderedMap => (col, 36),
+        Collection::UnorderedMap => (col, 42),
         Collection::Vector => (col, 1700),
         _ => (col, 0),
     }) {

--- a/near-sdk/tests/test-contracts/store/Cargo.toml
+++ b/near-sdk/tests/test-contracts/store/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = { path = "../../../../near-sdk", features = ["default", "unstable"]}
+near-sdk = { path = "../../../../near-sdk", features = ["default", "unstable"] }
 
 [workspace]


### PR DESCRIPTION
The 1.81 release finishes the C-unwind transition: [Details](https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html#abort-on-uncaught-panics-in-extern-c-functions)


It's a bit weird that UnorderedMap performs better on 1.81 than UnorderedSet. UnorderedMap uses 100 T whereas UnorderedSet uses 106T on fewer iterations. 