### PR TITLE
chore: release v5.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [5.6.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.6.0...near-sdk-v5.6.1) - 2024-12-13
+
+### Other
+
+- updates near-* dependencies to 0.28 release (#1272)
+- tests for Lazy and moving out of unstable (#1268)
+- add a `cargo doc` job (#1269)
+- allow clippy::needless_lifetimes (1.83 more suggestions) (#1267)
+- examples for Near-related host functions (#1259)
+- updates near-workspaces to 0.15 version (#1260)
+
 ## [5.6.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.5.0...near-sdk-v5.6.0) - 2024-11-14
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["near-sdk", "near-sdk-macros", "near-contract-standards", "near-sys"]
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.6.0"
+version = "5.6.1"
 
 # Special triple # comment for ci.
 [patch.crates-io]

--- a/near-contract-standards/CHANGELOG.md
+++ b/near-contract-standards/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.1](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.6.0...near-contract-standards-v5.6.1) - 2024-12-13
+
+### Other
+
+- add a `cargo doc` job (#1269)
+- allow clippy::needless_lifetimes (1.83 more suggestions) (#1267)
+
 ## [5.5.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.4.0...near-contract-standards-v5.5.0) - 2024-09-11
 
 ### Other

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.6.0", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.6.1", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.6.0" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.6.1" }
 near-sys = { path = "../near-sys", version = "0.2.2" }
 base64 = "0.22"
 borsh = { version = "1.0.0", features = ["derive"] }


### PR DESCRIPTION
## 🤖 New release
* `near-sdk`: 5.6.0 -> 5.6.1 (✓ API compatible changes)
* `near-sdk-macros`: 5.6.0 -> 5.6.1
* `near-contract-standards`: 5.6.0 -> 5.6.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-sdk`
<blockquote>

## [5.6.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.6.0...near-sdk-v5.6.1) - 2024-12-13

### Other

- updates near-* dependencies to 0.28 release (#1272)
- tests for Lazy and moving out of unstable (#1268)
- add a `cargo doc` job (#1269)
- allow clippy::needless_lifetimes (1.83 more suggestions) (#1267)
- examples for Near-related host functions (#1259)
- updates near-workspaces to 0.15 version (#1260)
</blockquote>

## `near-contract-standards`
<blockquote>

## [5.6.1](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.6.0...near-contract-standards-v5.6.1) - 2024-12-13

### Other

- add a `cargo doc` job (#1269)
- allow clippy::needless_lifetimes (1.83 more suggestions) (#1267)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).