### PR TITLE
fix: impaired PublicKey having his BorshSchema missing

### DIFF
--- a/near-sdk/src/types/public_key.rs
+++ b/near-sdk/src/types/public_key.rs
@@ -97,6 +97,7 @@ impl TryFrom<PublicKey> for near_crypto::PublicKey {
 ///             .unwrap();
 /// ```
 #[derive(Debug, Clone, PartialEq, PartialOrd, Ord, Eq, BorshSerialize, Hash)]
+#[cfg_attr(feature = "abi", derive(borsh::BorshSchema))]
 pub struct PublicKey {
     data: Vec<u8>,
 }


### PR DESCRIPTION
resolves #1280 

checked on such a contract
```rust
use near_sdk::PublicKey;

#[near(serializers = [json, borsh])]
pub struct Errors {
    field: Vec<PublicKey>,
}
```