### PR TITLE
chore: release v5.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## [6.0.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.11.0...near-sdk-v6.0.0) - 2025-04-10
+## [5.12.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.11.0...near-sdk-v5.12.0) - 2025-04-10
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [6.0.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.11.0...near-sdk-v6.0.0) - 2025-04-10
+
+### Added
+
+- nep330 result wasm path field  ([#1344](https://github.com/near/near-sdk-rs/pull/1344))
+
+### Other
+
+- Fixed linting warnings (clippy Rust 1.86) ([#1345](https://github.com/near/near-sdk-rs/pull/1345))
+- added example how to use `promise_yield_create` and `promise_yield_resume` ([#1133](https://github.com/near/near-sdk-rs/pull/1133))
+- updated near-workspaces in examples ([#1337](https://github.com/near/near-sdk-rs/pull/1337))
+
 ## [5.11.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.10.0...near-sdk-v5.11.0) - 2025-03-22
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["near-sdk", "near-sdk-macros", "near-contract-standards", "near-sys"]
 exclude = ["examples/"]
 
 [workspace.package]
-version = "6.0.0"
+version = "5.12.0"
 
 # Special triple # comment for ci.
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["near-sdk", "near-sdk-macros", "near-contract-standards", "near-sys"]
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.11.0"
+version = "6.0.0"
 
 # Special triple # comment for ci.
 [patch.crates-io]

--- a/near-contract-standards/CHANGELOG.md
+++ b/near-contract-standards/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.11.0...near-contract-standards-v6.0.0) - 2025-04-10
+
+### Added
+
+- nep330 result wasm path field  ([#1344](https://github.com/near/near-sdk-rs/pull/1344))
+
 ## [5.8.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.7.1...near-contract-standards-v5.8.0) - 2025-02-07
 
 ### Other

--- a/near-contract-standards/CHANGELOG.md
+++ b/near-contract-standards/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [6.0.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.11.0...near-contract-standards-v6.0.0) - 2025-04-10
+## [5.12.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.11.0...near-contract-standards-v5.12.0) - 2025-04-10
 
 ### Added
 

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~6.0.0", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.12.0", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.11.0", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~6.0.0", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~6.0.0" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.12.0" }
 near-sys = { path = "../near-sys", version = "0.2.2" }
 base64 = "0.22"
 borsh = { version = "1.0.0", features = ["derive"] }

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.11.0" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~6.0.0" }
 near-sys = { path = "../near-sys", version = "0.2.2" }
 base64 = "0.22"
 borsh = { version = "1.0.0", features = ["derive"] }


### PR DESCRIPTION
## 🤖 New release

* `near-sdk-macros`: 5.11.0 -> 5.12.0
* `near-sdk`: 5.11.0 -> 5.12.0 (✓ API compatible changes)
* `near-contract-standards`: 5.11.0 -> 5.12.0 (⚠ API breaking changes)

### ⚠ `near-contract-standards` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field BuildInfo.output_wasm_path in /tmp/.tmpY5Au7r/near-sdk-rs/near-contract-standards/src/contract_metadata.rs:183
```

<details><summary><i><b>Changelog</b></i></summary><p>


## `near-sdk`

<blockquote>

## [5.12.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.11.0...near-sdk-v5.12.0) - 2025-04-10

### Added

- nep330 result wasm path field  ([#1344](https://github.com/near/near-sdk-rs/pull/1344))

### Other

- Fixed linting warnings (clippy Rust 1.86) ([#1345](https://github.com/near/near-sdk-rs/pull/1345))
- added example how to use `promise_yield_create` and `promise_yield_resume` ([#1133](https://github.com/near/near-sdk-rs/pull/1133))
- updated near-workspaces in examples ([#1337](https://github.com/near/near-sdk-rs/pull/1337))
</blockquote>

## `near-contract-standards`

<blockquote>

## [5.12.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.11.0...near-contract-standards-v5.12.0) - 2025-04-10

### Added

- nep330 result wasm path field  ([#1344](https://github.com/near/near-sdk-rs/pull/1344))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).