### PR TITLE
ci(.github): add codecov.yml for failure threshold

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.2%


### PR DESCRIPTION
theoretically this should make coverage workflow not fail if single pr/change introduces less than 0.2% decrease of coverage

![image](https://github.com/user-attachments/assets/b5675857-4c69-441a-97cd-c48e81a5fcf7)
