### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+## [5.13.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.12.0...near-sdk-v5.13.0) - 2025-05-05
+
+### Added
+
+- Added BLS12-381 curve operations support in near-sys and exposed in near_sdk::env ([#1346](https://github.com/near/near-sdk-rs/pull/1346))
+
+### Fixed
+
+- BLS12-381 pairing check return value comparison ([#1352](https://github.com/near/near-sdk-rs/pull/1352))
+- Fixed the tokenization of of ContractMetadata, where it can lead to invalid meta if `link` and `version` is not provided ([#1349](https://github.com/near/near-sdk-rs/pull/1349))
+
+### Other
+
+- update `near-workspaces`, `cargo-near-build`in examples and core tests  to avoid `wasm-opt` compile ([#1350](https://github.com/near/near-sdk-rs/pull/1350))
+
 ## [5.12.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.11.0...near-sdk-v5.12.0) - 2025-04-10
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["near-sdk", "near-sdk-macros", "near-contract-standards", "near-sys"]
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.12.0"
+version = "5.13.0"
 
 # Special triple # comment for ci.
 [patch.crates-io]

--- a/near-contract-standards/CHANGELOG.md
+++ b/near-contract-standards/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.13.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.12.0...near-contract-standards-v5.13.0) - 2025-05-05
+
+### Other
+
+- resolves https://github.com/near/NEPs/pull/606/files#r2045175915 ([#1348](https://github.com/near/near-sdk-rs/pull/1348))
+
 ## [5.12.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.11.0...near-contract-standards-v5.12.0) - 2025-04-10
 
 ### Added

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.12.0", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.13.0", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,8 +21,8 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.12.0" }
-near-sys = { path = "../near-sys", version = "0.2.2" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.13.0" }
+near-sys = { path = "../near-sys", version = "0.2.3" }
 base64 = "0.22"
 borsh = { version = "1.0.0", features = ["derive"] }
 bs58 = "0.5"

--- a/near-sys/CHANGELOG.md
+++ b/near-sys/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.2...near-sys-v0.2.3) - 2025-05-05
+
+### Added
+
+- Added BLS12-381 curve operations support in near-sys and exposed in near_sdk::env ([#1346](https://github.com/near/near-sdk-rs/pull/1346))
+
 ## [0.2.2](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.1...near-sys-v0.2.2) - 2024-07-04
 
 ### Other

--- a/near-sys/Cargo.toml
+++ b/near-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sys"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Near Inc <hello@near.org>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `near-sdk-macros`: 5.12.0 -> 5.13.0
* `near-sys`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `near-sdk`: 5.12.0 -> 5.13.0 (✓ API compatible changes)
* `near-contract-standards`: 5.12.0 -> 5.13.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `near-sys`

<blockquote>

## [0.2.3](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.2...near-sys-v0.2.3) - 2025-05-05

### Added

- Added BLS12-381 curve operations support in near-sys and exposed in near_sdk::env ([#1346](https://github.com/near/near-sdk-rs/pull/1346))
</blockquote>

## `near-sdk`

<blockquote>

## [5.13.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.12.0...near-sdk-v5.13.0) - 2025-05-05

### Added

- Added BLS12-381 curve operations support in near-sys and exposed in near_sdk::env ([#1346](https://github.com/near/near-sdk-rs/pull/1346))

### Fixed

- BLS12-381 pairing check return value comparison ([#1352](https://github.com/near/near-sdk-rs/pull/1352))
- Fixed the tokenization of of ContractMetadata, where it can lead to invalid meta if `link` and `version` is not provided ([#1349](https://github.com/near/near-sdk-rs/pull/1349))

### Other

- update `near-workspaces`, `cargo-near-build`in examples and core tests  to avoid `wasm-opt` compile ([#1350](https://github.com/near/near-sdk-rs/pull/1350))
</blockquote>

## `near-contract-standards`

<blockquote>

## [5.13.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.12.0...near-contract-standards-v5.13.0) - 2025-05-05

### Other

- resolves https://github.com/near/NEPs/pull/606/files#r2045175915 ([#1348](https://github.com/near/near-sdk-rs/pull/1348))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).