### PR TITLE
chore: release v5.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [5.8.2](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.8.1...near-sdk-v5.8.2) - 2025-03-06
+
+### Other
+
+- impl details of `#[callback_unwrap]` ([#1321](https://github.com/near/near-sdk-rs/pull/1321))
+- `#[near(contract_state)]` in-depth pass ([#1307](https://github.com/near/near-sdk-rs/pull/1307))
+- document `callback_unwrap` attribute ([#1313](https://github.com/near/near-sdk-rs/pull/1313))
+
 ## [5.8.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.8.0...near-sdk-v5.8.1) - 2025-02-17
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["near-sdk", "near-sdk-macros", "near-contract-standards", "near-sys"]
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.8.1"
+version = "5.8.2"
 
 # Special triple # comment for ci.
 [patch.crates-io]

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.8.1", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.8.2", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.8.1" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.8.2" }
 near-sys = { path = "../near-sys", version = "0.2.2" }
 base64 = "0.22"
 borsh = { version = "1.0.0", features = ["derive"] }


### PR DESCRIPTION



## 🤖 New release

* `near-sdk-macros`: 5.8.1 -> 5.8.2
* `near-sdk`: 5.8.1 -> 5.8.2 (✓ API compatible changes)
* `near-contract-standards`: 5.8.1 -> 5.8.2

<details><summary><i><b>Changelog</b></i></summary><p>


## `near-sdk`

<blockquote>

## [5.8.2](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.8.1...near-sdk-v5.8.2) - 2025-03-06

### Other

- impl details of `#[callback_unwrap]` ([#1321](https://github.com/near/near-sdk-rs/pull/1321))
- `#[near(contract_state)]` in-depth pass ([#1307](https://github.com/near/near-sdk-rs/pull/1307))
- document `callback_unwrap` attribute ([#1313](https://github.com/near/near-sdk-rs/pull/1313))
</blockquote>

## `near-contract-standards`

<blockquote>

## [5.8.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.7.1...near-contract-standards-v5.8.0) - 2025-02-07

### Other

- *(near-contract-standards)* add `build_info` field (#1297)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).