### PR TITLE
chore: release v5.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## [5.5.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.5.0...near-sdk-v5.5.1) - 2024-11-14
+## [5.6.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.5.0...near-sdk-v5.6.0) - 2024-11-14
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [5.5.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.5.0...near-sdk-v5.5.1) - 2024-11-14
+
+### Other
+
+- updates near-* dependencies to 0.27 release ([#1254](https://github.com/near/near-sdk-rs/pull/1254))
+- freeze 1.81 for near-workspaces paths (temporarily) ([#1250](https://github.com/near/near-sdk-rs/pull/1250))
+- Benchmark near collections and provide the results as the reference in the docs ([#1248](https://github.com/near/near-sdk-rs/pull/1248))
+- Updated near-workspaces to 0.14 version (matching 0.26 near-* release) ([#1246](https://github.com/near/near-sdk-rs/pull/1246))
+
 ## [5.5.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.4.0...near-sdk-v5.5.0) - 2024-09-11
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["near-sdk", "near-sdk-macros", "near-contract-standards", "near-sys"]
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.5.0"
+version = "5.5.1"
 
 # Special triple # comment for ci.
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["near-sdk", "near-sdk-macros", "near-contract-standards", "near-sys"]
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.5.1"
+version = "5.6.0"
 
 # Special triple # comment for ci.
 [patch.crates-io]

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.5.0", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.5.1", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.5.1", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.6.0", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.5.0" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.5.1" }
 near-sys = { path = "../near-sys", version = "0.2.2" }
 base64 = "0.22"
 borsh = { version = "1.0.0", features = ["derive"] }

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.5.1" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.6.0" }
 near-sys = { path = "../near-sys", version = "0.2.2" }
 base64 = "0.22"
 borsh = { version = "1.0.0", features = ["derive"] }


### PR DESCRIPTION
## 🤖 New release
* `near-sdk`: 5.5.0 -> 5.6.0 (✓ API compatible changes)
* `near-sdk-macros`: 5.5.0 -> 5.6.0
* `near-contract-standards`: 5.5.0 -> 5.6.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-sdk`
<blockquote>

## [5.6.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.5.0...near-sdk-v5.6.0) - 2024-11-14

### Other

- updates near-* dependencies to 0.27 release ([#1254](https://github.com/near/near-sdk-rs/pull/1254))
- freeze 1.81 for near-workspaces paths (temporarily) ([#1250](https://github.com/near/near-sdk-rs/pull/1250))
- Benchmark near collections and provide the results as the reference in the docs ([#1248](https://github.com/near/near-sdk-rs/pull/1248))
- Updated near-workspaces to 0.14 version (matching 0.26 near-* release) ([#1246](https://github.com/near/near-sdk-rs/pull/1246))
</blockquote>

## `near-contract-standards`
<blockquote>

## [5.5.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.4.0...near-contract-standards-v5.5.0) - 2024-09-11

### Other

- Updated near-* dependendencies to v0.26.0. Migrated testing blockchain mock to C-unwind ([#1244](https://github.com/near/near-sdk-rs/pull/1244))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).