### PR TITLE
chore: Update dependencies in Cargo.toml files

### DIFF
--- a/examples/fungible-token/Cargo.toml
+++ b/examples/fungible-token/Cargo.toml
@@ -9,7 +9,6 @@ anyhow = "1.0"
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
 tokio = { version = "1.14", features = ["full"] }
 near-workspaces = { version = "0.15", features = ["unstable"] }
-cargo-near-build = "0.3.1"
 rstest = "0.23.0"
 
 [profile.release]

--- a/examples/lockable-fungible-token/Cargo.toml
+++ b/examples/lockable-fungible-token/Cargo.toml
@@ -15,7 +15,6 @@ anyhow = "1.0"
 tokio = { version = "1.14", features = ["full"] }
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
 near-workspaces = { version = "0.15", features = ["unstable"] }
-cargo-near-build = "0.3.1"
 rstest = "0.23.0"
 
 [profile.release]

--- a/examples/non-fungible-token/Cargo.toml
+++ b/examples/non-fungible-token/Cargo.toml
@@ -11,7 +11,6 @@ near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
 tokio = { version = "1.14", features = ["full"] }
 near-workspaces = { version = "0.15", features = ["unstable"] }
 rstest = "0.23.0"
-cargo-near-build = "0.3.1"
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
Closes #1257

Removed the individual export for `cargo-near-build` to use the default exported dependency