### PR TITLE
chore!: updates near-* dependencies to 0.27 release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,11 @@ jobs:
       matrix:
         platform:
           - os: ubuntu-latest
-            rs: 1.79
+            rs: 1.80.0
           - os: ubuntu-latest
             rs: stable
           - os: macos-latest
-            rs: 1.79
+            rs: 1.80.0
           - os: macos-latest
             rs: stable
         features: ['', '--features unstable,legacy,__abi-generate']

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
   <p>
     <a href="https://docs.rs/near-sdk"><img src="https://docs.rs/near-sdk/badge.svg?style=flat-square" alt="Reference Documentation" /></a>
-    <a href="https://blog.rust-lang.org/2024/02/08/Rust-1.76.0.html"><img src="https://img.shields.io/badge/rustc-1.76+-lightgray.svg?style=flat-square" alt="MSRV" /></a>
+    <a href="https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html"><img src="https://img.shields.io/badge/rustc-1.80+-lightgray.svg?style=flat-square" alt="MSRV" /></a>
     <a href="https://crates.io/crates/near-sdk"><img src="https://img.shields.io/crates/v/near-sdk.svg?style=flat-square" alt="Crates.io version" /></a>
     <a href="https://crates.io/crates/near-sdk"><img src="https://img.shields.io/crates/d/near-sdk.svg?style=flat-square" alt="Download" /></a>
     <a href="https://near.chat"><img src="https://img.shields.io/discord/490367152054992913?style=flat-square&label=discord&color=lightgreen" alt="Join the community on Discord" /></a>
@@ -321,7 +321,7 @@ State breaking changes (low-level serialization format of any data type) will be
 
 ### MSRV
 
-The minimum supported Rust version is currently `1.76`. There are no guarantees that this will be upheld if a security patch release needs to come in that requires a Rust toolchain increase.
+The minimum supported Rust version is currently `1.80`. There are no guarantees that this will be upheld if a security patch release needs to come in that requires a Rust toolchain increase.
 
 ## Contributing
 

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -42,11 +42,11 @@ schemars = { version = "0.8.8", optional = true }
 near-abi = { version = "0.4.0", features = [
     "__chunked-entries",
 ], optional = true }
-near-vm-runner = { version = "0.26", optional = true }
-near-primitives-core = { version = "0.26", optional = true }
-near-primitives = { version = "0.26", optional = true }
-near-crypto = { version = "0.26", default-features = false, optional = true }
-near-parameters = { version = "0.26", optional = true }
+near-vm-runner = { version = "0.27", optional = true }
+near-primitives-core = { version = "0.27", optional = true }
+near-primitives = { version = "0.27", optional = true }
+near-crypto = { version = "0.27", default-features = false, optional = true }
+near-parameters = { version = "0.27", optional = true }
 
 [dev-dependencies]
 near-sdk = { path = ".", features = ["legacy", "unit-testing"] }

--- a/near-sdk/src/environment/mock/mocked_blockchain.rs
+++ b/near-sdk/src/environment/mock/mocked_blockchain.rs
@@ -61,6 +61,7 @@ struct LogicFixture {
     ext: Box<MockedExternal>,
     fees_config: Arc<RuntimeFeesConfig>,
     context: Box<near_vm_runner::logic::VMContext>,
+    memory: Box<dyn MemoryLike>,
 }
 
 impl<Memory> MockedBlockchain<Memory>
@@ -88,8 +89,9 @@ where
         let fees_config = Arc::new(fees_config);
         let result_state =
             ExecutionResultState::new(&context, context.make_gas_counter(&config), config.clone());
+        let memory = Box::new(memory.unwrap_or_default());
 
-        let mut logic_fixture = LogicFixture { ext, context, fees_config };
+        let mut logic_fixture = LogicFixture { ext, context, fees_config, memory };
 
         let logic = unsafe {
             VMLogic::new(
@@ -97,7 +99,7 @@ where
                 &*(logic_fixture.context.as_mut() as *mut near_vm_runner::logic::VMContext),
                 logic_fixture.fees_config.clone(),
                 result_state,
-                memory.unwrap_or_default(),
+                &mut *(logic_fixture.memory.as_mut() as *mut dyn MemoryLike),
             )
         };
 


### PR DESCRIPTION
bump up rust as near-crypto doesn't support 1.79 anymore