### PR TITLE
chore: release v5.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [6.0.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.7.1...near-sdk-v6.0.0) - 2025-02-07
+
+### Added
+
+- *(near_sdk_macros)* improved error reporting for `near` macro (#1301)
+
+### Other
+
+- moved annotations to the near macro documentation.  (#1299)
+- moved near-sdk-macros doc to near-sdk crate. (#1295)
+
 ## [5.7.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.7.0...near-sdk-v5.7.1) - 2025-01-30
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## [6.0.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.7.1...near-sdk-v6.0.0) - 2025-02-07
+## [5.7.2](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.7.1...near-sdk-v5.7.2) - 2025-02-07
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## [5.7.2](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.7.1...near-sdk-v5.7.2) - 2025-02-07
+## [5.8.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.7.1...near-sdk-v5.8.0) - 2025-02-07
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["near-sdk", "near-sdk-macros", "near-contract-standards", "near-sys"]
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.7.2"
+version = "5.8.0"
 
 # Special triple # comment for ci.
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["near-sdk", "near-sdk-macros", "near-contract-standards", "near-sys"]
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.7.1"
+version = "6.0.0"
 
 # Special triple # comment for ci.
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["near-sdk", "near-sdk-macros", "near-contract-standards", "near-sys"]
 exclude = ["examples/"]
 
 [workspace.package]
-version = "6.0.0"
+version = "5.7.2"
 
 # Special triple # comment for ci.
 [patch.crates-io]

--- a/near-contract-standards/CHANGELOG.md
+++ b/near-contract-standards/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [5.7.2](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.7.1...near-contract-standards-v5.7.2) - 2025-02-07
+## [5.8.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.7.1...near-contract-standards-v5.8.0) - 2025-02-07
 
 ### Other
 

--- a/near-contract-standards/CHANGELOG.md
+++ b/near-contract-standards/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [6.0.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.7.1...near-contract-standards-v6.0.0) - 2025-02-07
+## [5.7.2](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.7.1...near-contract-standards-v5.7.2) - 2025-02-07
 
 ### Other
 

--- a/near-contract-standards/CHANGELOG.md
+++ b/near-contract-standards/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.7.1...near-contract-standards-v6.0.0) - 2025-02-07
+
+### Other
+
+- *(near-contract-standards)* add `build_info` field (#1297)
+
 ## [5.7.1](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.7.0...near-contract-standards-v5.7.1) - 2025-01-30
 
 ### Other

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.7.2", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.8.0", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~6.0.0", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.7.2", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.7.1", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~6.0.0", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~6.0.0" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.7.2" }
 near-sys = { path = "../near-sys", version = "0.2.2" }
 base64 = "0.22"
 borsh = { version = "1.0.0", features = ["derive"] }
@@ -98,4 +98,10 @@ __abi-generate = ["abi", "near-sdk-macros/__abi-generate"]
 __macro-docs = []
 
 [package.metadata.docs.rs]
-features = ["unstable", "legacy", "unit-testing", "__macro-docs", "__abi-generate"]
+features = [
+    "unstable",
+    "legacy",
+    "unit-testing",
+    "__macro-docs",
+    "__abi-generate",
+]

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.7.1" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~6.0.0" }
 near-sys = { path = "../near-sys", version = "0.2.2" }
 base64 = "0.22"
 borsh = { version = "1.0.0", features = ["derive"] }

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.7.2" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.8.0" }
 near-sys = { path = "../near-sys", version = "0.2.2" }
 base64 = "0.22"
 borsh = { version = "1.0.0", features = ["derive"] }


### PR DESCRIPTION

## 🤖 New release

* `near-sdk`: 5.8.0
* `near-sdk-macros`: 5.8.0
* `near-contract-standards`: 5.8.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-sdk`

<blockquote>

## [5.8.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.7.1...near-sdk-v5.8.0) - 2025-02-07

### Added

- *(near_sdk_macros)* improved error reporting for `near` macro (#1301)

### Other

- moved annotations to the near macro documentation.  (#1299)
- moved near-sdk-macros doc to near-sdk crate. (#1295)
</blockquote>


## `near-contract-standards`

<blockquote>

## [5.8.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.7.1...near-contract-standards-v5.8.0) - 2025-02-07

### Other

- *(near-contract-standards)* add `build_info` field (#1297)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).