### PR TITLE
chore: release v5.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## [5.8.3](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.8.2...near-sdk-v5.8.3) - 2025-03-06
+## [5.9.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.8.2...near-sdk-v5.9.0) - 2025-03-06
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [5.8.3](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.8.2...near-sdk-v5.8.3) - 2025-03-06
+
+### Other
+
+- updates near-* dependencies to 0.29 release ([#1325](https://github.com/near/near-sdk-rs/pull/1325))
+
 ## [5.8.2](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.8.1...near-sdk-v5.8.2) - 2025-03-06
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["near-sdk", "near-sdk-macros", "near-contract-standards", "near-sys"]
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.8.3"
+version = "5.9.0"
 
 # Special triple # comment for ci.
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["near-sdk", "near-sdk-macros", "near-contract-standards", "near-sys"]
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.8.2"
+version = "5.8.3"
 
 # Special triple # comment for ci.
 [patch.crates-io]

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.8.3", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.9.0", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.8.2", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.8.3", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.8.3" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.9.0" }
 near-sys = { path = "../near-sys", version = "0.2.2" }
 base64 = "0.22"
 borsh = { version = "1.0.0", features = ["derive"] }

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.8.2" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.8.3" }
 near-sys = { path = "../near-sys", version = "0.2.2" }
 base64 = "0.22"
 borsh = { version = "1.0.0", features = ["derive"] }


### PR DESCRIPTION


## 🤖 New release

* `near-sdk-macros`: 5.8.2 -> 5.9.0
* `near-sdk`: 5.8.2 -> 5.9.0
* `near-contract-standards`: 5.8.2 -> 5.9.0

<details><summary><i><b>Changelog</b></i></summary><p>


## `near-sdk`

<blockquote>

## [5.9.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.8.2...near-sdk-v5.9.0) - 2025-03-06

### Other

- updates near-* dependencies to 0.29 release ([#1325](https://github.com/near/near-sdk-rs/pull/1325))
</blockquote>

## `near-contract-standards`

<blockquote>

## [5.9.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.7.1...near-contract-standards-v5.9.0) - 2025-02-07

### Other

- *(near-contract-standards)* add `build_info` field (#1297)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).