### PR TITLE
fix: populate default values for contract_metadata

### DIFF
--- a/near-sdk-macros/src/core_impl/contract_metadata/mod.rs
+++ b/near-sdk-macros/src/core_impl/contract_metadata/mod.rs
@@ -13,7 +13,9 @@ struct MacroConfig {
 
 #[derive(serde::Serialize, Default, FromMeta)]
 pub(crate) struct ContractMetadata {
+    #[darling(default)]
     version: Option<String>,
+    #[darling(default)]
     link: Option<String>,
 
     #[darling(multiple, rename = "standard")]


### PR DESCRIPTION
Add `#[darling(default)]` attribute for `link` and `version` to make it possible to derive them from env:
```rust
#[near(contract_metadata(standard(standard = "nep141", version = "1.0.0")))
struct Contract {}
```

As current implementation returns an error:
```
error: expected an expression
 │   --> src/lib.rs:49:1
 │    |
 │ 49 | / #[near(
 │ 50 | |     contract_state,
 │ 51 | |     contract_metadata(standard(standard = "nep141", version = "1.0.0"))
 │ 52 | | )]
 │    | |__^
 │    |
 │    = note: this error originates in the attribute macro `near` (in Nightly builds, run with -Z macro-backtrace for more info)
 │ 
 │ error[E0425]: cannot find value `CONTRACT_SOURCE_METADATA` in this scope
 │   -->src/lib.rs:49:1
 │    |
 │ 49 | / #[near(
 │ 50 | |     contract_state,
 │ 51 | |     contract_metadata(standard(standard = "nep141", version = "1.0.0"))
 │ 52 | | )]
 │    | |__^ not found in this scope
 │    |
 │    = note: this error originates in the attribute macro `::near_sdk::near_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
```