### PR TITLE
chore: release v5.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [5.7.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.7.0...near-sdk-v5.7.1) - 2025-01-30
+
+### Other
+
+- improved documentation for near-sdk and near-sdk-macros crates (#1262)
+- clippy lint of 1.84 fixed (#1290)
+- `__abi-generate` feature in docs.rs (#1286)
+- updates near-workspaces to 0.16 version (#1284)
+- impaired PublicKey with missing BorshSchema (#1281)
+
 ## [5.7.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.6.0...near-sdk-v5.7.0) - 2024-12-13
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["near-sdk", "near-sdk-macros", "near-contract-standards", "near-sys"]
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.7.0"
+version = "5.7.1"
 
 # Special triple # comment for ci.
 [patch.crates-io]

--- a/near-contract-standards/CHANGELOG.md
+++ b/near-contract-standards/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.7.1](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.7.0...near-contract-standards-v5.7.1) - 2025-01-30
+
+### Other
+
+- `__abi-generate` feature in docs.rs (#1286)
+
 ## [5.7.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.6.0...near-contract-standards-v5.7.0) - 2024-12-13
 
 ### Other

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.7.0", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.7.1", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.7.0" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.7.1" }
 near-sys = { path = "../near-sys", version = "0.2.2" }
 base64 = "0.22"
 borsh = { version = "1.0.0", features = ["derive"] }


### PR DESCRIPTION
## 🤖 New release
* `near-sdk`: 5.7.0 -> 5.7.1 (✓ API compatible changes)
* `near-sdk-macros`: 5.7.0 -> 5.7.1
* `near-contract-standards`: 5.7.0 -> 5.7.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-sdk`
<blockquote>

## [5.7.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.7.0...near-sdk-v5.7.1) - 2025-01-30

### Other

- improved documentation for near-sdk and near-sdk-macros crates (#1262)
- clippy lint of 1.84 fixed (#1290)
- `__abi-generate` feature in docs.rs (#1286)
- updates near-workspaces to 0.16 version (#1284)
- impaired PublicKey with missing BorshSchema (#1281)
</blockquote>

## `near-contract-standards`
<blockquote>

## [5.7.1](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.7.0...near-contract-standards-v5.7.1) - 2025-01-30

### Other

- `__abi-generate` feature in docs.rs (#1286)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).