### PR TITLE
doc: `__abi-generate` feature in docs.rs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
       env:
         RUSTDOCFLAGS: -D warnings
       run: |
-        cargo doc -p near-sdk --features unstable,legacy,unit-testing,__macro-docs
-        cargo doc -p near-sdk-macros
-        cargo doc -p near-contract-standards --no-deps
+        cargo doc -p near-sdk --features unstable,legacy,unit-testing,__macro-docs,__abi-generate
+        cargo doc -p near-sdk-macros --features __abi-generate
+        cargo doc -p near-contract-standards --no-deps --features abi
         cargo doc -p near-sys

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -24,4 +24,7 @@ near-sdk = { path = "../near-sdk", default-features = false, features = [
 
 [features]
 default = []
-abi = ["near-sdk/abi"]
+abi = ["near-sdk/__abi-generate"]
+
+[package.metadata.docs.rs]
+features = ["abi"]

--- a/near-sdk-macros/Cargo.toml
+++ b/near-sdk-macros/Cargo.toml
@@ -34,3 +34,6 @@ prettyplease = { version = "0.2.15" }
 abi = []
 __abi-embed = ["abi"]
 __abi-generate = ["abi"]
+
+[package.metadata.docs.rs]
+features = ["__abi-generate"]

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -98,4 +98,4 @@ __abi-generate = ["abi", "near-sdk-macros/__abi-generate"]
 __macro-docs = []
 
 [package.metadata.docs.rs]
-features = ["unstable", "legacy", "unit-testing", "__macro-docs"]
+features = ["unstable", "legacy", "unit-testing", "__macro-docs", "__abi-generate"]


### PR DESCRIPTION
this changes how `Trait implementations` section for  https://docs.rs/near-sdk/5.7.0/near_sdk/struct.PublicKey.html looks :

from 
![image](https://github.com/user-attachments/assets/13429c43-461c-4407-bf24-9112845e70fd)

to 
![image](https://github.com/user-attachments/assets/68e59930-bf99-4afe-bb88-5c4f769c2b0a)
