### PR TITLE
chore(near-contract-standards): deserialize `ContractSourceMetadata::standards` field so, as if it were optional

### DIFF
--- a/near-contract-standards/src/contract_metadata.rs
+++ b/near-contract-standards/src/contract_metadata.rs
@@ -72,6 +72,7 @@ pub struct ContractSourceMetadata {
     /// # ;
     /// ```
     // it's a guess it was added as 1.1.0 of nep330, [nep330 1.1.0 standard recording](https://www.youtube.com/watch?v=pBLN9UyE6AA) actually discusses nep351
+    #[serde(default)]
     pub standards: Vec<Standard>,
     /// Optional details that are required for formal contract WASM build reproducibility verification
     ///


### PR DESCRIPTION
resolves https://github.com/near/NEPs/pull/606/files/1c5678510ae37f52037f1497e27febd564525d54#r2045175915