### PR TITLE
Fix the tokenization of of ContractMetadata, where it can lead to invalid meta

### DIFF
--- a/near-sdk-macros/src/core_impl/contract_metadata/mod.rs
+++ b/near-sdk-macros/src/core_impl/contract_metadata/mod.rs
@@ -47,10 +47,16 @@ impl quote::ToTokens for ContractMetadata {
                 standard(standard = #standard_name, version = #standard_version),
             };
         }
+
+        // This is necessary, because using a simple `version = #version`, will lead to macros tokenizing `version = None` to `version = `, which
+        // cannot be parsed as meta and is considered invalid.
+        let version_tokens = version.as_ref().map(|v| quote! { version = #v, });
+        let link_tokens = link.as_ref().map(|l| quote! { link = #l, });
+
         tokens.extend(quote! {
             contract_metadata(
-                version = #version,
-                link = #link,
+                #version_tokens
+                #link_tokens
                 #standards
             )
         })

--- a/near-sdk/compilation_tests/all.rs
+++ b/near-sdk/compilation_tests/all.rs
@@ -38,6 +38,7 @@ fn compilation_tests() {
     t.compile_fail("compilation_tests/self_forbidden_in_non_init_fn_arg.rs");
     t.pass("compilation_tests/handle_result_alias.rs");
     t.pass("compilation_tests/contract_metadata.rs");
+    t.pass("compilation_tests/contract_metadata-no-version-no-link.rs");
     t.compile_fail("compilation_tests/contract_metadata_fn_name.rs");
     t.pass("compilation_tests/contract_metadata_bindgen.rs");
     t.pass("compilation_tests/types.rs");

--- a/near-sdk/compilation_tests/contract_metadata-no-version-no-link.rs
+++ b/near-sdk/compilation_tests/contract_metadata-no-version-no-link.rs
@@ -1,0 +1,13 @@
+use near_sdk::near;
+
+#[near(contract_state, contract_metadata(
+    standard(standard = "nep330", version = "1.1.0"),
+    standard(standard = "nep171", version = "1.0.0"),
+    standard(standard = "nep177", version = "2.0.0"),
+))]
+struct Contract {}
+
+#[near]
+impl Contract {}
+
+fn main() {}


### PR DESCRIPTION
When macros like `#[near]` tokenize the user input of metadata to put it in `ContractMetadata`, the way it's implemented now leads to invalid meta if the user doesn't include version or link. This happens because, for example, a non-existing version is tokenized to `version = ` instead of nothing. This leads to compilation errors that originate at `MacroConfig::from_list(...)`, since a key without a valid value is not seen as valid meta code.

This PR fixes that issue for both `version` and `link`. Now both work correctly and can be omitted, and they will be inherited from cargo attributes.