### PR TITLE
chore: updates near-* dependencies to 0.28 release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,11 @@ jobs:
       matrix:
         platform:
           - os: ubuntu-latest
-            rs: 1.80.0
+            rs: 1.82.0
           - os: ubuntu-latest
             rs: stable
           - os: macos-latest
-            rs: 1.80.0
+            rs: 1.82.0
           - os: macos-latest
             rs: stable
         features: ['', '--features unstable,legacy,__abi-generate']

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -42,11 +42,11 @@ schemars = { version = "0.8.8", optional = true }
 near-abi = { version = "0.4.0", features = [
     "__chunked-entries",
 ], optional = true }
-near-vm-runner = { version = "0.27", optional = true }
-near-primitives-core = { version = "0.27", optional = true }
-near-primitives = { version = "0.27", optional = true }
-near-crypto = { version = "0.27", default-features = false, optional = true }
-near-parameters = { version = "0.27", optional = true }
+near-vm-runner = { version = "0.28", optional = true }
+near-primitives-core = { version = "0.28", optional = true }
+near-primitives = { version = "0.28", optional = true }
+near-crypto = { version = "0.28", default-features = false, optional = true }
+near-parameters = { version = "0.28", optional = true }
 
 [dev-dependencies]
 near-sdk = { path = ".", features = ["legacy", "unit-testing"] }


### PR DESCRIPTION
Bumped up rust to the 1.82  

@race-of-sloths