### PR TITLE
feat: Added promise_yield_create and promise_yield_resume APIs to the mocked test utils

### DIFF
--- a/near-sdk/src/environment/mock/mocked_blockchain.rs
+++ b/near-sdk/src/environment/mock/mocked_blockchain.rs
@@ -548,6 +548,44 @@ mod mock_chain {
         })
     }
     #[no_mangle]
+    extern "C-unwind" fn promise_yield_create(
+        function_name_len: u64,
+        function_name_ptr: u64,
+        arguments_len: u64,
+        arguments_ptr: u64,
+        gas: u64,
+        gas_weight: u64,
+        register_id: u64,
+    ) -> u64 {
+        with_mock_interface(|b| {
+            b.promise_yield_create(
+                function_name_len,
+                function_name_ptr,
+                arguments_len,
+                arguments_ptr,
+                gas,
+                gas_weight,
+                register_id,
+            )
+        })
+    }
+    #[no_mangle]
+    extern "C-unwind" fn promise_yield_resume(
+        data_id_len: u64,
+        data_id_ptr: u64,
+        payload_len: u64,
+        payload_ptr: u64,
+    ) -> u32 {
+        with_mock_interface(|b| {
+            b.promise_yield_resume(
+                data_id_len,
+                data_id_ptr,
+                payload_len,
+                payload_ptr,
+            )
+        })
+    }
+    #[no_mangle]
     extern "C-unwind" fn promise_results_count() -> u64 {
         with_mock_interface(|b| b.promise_results_count())
     }

--- a/near-sdk/src/environment/mock/mocked_blockchain.rs
+++ b/near-sdk/src/environment/mock/mocked_blockchain.rs
@@ -577,12 +577,7 @@ mod mock_chain {
         payload_ptr: u64,
     ) -> u32 {
         with_mock_interface(|b| {
-            b.promise_yield_resume(
-                data_id_len,
-                data_id_ptr,
-                payload_len,
-                payload_ptr,
-            )
+            b.promise_yield_resume(data_id_len, data_id_ptr, payload_len, payload_ptr)
         })
     }
     #[no_mangle]


### PR DESCRIPTION
Without this change the tests for the contracts that use yield API fail with the following compilation errors:

```
ld: warning: object file (/projects/near/mpc/libs/chain-signatures/target/debug/deps/libsecp256k1_sys-98527547b5aca695.rlib[6](fce6141bfa9bf74c-precomputed_ecmult.o)) was built for newer 'macOS' version (15.2) than being linked (15.0)
ld: warning: object file (/projects/near/mpc/libs/chain-signatures/target/debug/deps/libsecp256k1_sys-98527547b5aca695.rlib[7](fce6141bfa9bf74c-secp256k1.o)) was built for newer 'macOS' version (15.2) than being linked (15.0)
Undefined symbols for architecture arm64:
  "_promise_yield_create", referenced from:
    near_sdk::environment::env::promise_yield_create::h6ab688e32bb03837 in libnear_sdk-6b877ec05e41e84e.rlib[7](near_sdk-6b877ec05e41e84e.near_sdk.2aa833a138d63134-cgu.04.rcgu.o)
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```