### PR TITLE
ci: freeze 1.81 for near-workspaces paths (temporarily)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,7 @@ jobs:
           - os: ubuntu-latest
             rs: 1.79
           - os: ubuntu-latest
-            # rs: stable # tests/store-performance with near-workspaces involved are only on linux
-            rs: 1.81
+            rs: stable
           - os: macos-latest
             rs: 1.79
           - os: macos-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,13 +16,12 @@ jobs:
           - os: ubuntu-latest
             rs: 1.79
           - os: ubuntu-latest
-            # rs: stable
+            # rs: stable # tests/store-performance with near-workspaces involved are only on linux
             rs: 1.81
           - os: macos-latest
             rs: 1.79
           - os: macos-latest
-            # rs: stable
-            rs: 1.81
+            rs: stable
         features: ['', '--features unstable,legacy,__abi-generate']
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,13 @@ jobs:
           - os: ubuntu-latest
             rs: 1.79
           - os: ubuntu-latest
-            rs: stable
+            # rs: stable
+            rs: 1.81
           - os: macos-latest
             rs: 1.79
           - os: macos-latest
-            rs: stable
+            # rs: stable
+            rs: 1.81
         features: ['', '--features unstable,legacy,__abi-generate']
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -34,13 +34,16 @@ jobs:
       - uses: Swatinem/rust-cache@v1
         with:
           working-directory: ./examples/${{ matrix.example }}
-      - name: Build status-message
+      - name: Build status-message, factory-contract && test factory-contract
         if: matrix.example == 'factory-contract'
         env:
           RUSTFLAGS: '-C link-arg=-s'
         run: |
-          cargo +${{ matrix.toolchain }} build --manifest-path="./examples/status-message/Cargo.toml" --target wasm32-unknown-unknown --release --all &&
+          cargo +${{ matrix.toolchain }} build --manifest-path="./examples/status-message/Cargo.toml" --target wasm32-unknown-unknown --release --all
           cp ./examples/status-message/target/wasm32-unknown-unknown/release/*.wasm ./examples/status-message/res/
+          cargo +${{ matrix.toolchain }} build --manifest-path=./examples/factory-contract/Cargo.toml --target wasm32-unknown-unknown --release --all
+          cp ./examples/factory-contract/target/wasm32-unknown-unknown/release/*.wasm ./examples/factory-contract/res/
+          cargo +${{ matrix.toolchain }} test --manifest-path=./examples/factory-contract/Cargo.toml --all
       - name: Build
         env:
           RUSTFLAGS: '-C link-arg=-s'

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -13,7 +13,8 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest]
-        toolchain: [stable]
+        toolchain: [1.81]
+        # toolchain: [stable]
         example: [
           adder,
           callback-results,

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -35,16 +35,13 @@ jobs:
       - uses: Swatinem/rust-cache@v1
         with:
           working-directory: ./examples/${{ matrix.example }}
-      - name: Build status-message, factory-contract && test factory-contract
+      - name: Build `status-message`, that `factory-contract` depends on
         if: matrix.example == 'factory-contract'
         env:
           RUSTFLAGS: '-C link-arg=-s'
         run: |
-          cargo +${{ matrix.toolchain }} build --manifest-path="./examples/status-message/Cargo.toml" --target wasm32-unknown-unknown --release --all
+          cargo +${{ matrix.toolchain }} build --manifest-path="./examples/status-message/Cargo.toml" --target wasm32-unknown-unknown --release --all &&
           cp ./examples/status-message/target/wasm32-unknown-unknown/release/*.wasm ./examples/status-message/res/
-          cargo +${{ matrix.toolchain }} build --manifest-path=./examples/factory-contract/Cargo.toml --target wasm32-unknown-unknown --release --all
-          cp ./examples/factory-contract/target/wasm32-unknown-unknown/release/*.wasm ./examples/factory-contract/res/
-          cargo +${{ matrix.toolchain }} test --manifest-path=./examples/factory-contract/Cargo.toml --all
       - name: Build
         env:
           RUSTFLAGS: '-C link-arg=-s'

--- a/.github/workflows/test_examples_small.yml
+++ b/.github/workflows/test_examples_small.yml
@@ -13,7 +13,8 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest]
-        toolchain: [stable]
+        toolchain: [1.81]
+        # toolchain: [stable]
     steps:
       - uses: actions/checkout@v3
       - name: "${{ matrix.toolchain }} with rustfmt, clippy, and wasm32"

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -63,7 +63,7 @@ rand_chacha = "0.3.1"
 near-rng = "0.1.1"
 near-abi = { version = "0.4.0", features = ["__chunked-entries"] }
 symbolic-debuginfo = "12"
-near-workspaces = { version = "0.14", features = ["unstable"] }
+near-workspaces = { version = "0.14.1", features = ["unstable"] }
 anyhow = "1.0"
 tokio = { version = "1", features = ["full"] }
 strum = "0.25.0"

--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -105,6 +105,8 @@ pub fn set_blockchain_interface(blockchain_interface: MockedBlockchain) {
 
 /// Implements panic hook that converts `PanicInfo` into a string and provides it through the
 /// blockchain interface.
+// TODO: replace with std::panic::PanicHookInfo when MSRV becomes >= 1.81.0
+#[allow(deprecated)]
 fn panic_hook_impl(info: &std_panic::PanicInfo) {
     panic_str(info.to_string().as_str());
 }

--- a/near-sdk/tests/store_performance_tests.rs
+++ b/near-sdk/tests/store_performance_tests.rs
@@ -221,6 +221,7 @@ async fn iter() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[allow(clippy::ifs_same_cond)]
 #[tokio::test]
 async fn random_access() -> anyhow::Result<()> {
     // LookupMap and LookupSet are not iterable.
@@ -249,8 +250,6 @@ async fn random_access() -> anyhow::Result<()> {
     let unordered_map = if rustversion::cfg!(since(1.82)) {
         40
     // Rust 1.81 improved performance of unordered collections, 1.82 regressed it
-    //
-    // or maybe it's just different performace of the vm in github in different moments
     } else if rustversion::cfg!(since(1.81)) {
         42
     } else {

--- a/near-sdk/tests/store_performance_tests.rs
+++ b/near-sdk/tests/store_performance_tests.rs
@@ -246,8 +246,16 @@ async fn random_access() -> anyhow::Result<()> {
             .unwrap();
     }
 
-    // Rust 1.81 improved performance of unordered collections.
-    let unordered_map = if rustversion::cfg!(since(1.81)) { 42 } else { 36 };
+    let unordered_map = if rustversion::cfg!(since(1.82)) {
+        40
+    // Rust 1.81 improved performance of unordered collections, 1.82 regressed it
+    //
+    // or maybe it's just different performace of the vm in github in different moments
+    } else if rustversion::cfg!(since(1.81)) {
+        42
+    } else {
+        36
+    };
 
     // iter, repeat here is the number that reflects how many times we retrieve a random element.
     // It's used to measure relative performance.


### PR DESCRIPTION
https://github.com/near/near-sdk-rs/blob/master/.github/workflows/test.yml#L19-L23 is not affected, because `Test Core` job uses [`near_workspaces::compile_project`](https://github.com/near/near-sdk-rs/blob/master/near-sdk/tests/store_performance_tests.rs#L58)