### PR TITLE
ci: allow clippy::needless_lifetimes (1.83 more suggestions)

### DIFF
--- a/near-contract-standards/src/lib.rs
+++ b/near-contract-standards/src/lib.rs
@@ -1,5 +1,6 @@
 // We want to enable all clippy lints, but some of them generate false positives.
 #![allow(clippy::missing_const_for_fn, clippy::redundant_pub_crate)]
+#![allow(clippy::needless_lifetimes)]
 
 /// Fungible tokens as described in [by the spec](https://nomicon.io/Standards/FungibleToken/README.html).
 pub mod fungible_token;

--- a/near-sdk/src/lib.rs
+++ b/near-sdk/src/lib.rs
@@ -4,6 +4,7 @@
 // We want to enable all clippy lints, but some of them generate false positives.
 #![allow(clippy::missing_const_for_fn, clippy::redundant_pub_crate)]
 #![allow(clippy::multiple_bound_locations)]
+#![allow(clippy::needless_lifetimes)]
 
 #[cfg(test)]
 extern crate quickcheck;


### PR DESCRIPTION
after comparing with #1266 the replacement `'_` doesn't look all that informative
![image](https://github.com/user-attachments/assets/43b32c9f-0f7e-40bf-8f34-b0faa7a57a5b)

mentioning https://github.com/rust-lang/rust-clippy/issues/13514
