### PR TITLE
ci: update `near-workspaces`, `cargo-near-build`in examples and core tests  to avoid `wasm-opt` compile

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,6 +44,8 @@ jobs:
         run: rustup component add rust-src --toolchain ${{ matrix.toolchain }}
       - name: Verify Rust Toolchain
         run: rustup show
+      - name: Install cargo-near CLI (dependency for build with near-workspaces)
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.14.0/cargo-near-installer.sh | sh
       - name: Generate code coverage
         run: cargo +${{ matrix.toolchain }} llvm-cov --lcov --output-path llvm-cov-output.lcov
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ jobs:
           toolchain: ${{ matrix.platform.rs }}
           default: true
           target: wasm32-unknown-unknown
+      - name: Install cargo-near CLI (dependency for build with near-workspaces)
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.14.0/cargo-near-installer.sh | sh
       - uses: Swatinem/rust-cache@v2
 #      - name: Downgrade dependencies
 #        run: |

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -39,4 +39,6 @@ jobs:
         with:
           workspaces: "./examples/${{ matrix.example }} -> target"
       - name: Test
+        env:
+          NEAR_RPC_TIMEOUT_SECS: 100
         run: cargo +${{ matrix.toolchain }} test --manifest-path="./examples/${{ matrix.example }}/Cargo.toml" --workspace

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -33,6 +33,8 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
           target: wasm32-unknown-unknown
+      - name: Install cargo-near CLI (dependency for build with near-workspaces)
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.14.0/cargo-near-installer.sh | sh
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "./examples/${{ matrix.example }} -> target"

--- a/.github/workflows/test_examples_small.yml
+++ b/.github/workflows/test_examples_small.yml
@@ -29,6 +29,8 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
           target: wasm32-unknown-unknown
+      - name: Install cargo-near CLI (dependency for build with near-workspaces)
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.14.0/cargo-near-installer.sh | sh
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "./examples/${{ matrix.example }} -> target"

--- a/.github/workflows/test_examples_small.yml
+++ b/.github/workflows/test_examples_small.yml
@@ -35,4 +35,6 @@ jobs:
         with:
           workspaces: "./examples/${{ matrix.example }} -> target"
       - name: Test
+        env:
+          NEAR_RPC_TIMEOUT_SECS: 100
         run: cargo +${{ matrix.toolchain }} test  --manifest-path=./examples/${{ matrix.example }}/Cargo.toml --workspace

--- a/examples/adder/Cargo.toml
+++ b/examples/adder/Cargo.toml
@@ -11,9 +11,7 @@ crate-type = ["cdylib"]
 near-sdk = { path = "../../near-sdk" }
 
 [dev-dependencies]
-near-workspaces = { version = "0.18", features = [
-    "unstable",
-], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
+near-workspaces = { version = "0.19", features = ["unstable"] }
 tokio = { version = "1.14", features = ["full"] }
 anyhow = "1.0"
 near-abi = "0.4.0"

--- a/examples/adder/Cargo.toml
+++ b/examples/adder/Cargo.toml
@@ -11,7 +11,9 @@ crate-type = ["cdylib"]
 near-sdk = { path = "../../near-sdk" }
 
 [dev-dependencies]
-near-workspaces = { version = "0.18", features = ["unstable"] }
+near-workspaces = { version = "0.18", features = [
+    "unstable",
+], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
 tokio = { version = "1.14", features = ["full"] }
 anyhow = "1.0"
 near-abi = "0.4.0"

--- a/examples/callback-results/Cargo.toml
+++ b/examples/callback-results/Cargo.toml
@@ -11,7 +11,9 @@ crate-type = ["cdylib"]
 near-sdk = { path = "../../near-sdk" }
 
 [dev-dependencies]
-near-workspaces = { version = "0.18", features = ["unstable"] }
+near-workspaces = { version = "0.18", features = [
+    "unstable",
+], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
 tokio = { version = "1.14", features = ["full"] }
 anyhow = "1.0"
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }

--- a/examples/callback-results/Cargo.toml
+++ b/examples/callback-results/Cargo.toml
@@ -11,9 +11,7 @@ crate-type = ["cdylib"]
 near-sdk = { path = "../../near-sdk" }
 
 [dev-dependencies]
-near-workspaces = { version = "0.18", features = [
-    "unstable",
-], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
+near-workspaces = { version = "0.19", features = ["unstable"] }
 tokio = { version = "1.14", features = ["full"] }
 anyhow = "1.0"
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }

--- a/examples/cross-contract-calls/Cargo.toml
+++ b/examples/cross-contract-calls/Cargo.toml
@@ -9,9 +9,7 @@ anyhow = "1.0"
 near-sdk = { path = "../../near-sdk", features = ["default", "unit-testing"] }
 test-case = "2.0"
 tokio = { version = "1.14", features = ["full"] }
-near-workspaces = { version = "0.18", features = [
-    "unstable",
-], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
+near-workspaces = { version = "0.19", features = ["unstable"] }
 
 cross-contract-high-level = { path = "./high-level" }
 cross-contract-low-level = { path = "./low-level" }

--- a/examples/cross-contract-calls/Cargo.toml
+++ b/examples/cross-contract-calls/Cargo.toml
@@ -9,7 +9,9 @@ anyhow = "1.0"
 near-sdk = { path = "../../near-sdk", features = ["default", "unit-testing"] }
 test-case = "2.0"
 tokio = { version = "1.14", features = ["full"] }
-near-workspaces = { version = "0.18", features = ["unstable"] }
+near-workspaces = { version = "0.18", features = [
+    "unstable",
+], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
 
 cross-contract-high-level = { path = "./high-level" }
 cross-contract-low-level = { path = "./low-level" }

--- a/examples/factory-contract/Cargo.toml
+++ b/examples/factory-contract/Cargo.toml
@@ -9,9 +9,7 @@ anyhow = "1.0"
 test-case = "2.0"
 tokio = { version = "1.14", features = ["full"] }
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
-near-workspaces = { version = "0.18", features = [
-    "unstable",
-], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
+near-workspaces = { version = "0.19", features = ["unstable"] }
 
 [profile.release]
 codegen-units = 1

--- a/examples/factory-contract/Cargo.toml
+++ b/examples/factory-contract/Cargo.toml
@@ -9,7 +9,9 @@ anyhow = "1.0"
 test-case = "2.0"
 tokio = { version = "1.14", features = ["full"] }
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
-near-workspaces = { version = "0.18", features = ["unstable"] }
+near-workspaces = { version = "0.18", features = [
+    "unstable",
+], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
 
 [profile.release]
 codegen-units = 1

--- a/examples/factory-contract/high-level/Cargo.toml
+++ b/examples/factory-contract/high-level/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 near-sdk = { path = "../../../near-sdk" }
 [build-dependencies]
-cargo-near-build = { version = "0.3.0", features = ["build_script"] }
+cargo-near-build = { version = "0.5.1", git = "https://github.com/dj8yfo/cargo-near.git", branch = "feat/build-external-method" }
 
 [dev-dependencies]
-near-sdk = { path = "../../../near-sdk", features = ["unit-testing"] }
+cargo-near-build = { version = "0.5.1", git = "https://github.com/dj8yfo/cargo-near.git", branch = "feat/build-external-method" }

--- a/examples/factory-contract/high-level/Cargo.toml
+++ b/examples/factory-contract/high-level/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 near-sdk = { path = "../../../near-sdk" }
 [build-dependencies]
-cargo-near-build = { version = "0.5.1", git = "https://github.com/dj8yfo/cargo-near.git", branch = "feat/build-external-method" }
+cargo-near-build = { version = "0.5.1", git = "https://github.com/dj8yfo/cargo-near.git", branch = "feat/extended-build-with-cli" }
 
 [dev-dependencies]
-cargo-near-build = { version = "0.5.1", git = "https://github.com/dj8yfo/cargo-near.git", branch = "feat/build-external-method" }
+cargo-near-build = { version = "0.5.1", git = "https://github.com/dj8yfo/cargo-near.git", branch = "feat/extended-build-with-cli" }

--- a/examples/factory-contract/high-level/Cargo.toml
+++ b/examples/factory-contract/high-level/Cargo.toml
@@ -10,8 +10,5 @@ crate-type = ["cdylib"]
 [dependencies]
 near-sdk = { path = "../../../near-sdk" }
 [build-dependencies]
-cargo-near-build = { version = "0.5.1", git = "https://github.com/dj8yfo/cargo-near.git", branch = "feat/extended-build-with-cli" }
+cargo-near-build = { version = "0.6.0" }
 duct = "0.13.7"
-
-[dev-dependencies]
-cargo-near-build = { version = "0.5.1", git = "https://github.com/dj8yfo/cargo-near.git", branch = "feat/extended-build-with-cli" }

--- a/examples/factory-contract/high-level/Cargo.toml
+++ b/examples/factory-contract/high-level/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 near-sdk = { path = "../../../near-sdk" }
 [build-dependencies]
 cargo-near-build = { version = "0.5.1", git = "https://github.com/dj8yfo/cargo-near.git", branch = "feat/extended-build-with-cli" }
+duct = "0.13.7"
 
 [dev-dependencies]
 cargo-near-build = { version = "0.5.1", git = "https://github.com/dj8yfo/cargo-near.git", branch = "feat/extended-build-with-cli" }

--- a/examples/factory-contract/high-level/build.rs
+++ b/examples/factory-contract/high-level/build.rs
@@ -37,6 +37,7 @@ fn main() {
     let override_cargo_target_dir = override_cargo_target_dir();
     let build_opts = cargo_near_build::BuildOpts::builder()
         .manifest_path(manifest)
+        .no_locked(true)
         .override_cargo_target_dir(override_cargo_target_dir.to_string())
         .override_nep330_contract_path(nep330_contract_path)
         .override_nep330_output_wasm_path(nep330_output_wasm_path)
@@ -50,7 +51,7 @@ fn main() {
         is_abi_or_cargo_check,
         vec![&workdir, "Cargo.toml", "../Cargo.lock"],
         out_path,
-        "BUILD_RS_SUB_BUILD_ARTIFACT_1",
+        "BUILD_RS_SUB_BUILD_STATUS-MESSAGE",
     );
 }
 

--- a/examples/factory-contract/high-level/build.rs
+++ b/examples/factory-contract/high-level/build.rs
@@ -67,7 +67,7 @@ mod run_build {
             std::fs::write(&out_path, b"").expect("success write");
             out_path
         } else {
-            cargo_near_build::build_with_cli(opts).expect("successfull build")
+            cargo_near_build::build_with_cli(opts).expect("successful build")
         }
     }
 }

--- a/examples/factory-contract/high-level/build.rs
+++ b/examples/factory-contract/high-level/build.rs
@@ -1,14 +1,18 @@
 use cargo_near_build::{bon, camino};
+use duct::cmd;
 
 fn main() {
-    let build_opts = cargo_near_build::BuildOpts::builder()
-        .manifest_path(camino::Utf8PathBuf::from("../../status-message").join("Cargo.toml"))
-        // `--no-locked` flag isn't recommended to be used in build-scripts for
-        // production contracts for reproducible builds,
-        // as such contracts won't verify with respect to WASM reproducibility;
-        // it's fine for current demo contract in `near-sdk`, which has certain hardships with tracking `Cargo.lock`-s continuously for examples
-        .no_locked(true)
-        .build();
+    let manifest_path = camino::Utf8PathBuf::from("../../status-message").join("Cargo.toml");
+    // =================================
+    // this workaround with calling `cargo update` before building sub-contract
+    // is specifically for current demo contract in `near-sdk`, which has certain hardships with tracking `Cargo.lock`-s continuously for examples
+    // this is not recommended for use in production sub-contracts,
+    // as such contracts won't verify with respect to WASM reproducibility;
+    cmd!("cargo", "update", "--manifest-path", manifest_path.as_str())
+        .run()
+        .expect("no `cargo update` err");
+    // =================================
+    let build_opts = cargo_near_build::BuildOpts::builder().manifest_path(manifest_path).build();
 
     let extended_build_opts = cargo_near_build::extended::BuildOptsExtended::builder()
         .build_opts(build_opts)

--- a/examples/factory-contract/high-level/build.rs
+++ b/examples/factory-contract/high-level/build.rs
@@ -1,41 +1,111 @@
-use std::str::FromStr;
+pub fn is_abi_build_step_or_debug_profile() -> bool {
+    if let Ok(value) = std::env::var("CARGO_NEAR_ABI_GENERATION") {
+        if value == "true" {
+            return true;
+        }
+    }
+    if let Ok(value) = std::env::var("PROFILE") {
+        if value == "debug" {
+            return true;
+        }
+    }
+    false
+}
 
-use cargo_near_build::BuildOpts;
-use cargo_near_build::{bon, camino, extended};
+fn override_cargo_target_dir() -> cargo_near_build::camino::Utf8PathBuf {
+    let out_dir_env = std::env::var("OUT_DIR").expect("OUT_DIR is always set in build scripts");
+    let out_dir = cargo_near_build::camino::Utf8PathBuf::from(out_dir_env);
 
-fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
+    let dir =
+        out_dir.join(format!("target-{}-for-{}", "status-message", "factory-contract-high-level"));
+
+    std::fs::create_dir_all(&dir).expect("create dir");
+    dir
+}
+fn main() {
     // directory of target `status-message` sub-contract's crate
-    let workdir = "../../status-message";
+    let workdir = "../../status-message".to_string();
+    let manifest = cargo_near_build::camino::Utf8PathBuf::from(workdir.clone()).join("Cargo.toml");
     // unix path to target `status-message` sub-contract's crate from root of the repo
     let nep330_contract_path = "examples/status-message";
 
-    let manifest = camino::Utf8PathBuf::from_str(workdir)
-        .expect("pathbuf from str")
-        .join("Cargo.toml");
+    // this is wasm result path of `cargo near build non-reproducible-wasm`
+    // for target sub-contract, where repo's root is replaced with `/home/near/code`
+    let nep330_output_wasm_path: &str =
+        "/home/near/code/examples/status-message/target/near/status_message.wasm";
 
-    let build_opts = BuildOpts::builder()
+    let override_cargo_target_dir = override_cargo_target_dir();
+    let build_opts = cargo_near_build::BuildOpts::builder()
         .manifest_path(manifest)
-        .no_locked(true)
+        .override_cargo_target_dir(override_cargo_target_dir.to_string())
         .override_nep330_contract_path(nep330_contract_path)
-        // a distinct target is needed to avoid deadlock during build
-        .override_cargo_target_dir("../target/build-rs-status-message-for-high-level-factory")
+        .override_nep330_output_wasm_path(nep330_output_wasm_path)
         .build();
 
-    let build_script_opts = extended::BuildScriptOpts::builder()
-        .rerun_if_changed_list(bon::vec![workdir, "Cargo.toml", "../Cargo.lock"])
-        .build_skipped_when_env_is(vec![
-            // shorter build for `cargo check`
-            ("PROFILE", "debug"),
-            (cargo_near_build::env_keys::BUILD_RS_ABI_STEP_HINT, "true"),
-        ])
-        .stub_path("../target/status-message-high-level-stub.bin")
-        .result_env_key("BUILD_RS_SUB_BUILD_STATUS-MESSAGE")
-        .build();
+    let is_abi_or_cargo_check = is_abi_build_step_or_debug_profile();
 
-    let extended_opts = extended::BuildOptsExtended::builder()
-        .build_opts(build_opts)
-        .build_script_opts(build_script_opts)
-        .build();
-    cargo_near_build::extended::build(extended_opts)?;
-    Ok(())
+    let out_path = run_build::step(build_opts, is_abi_or_cargo_check, &override_cargo_target_dir);
+
+    post_build::step(
+        is_abi_or_cargo_check,
+        vec![&workdir, "Cargo.toml", "../Cargo.lock"],
+        out_path,
+        "BUILD_RS_SUB_BUILD_ARTIFACT_1",
+    );
+}
+
+mod run_build {
+
+    pub fn step(
+        opts: cargo_near_build::BuildOpts,
+        is_abi_or_cargo_check: bool,
+        override_cargo_target_dir: &cargo_near_build::camino::Utf8PathBuf,
+    ) -> cargo_near_build::camino::Utf8PathBuf {
+        if is_abi_or_cargo_check {
+            let out_path = override_cargo_target_dir.join("empty_subcontract_stub.wasm");
+            std::fs::write(&out_path, b"").expect("success write");
+            out_path
+        } else {
+            cargo_near_build::build_with_cli(opts).expect("successfull build")
+        }
+    }
+}
+
+mod post_build {
+
+    use cargo_near_build::camino::Utf8PathBuf;
+    pub fn step(
+        is_abi_or_cargo_check: bool,
+        watched_paths: Vec<&str>,
+        out_path: Utf8PathBuf,
+        result_env_var: &str,
+    ) {
+        for in_path in watched_paths {
+            println!("cargo::rerun-if-changed={}", in_path);
+        }
+        println!("cargo::rustc-env={}={}", result_env_var, out_path.as_str());
+        if is_abi_or_cargo_check {
+            println!(
+                "cargo::warning={}",
+                format!("subcontract empty stub is `{}`", out_path.as_str())
+            );
+        } else {
+            println!(
+                "cargo::warning={}",
+                format!("subcontract out path is `{}`", out_path.as_str())
+            );
+        }
+
+        if !is_abi_or_cargo_check {
+            println!(
+                "cargo::warning={}",
+                format!(
+                    "subcontract sha256 is {}",
+                    cargo_near_build::SHA256Checksum::new(&out_path)
+                        .expect("read file")
+                        .to_base58_string()
+                )
+            );
+        }
+    }
 }

--- a/examples/factory-contract/high-level/build.rs
+++ b/examples/factory-contract/high-level/build.rs
@@ -1,112 +1,26 @@
-pub fn is_abi_build_step_or_debug_profile() -> bool {
-    if let Ok(value) = std::env::var("CARGO_NEAR_ABI_GENERATION") {
-        if value == "true" {
-            return true;
-        }
-    }
-    if let Ok(value) = std::env::var("PROFILE") {
-        if value == "debug" {
-            return true;
-        }
-    }
-    false
-}
+use cargo_near_build::{bon, camino};
 
-fn override_cargo_target_dir() -> cargo_near_build::camino::Utf8PathBuf {
-    let out_dir_env = std::env::var("OUT_DIR").expect("OUT_DIR is always set in build scripts");
-    let out_dir = cargo_near_build::camino::Utf8PathBuf::from(out_dir_env);
-
-    let dir =
-        out_dir.join(format!("target-{}-for-{}", "status-message", "factory-contract-high-level"));
-
-    std::fs::create_dir_all(&dir).expect("create dir");
-    dir
-}
 fn main() {
-    // directory of target `status-message` sub-contract's crate
-    let workdir = "../../status-message".to_string();
-    let manifest = cargo_near_build::camino::Utf8PathBuf::from(workdir.clone()).join("Cargo.toml");
-    // unix path to target `status-message` sub-contract's crate from root of the repo
-    let nep330_contract_path = "examples/status-message";
-
-    // this is wasm result path of `cargo near build non-reproducible-wasm`
-    // for target sub-contract, where repo's root is replaced with `/home/near/code`
-    let nep330_output_wasm_path: &str =
-        "/home/near/code/examples/status-message/target/near/status_message.wasm";
-
-    let override_cargo_target_dir = override_cargo_target_dir();
     let build_opts = cargo_near_build::BuildOpts::builder()
-        .manifest_path(manifest)
+        .manifest_path(camino::Utf8PathBuf::from("../../status-message").join("Cargo.toml"))
+        // `--no-locked` flag isn't recommended to be used in build-scripts for
+        // production contracts for reproducible builds,
+        // as such contracts won't verify with respect to WASM reproducibility;
+        // it's fine for current demo contract in `near-sdk`, which has certain hardships with tracking `Cargo.lock`-s continuously for examples
         .no_locked(true)
-        .override_cargo_target_dir(override_cargo_target_dir.to_string())
-        .override_nep330_contract_path(nep330_contract_path)
-        .override_nep330_output_wasm_path(nep330_output_wasm_path)
         .build();
 
-    let is_abi_or_cargo_check = is_abi_build_step_or_debug_profile();
+    let extended_build_opts = cargo_near_build::extended::BuildOptsExtended::builder()
+        .build_opts(build_opts)
+        .rerun_if_changed_list(bon::vec!["Cargo.toml", "../Cargo.lock"])
+        .result_file_path_env_key("BUILD_RS_SUB_BUILD_STATUS-MESSAGE")
+        .prepare()
+        .expect("no error in auto-compute of params");
 
-    let out_path = run_build::step(build_opts, is_abi_or_cargo_check, &override_cargo_target_dir);
-
-    post_build::step(
-        is_abi_or_cargo_check,
-        vec![&workdir, "Cargo.toml", "../Cargo.lock"],
-        out_path,
-        "BUILD_RS_SUB_BUILD_STATUS-MESSAGE",
-    );
-}
-
-mod run_build {
-
-    pub fn step(
-        opts: cargo_near_build::BuildOpts,
-        is_abi_or_cargo_check: bool,
-        override_cargo_target_dir: &cargo_near_build::camino::Utf8PathBuf,
-    ) -> cargo_near_build::camino::Utf8PathBuf {
-        if is_abi_or_cargo_check {
-            let out_path = override_cargo_target_dir.join("empty_subcontract_stub.wasm");
-            std::fs::write(&out_path, b"").expect("success write");
-            out_path
-        } else {
-            cargo_near_build::build_with_cli(opts).expect("successful build")
-        }
-    }
-}
-
-mod post_build {
-
-    use cargo_near_build::camino::Utf8PathBuf;
-    pub fn step(
-        is_abi_or_cargo_check: bool,
-        watched_paths: Vec<&str>,
-        out_path: Utf8PathBuf,
-        result_env_var: &str,
-    ) {
-        for in_path in watched_paths {
-            println!("cargo::rerun-if-changed={}", in_path);
-        }
-        println!("cargo::rustc-env={}={}", result_env_var, out_path.as_str());
-        if is_abi_or_cargo_check {
-            println!(
-                "cargo::warning={}",
-                format!("subcontract empty stub is `{}`", out_path.as_str())
-            );
-        } else {
-            println!(
-                "cargo::warning={}",
-                format!("subcontract out path is `{}`", out_path.as_str())
-            );
-        }
-
-        if !is_abi_or_cargo_check {
-            println!(
-                "cargo::warning={}",
-                format!(
-                    "subcontract sha256 is {}",
-                    cargo_near_build::SHA256Checksum::new(&out_path)
-                        .expect("read file")
-                        .to_base58_string()
-                )
-            );
-        }
-    }
+    // the output `_wasm_path` can be reused in build.rs for more transformations, if needed
+    //
+    // required option `result_file_path_env_key` env variable is used in src/lib.rs to obtain the built wasm result:
+    // const DONATION_DEFAULT_CONTRACT: &[u8] = include_bytes!(env!("BUILD_RS_SUB_BUILD_STATUS-MESSAGE"));
+    let _wasm_path =
+        cargo_near_build::extended::build_with_cli(extended_build_opts).expect("no build error");
 }

--- a/examples/factory-contract/low-level/Cargo.toml
+++ b/examples/factory-contract/low-level/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 near-sdk = { path = "../../../near-sdk" }
 [build-dependencies]
-cargo-near-build = { version = "0.5.1", git = "https://github.com/dj8yfo/cargo-near.git", branch = "feat/build-external-method" }
+cargo-near-build = { version = "0.5.1", git = "https://github.com/dj8yfo/cargo-near.git", branch = "feat/extended-build-with-cli" }
 
 
 [dev-dependencies]

--- a/examples/factory-contract/low-level/Cargo.toml
+++ b/examples/factory-contract/low-level/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 near-sdk = { path = "../../../near-sdk" }
 [build-dependencies]
 cargo-near-build = { version = "0.5.1", git = "https://github.com/dj8yfo/cargo-near.git", branch = "feat/extended-build-with-cli" }
+duct = "0.13.7"
 
 
 [dev-dependencies]

--- a/examples/factory-contract/low-level/Cargo.toml
+++ b/examples/factory-contract/low-level/Cargo.toml
@@ -10,9 +10,5 @@ crate-type = ["cdylib"]
 [dependencies]
 near-sdk = { path = "../../../near-sdk" }
 [build-dependencies]
-cargo-near-build = { version = "0.5.1", git = "https://github.com/dj8yfo/cargo-near.git", branch = "feat/extended-build-with-cli" }
+cargo-near-build = { version = "0.6.0" }
 duct = "0.13.7"
-
-
-[dev-dependencies]
-near-sdk = { path = "../../../near-sdk", features = ["unit-testing"] }

--- a/examples/factory-contract/low-level/Cargo.toml
+++ b/examples/factory-contract/low-level/Cargo.toml
@@ -10,7 +10,8 @@ crate-type = ["cdylib"]
 [dependencies]
 near-sdk = { path = "../../../near-sdk" }
 [build-dependencies]
-cargo-near-build = { version = "0.3.0", features = ["build_script"] }
+cargo-near-build = { version = "0.5.1", git = "https://github.com/dj8yfo/cargo-near.git", branch = "feat/build-external-method" }
+
 
 [dev-dependencies]
 near-sdk = { path = "../../../near-sdk", features = ["unit-testing"] }

--- a/examples/factory-contract/low-level/build.rs
+++ b/examples/factory-contract/low-level/build.rs
@@ -1,40 +1,112 @@
-use std::str::FromStr;
+pub fn is_abi_build_step_or_debug_profile() -> bool {
+    if let Ok(value) = std::env::var("CARGO_NEAR_ABI_GENERATION") {
+        if value == "true" {
+            return true;
+        }
+    }
+    if let Ok(value) = std::env::var("PROFILE") {
+        if value == "debug" {
+            return true;
+        }
+    }
+    false
+}
 
-use cargo_near_build::BuildOpts;
-use cargo_near_build::{bon, camino, extended};
+fn override_cargo_target_dir() -> cargo_near_build::camino::Utf8PathBuf {
+    let out_dir_env = std::env::var("OUT_DIR").expect("OUT_DIR is always set in build scripts");
+    let out_dir = cargo_near_build::camino::Utf8PathBuf::from(out_dir_env);
 
-fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
+    let dir =
+        out_dir.join(format!("target-{}-for-{}", "status-message", "factory-contract-low-level"));
+
+    std::fs::create_dir_all(&dir).expect("create dir");
+    dir
+}
+fn main() {
     // directory of target `status-message` sub-contract's crate
-    let workdir = "../../status-message";
+    let workdir = "../../status-message".to_string();
+    let manifest = cargo_near_build::camino::Utf8PathBuf::from(workdir.clone()).join("Cargo.toml");
     // unix path to target `status-message` sub-contract's crate from root of the repo
     let nep330_contract_path = "examples/status-message";
 
-    let manifest =
-        camino::Utf8PathBuf::from_str(workdir).expect("pathbuf from str").join("Cargo.toml");
+    // this is wasm result path of `cargo near build non-reproducible-wasm`
+    // for target sub-contract, where repo's root is replaced with `/home/near/code`
+    let nep330_output_wasm_path: &str =
+        "/home/near/code/examples/status-message/target/near/status_message.wasm";
 
-    let build_opts = BuildOpts::builder()
+    let override_cargo_target_dir = override_cargo_target_dir();
+    let build_opts = cargo_near_build::BuildOpts::builder()
         .manifest_path(manifest)
         .no_locked(true)
+        .override_cargo_target_dir(override_cargo_target_dir.to_string())
         .override_nep330_contract_path(nep330_contract_path)
-        // a distinct target is needed to avoid deadlock during build
-        .override_cargo_target_dir("../target/build-rs-status-message-for-low-level-factory")
+        .override_nep330_output_wasm_path(nep330_output_wasm_path)
         .build();
 
-    let build_script_opts = extended::BuildScriptOpts::builder()
-        .rerun_if_changed_list(bon::vec![workdir, "Cargo.toml", "../Cargo.lock"])
-        .build_skipped_when_env_is(vec![
-            // shorter build for `cargo check`
-            ("PROFILE", "debug"),
-            (cargo_near_build::env_keys::BUILD_RS_ABI_STEP_HINT, "true"),
-        ])
-        .stub_path("../target/status-message-low-level-stub.bin")
-        .result_env_key("BUILD_RS_SUB_BUILD_STATUS-MESSAGE")
-        .build();
+    let is_abi_or_cargo_check = is_abi_build_step_or_debug_profile();
 
-    let extended_opts = extended::BuildOptsExtended::builder()
-        .build_opts(build_opts)
-        .build_script_opts(build_script_opts)
-        .build();
-    cargo_near_build::extended::build(extended_opts)?;
-    Ok(())
+    let out_path = run_build::step(build_opts, is_abi_or_cargo_check, &override_cargo_target_dir);
+
+    post_build::step(
+        is_abi_or_cargo_check,
+        vec![&workdir, "Cargo.toml", "../Cargo.lock"],
+        out_path,
+        "BUILD_RS_SUB_BUILD_STATUS-MESSAGE",
+    );
+}
+
+mod run_build {
+
+    pub fn step(
+        opts: cargo_near_build::BuildOpts,
+        is_abi_or_cargo_check: bool,
+        override_cargo_target_dir: &cargo_near_build::camino::Utf8PathBuf,
+    ) -> cargo_near_build::camino::Utf8PathBuf {
+        if is_abi_or_cargo_check {
+            let out_path = override_cargo_target_dir.join("empty_subcontract_stub.wasm");
+            std::fs::write(&out_path, b"").expect("success write");
+            out_path
+        } else {
+            cargo_near_build::build_with_cli(opts).expect("successfull build")
+        }
+    }
+}
+
+mod post_build {
+
+    use cargo_near_build::camino::Utf8PathBuf;
+    pub fn step(
+        is_abi_or_cargo_check: bool,
+        watched_paths: Vec<&str>,
+        out_path: Utf8PathBuf,
+        result_env_var: &str,
+    ) {
+        for in_path in watched_paths {
+            println!("cargo::rerun-if-changed={}", in_path);
+        }
+        println!("cargo::rustc-env={}={}", result_env_var, out_path.as_str());
+        if is_abi_or_cargo_check {
+            println!(
+                "cargo::warning={}",
+                format!("subcontract empty stub is `{}`", out_path.as_str())
+            );
+        } else {
+            println!(
+                "cargo::warning={}",
+                format!("subcontract out path is `{}`", out_path.as_str())
+            );
+        }
+
+        if !is_abi_or_cargo_check {
+            println!(
+                "cargo::warning={}",
+                format!(
+                    "subcontract sha256 is {}",
+                    cargo_near_build::SHA256Checksum::new(&out_path)
+                        .expect("read file")
+                        .to_base58_string()
+                )
+            );
+        }
+    }
 }

--- a/examples/factory-contract/low-level/build.rs
+++ b/examples/factory-contract/low-level/build.rs
@@ -1,112 +1,26 @@
-pub fn is_abi_build_step_or_debug_profile() -> bool {
-    if let Ok(value) = std::env::var("CARGO_NEAR_ABI_GENERATION") {
-        if value == "true" {
-            return true;
-        }
-    }
-    if let Ok(value) = std::env::var("PROFILE") {
-        if value == "debug" {
-            return true;
-        }
-    }
-    false
-}
+use cargo_near_build::{bon, camino};
 
-fn override_cargo_target_dir() -> cargo_near_build::camino::Utf8PathBuf {
-    let out_dir_env = std::env::var("OUT_DIR").expect("OUT_DIR is always set in build scripts");
-    let out_dir = cargo_near_build::camino::Utf8PathBuf::from(out_dir_env);
-
-    let dir =
-        out_dir.join(format!("target-{}-for-{}", "status-message", "factory-contract-low-level"));
-
-    std::fs::create_dir_all(&dir).expect("create dir");
-    dir
-}
 fn main() {
-    // directory of target `status-message` sub-contract's crate
-    let workdir = "../../status-message".to_string();
-    let manifest = cargo_near_build::camino::Utf8PathBuf::from(workdir.clone()).join("Cargo.toml");
-    // unix path to target `status-message` sub-contract's crate from root of the repo
-    let nep330_contract_path = "examples/status-message";
-
-    // this is wasm result path of `cargo near build non-reproducible-wasm`
-    // for target sub-contract, where repo's root is replaced with `/home/near/code`
-    let nep330_output_wasm_path: &str =
-        "/home/near/code/examples/status-message/target/near/status_message.wasm";
-
-    let override_cargo_target_dir = override_cargo_target_dir();
     let build_opts = cargo_near_build::BuildOpts::builder()
-        .manifest_path(manifest)
+        .manifest_path(camino::Utf8PathBuf::from("../../status-message").join("Cargo.toml"))
+        // `--no-locked` flag isn't recommended to be used in build-scripts for
+        // production contracts for reproducible builds,
+        // as such contracts won't verify with respect to WASM reproducibility;
+        // it's fine for current demo contract in `near-sdk`, which has certain hardships with tracking `Cargo.lock`-s continuously for examples
         .no_locked(true)
-        .override_cargo_target_dir(override_cargo_target_dir.to_string())
-        .override_nep330_contract_path(nep330_contract_path)
-        .override_nep330_output_wasm_path(nep330_output_wasm_path)
         .build();
 
-    let is_abi_or_cargo_check = is_abi_build_step_or_debug_profile();
+    let extended_build_opts = cargo_near_build::extended::BuildOptsExtended::builder()
+        .build_opts(build_opts)
+        .rerun_if_changed_list(bon::vec!["Cargo.toml", "../Cargo.lock"])
+        .result_file_path_env_key("BUILD_RS_SUB_BUILD_STATUS-MESSAGE")
+        .prepare()
+        .expect("no error in auto-compute of params");
 
-    let out_path = run_build::step(build_opts, is_abi_or_cargo_check, &override_cargo_target_dir);
-
-    post_build::step(
-        is_abi_or_cargo_check,
-        vec![&workdir, "Cargo.toml", "../Cargo.lock"],
-        out_path,
-        "BUILD_RS_SUB_BUILD_STATUS-MESSAGE",
-    );
-}
-
-mod run_build {
-
-    pub fn step(
-        opts: cargo_near_build::BuildOpts,
-        is_abi_or_cargo_check: bool,
-        override_cargo_target_dir: &cargo_near_build::camino::Utf8PathBuf,
-    ) -> cargo_near_build::camino::Utf8PathBuf {
-        if is_abi_or_cargo_check {
-            let out_path = override_cargo_target_dir.join("empty_subcontract_stub.wasm");
-            std::fs::write(&out_path, b"").expect("success write");
-            out_path
-        } else {
-            cargo_near_build::build_with_cli(opts).expect("successful build")
-        }
-    }
-}
-
-mod post_build {
-
-    use cargo_near_build::camino::Utf8PathBuf;
-    pub fn step(
-        is_abi_or_cargo_check: bool,
-        watched_paths: Vec<&str>,
-        out_path: Utf8PathBuf,
-        result_env_var: &str,
-    ) {
-        for in_path in watched_paths {
-            println!("cargo::rerun-if-changed={}", in_path);
-        }
-        println!("cargo::rustc-env={}={}", result_env_var, out_path.as_str());
-        if is_abi_or_cargo_check {
-            println!(
-                "cargo::warning={}",
-                format!("subcontract empty stub is `{}`", out_path.as_str())
-            );
-        } else {
-            println!(
-                "cargo::warning={}",
-                format!("subcontract out path is `{}`", out_path.as_str())
-            );
-        }
-
-        if !is_abi_or_cargo_check {
-            println!(
-                "cargo::warning={}",
-                format!(
-                    "subcontract sha256 is {}",
-                    cargo_near_build::SHA256Checksum::new(&out_path)
-                        .expect("read file")
-                        .to_base58_string()
-                )
-            );
-        }
-    }
+    // the output `_wasm_path` can be reused in build.rs for more transformations, if needed
+    //
+    // required option `result_file_path_env_key` env variable is used in src/lib.rs to obtain the built wasm result:
+    // const DONATION_DEFAULT_CONTRACT: &[u8] = include_bytes!(env!("BUILD_RS_SUB_BUILD_STATUS-MESSAGE1"));
+    let _wasm_path =
+        cargo_near_build::extended::build_with_cli(extended_build_opts).expect("no build error");
 }

--- a/examples/factory-contract/low-level/build.rs
+++ b/examples/factory-contract/low-level/build.rs
@@ -67,7 +67,7 @@ mod run_build {
             std::fs::write(&out_path, b"").expect("success write");
             out_path
         } else {
-            cargo_near_build::build_with_cli(opts).expect("successfull build")
+            cargo_near_build::build_with_cli(opts).expect("successful build")
         }
     }
 }

--- a/examples/factory-contract/low-level/build.rs
+++ b/examples/factory-contract/low-level/build.rs
@@ -1,14 +1,18 @@
 use cargo_near_build::{bon, camino};
+use duct::cmd;
 
 fn main() {
-    let build_opts = cargo_near_build::BuildOpts::builder()
-        .manifest_path(camino::Utf8PathBuf::from("../../status-message").join("Cargo.toml"))
-        // `--no-locked` flag isn't recommended to be used in build-scripts for
-        // production contracts for reproducible builds,
-        // as such contracts won't verify with respect to WASM reproducibility;
-        // it's fine for current demo contract in `near-sdk`, which has certain hardships with tracking `Cargo.lock`-s continuously for examples
-        .no_locked(true)
-        .build();
+    let manifest_path = camino::Utf8PathBuf::from("../../status-message").join("Cargo.toml");
+    // =================================
+    // this workaround with calling `cargo update` before building sub-contract
+    // is specifically for current demo contract in `near-sdk`, which has certain hardships with tracking `Cargo.lock`-s continuously for examples
+    // this is not recommended for use in production sub-contracts,
+    // as such contracts won't verify with respect to WASM reproducibility;
+    cmd!("cargo", "update", "--manifest-path", manifest_path.as_str())
+        .run()
+        .expect("no `cargo update` err");
+    // =================================
+    let build_opts = cargo_near_build::BuildOpts::builder().manifest_path(manifest_path).build();
 
     let extended_build_opts = cargo_near_build::extended::BuildOptsExtended::builder()
         .build_opts(build_opts)

--- a/examples/fungible-token/Cargo.toml
+++ b/examples/fungible-token/Cargo.toml
@@ -8,9 +8,7 @@ edition = "2021"
 anyhow = "1.0"
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
 tokio = { version = "1.14", features = ["full"] }
-near-workspaces = { version = "0.18", features = [
-    "unstable",
-], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
+near-workspaces = { version = "0.19", features = ["unstable"] }
 rstest = "0.23.0"
 
 [profile.release]

--- a/examples/fungible-token/Cargo.toml
+++ b/examples/fungible-token/Cargo.toml
@@ -8,7 +8,9 @@ edition = "2021"
 anyhow = "1.0"
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
 tokio = { version = "1.14", features = ["full"] }
-near-workspaces = { version = "0.18", features = ["unstable"] }
+near-workspaces = { version = "0.18", features = [
+    "unstable",
+], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
 rstest = "0.23.0"
 
 [profile.release]

--- a/examples/fungible-token/tests/workspaces.rs
+++ b/examples/fungible-token/tests/workspaces.rs
@@ -1,14 +1,13 @@
 use std::str::FromStr;
 
 use near_sdk::json_types::U128;
+use near_workspaces::cargo_near_build;
 use near_workspaces::operations::Function;
 use near_workspaces::result::ValueOrReceiptId;
 use near_workspaces::{types::NearToken, Account, AccountId, Contract};
 use rstest::{fixture, rstest};
-use near_workspaces::cargo_near_build;
 
 const ONE_YOCTO: NearToken = NearToken::from_yoctonear(1);
-
 
 async fn register_user(contract: &Contract, account_id: &AccountId) -> anyhow::Result<()> {
     let res = contract
@@ -24,7 +23,7 @@ async fn register_user(contract: &Contract, account_id: &AccountId) -> anyhow::R
 }
 
 fn build_contract(path: &str, contract_name: &str) -> Vec<u8> {
-    let artifact = cargo_near_build::build(cargo_near_build::BuildOpts {
+    let artifact = cargo_near_build::build_with_cli(cargo_near_build::BuildOpts {
         manifest_path: Some(
             cargo_near_build::camino::Utf8PathBuf::from_str(path).expect("camino PathBuf from str"),
         ),
@@ -32,8 +31,8 @@ fn build_contract(path: &str, contract_name: &str) -> Vec<u8> {
     })
     .expect(&format!("building `{}` contract for tests", contract_name));
 
-    let contract_wasm = std::fs::read(&artifact.path)
-        .map_err(|err| format!("accessing {} to read wasm contents: {}", artifact.path, err))
+    let contract_wasm = std::fs::read(&artifact)
+        .map_err(|err| format!("accessing {} to read wasm contents: {}", artifact, err))
         .expect("std::fs::read");
     contract_wasm
 }
@@ -43,7 +42,6 @@ fn build_contract(path: &str, contract_name: &str) -> Vec<u8> {
 fn fungible_contract_wasm() -> Vec<u8> {
     build_contract("./ft/Cargo.toml", "fungible-token")
 }
-
 
 #[fixture]
 #[once]
@@ -76,12 +74,7 @@ async fn initialized_contracts(
 
     let defi_contract = worker.dev_deploy(defi_contract_wasm).await?;
 
-    let res = defi_contract
-        .call("new")
-        .args_json((ft_contract.id(),))
-        .max_gas()
-        .transact()
-        .await?;
+    let res = defi_contract.call("new").args_json((ft_contract.id(),)).max_gas().transact().await?;
     assert!(res.is_success());
 
     let alice = ft_contract
@@ -111,8 +104,7 @@ async fn test_total_supply(
     initial_balance: U128,
     #[future] initialized_contracts: anyhow::Result<(Contract, Account, Contract)>,
 ) -> anyhow::Result<()> {
-    let (contract, _, _) =
-        initialized_contracts.await?;
+    let (contract, _, _) = initialized_contracts.await?;
 
     let res = contract.call("ft_total_supply").view().await?;
     assert_eq!(res.json::<U128>()?, initial_balance);
@@ -125,8 +117,7 @@ async fn test_total_supply(
 async fn test_storage_deposit_not_enough_deposit(
     #[future] initialized_contracts: anyhow::Result<(Contract, Account, Contract)>,
 ) -> anyhow::Result<()> {
-    let (contract, _, _) =
-        initialized_contracts.await?;
+    let (contract, _, _) = initialized_contracts.await?;
 
     let new_account = contract
         .as_account()
@@ -155,11 +146,8 @@ async fn test_storage_deposit_not_enough_deposit(
     assert!(new_account_balance_diff > NearToken::from_near(0));
     assert!(new_account_balance_diff < NearToken::from_millinear(1));
 
-    let contract_balance_diff = contract
-        .view_account()
-        .await?
-        .balance
-        .saturating_sub(contract_balance_before_deposit);
+    let contract_balance_diff =
+        contract.view_account().await?.balance.saturating_sub(contract_balance_before_deposit);
     // contract receives a gas rewards for the function call, so it should gain some NEAR
     assert!(contract_balance_diff > NearToken::from_near(0));
     assert!(contract_balance_diff < NearToken::from_yoctonear(30_000_000_000_000_000_000));
@@ -172,8 +160,7 @@ async fn test_storage_deposit_not_enough_deposit(
 async fn test_storage_deposit_minimal_deposit(
     #[future] initialized_contracts: anyhow::Result<(Contract, Account, Contract)>,
 ) -> anyhow::Result<()> {
-    let (contract, _, _) =
-        initialized_contracts.await?;
+    let (contract, _, _) = initialized_contracts.await?;
 
     let new_account = contract
         .as_account()
@@ -204,11 +191,8 @@ async fn test_storage_deposit_minimal_deposit(
         new_account_balance_diff < minimal_deposit.saturating_add(NearToken::from_millinear(1))
     );
 
-    let contract_balance_diff = contract
-        .view_account()
-        .await?
-        .balance
-        .saturating_sub(contract_balance_before_deposit);
+    let contract_balance_diff =
+        contract.view_account().await?.balance.saturating_sub(contract_balance_before_deposit);
     // contract receives a gas rewards for the function call, so the difference should be slightly more than minimal_deposit
     assert!(contract_balance_diff > minimal_deposit);
     // adjust the upper limit of the assertion to be more flexible for small variations in the gas reward received
@@ -225,8 +209,7 @@ async fn test_storage_deposit_minimal_deposit(
 async fn test_storage_deposit_refunds_excessive_deposit(
     #[future] initialized_contracts: anyhow::Result<(Contract, Account, Contract)>,
 ) -> anyhow::Result<()> {
-    let (contract, _, _) =
-        initialized_contracts.await?;
+    let (contract, _, _) = initialized_contracts.await?;
 
     let minimal_deposit = near_sdk::env::storage_byte_cost().saturating_mul(125);
 
@@ -238,19 +221,10 @@ async fn test_storage_deposit_refunds_excessive_deposit(
         min: U128,
         max: U128,
     }
-    let storage_balance_bounds: StorageBalanceBounds = contract
-        .call("storage_balance_bounds")
-        .view()
-        .await?
-        .json()?;
-    assert_eq!(
-        storage_balance_bounds.min,
-        minimal_deposit.as_yoctonear().into()
-    );
-    assert_eq!(
-        storage_balance_bounds.max,
-        minimal_deposit.as_yoctonear().into()
-    );
+    let storage_balance_bounds: StorageBalanceBounds =
+        contract.call("storage_balance_bounds").view().await?.json()?;
+    assert_eq!(storage_balance_bounds.min, minimal_deposit.as_yoctonear().into());
+    assert_eq!(storage_balance_bounds.max, minimal_deposit.as_yoctonear().into());
 
     // Check that a non-registered account does not have storage balance
     //
@@ -300,10 +274,7 @@ async fn test_storage_deposit_refunds_excessive_deposit(
         .view()
         .await?
         .json()?;
-    assert_eq!(
-        storage_balance_bounds.total,
-        minimal_deposit.as_yoctonear().into()
-    );
+    assert_eq!(storage_balance_bounds.total, minimal_deposit.as_yoctonear().into());
     assert_eq!(storage_balance_bounds.available, 0.into());
 
     let new_account_balance_diff = new_account_balance_before_deposit
@@ -314,11 +285,8 @@ async fn test_storage_deposit_refunds_excessive_deposit(
         new_account_balance_diff < minimal_deposit.saturating_add(NearToken::from_millinear(1))
     );
 
-    let contract_balance_diff = contract
-        .view_account()
-        .await?
-        .balance
-        .saturating_sub(contract_balance_before_deposit);
+    let contract_balance_diff =
+        contract.view_account().await?.balance.saturating_sub(contract_balance_before_deposit);
     // contract receives a gas rewards for the function call, so the difference should be slightly more than minimal_deposit
     assert!(contract_balance_diff > minimal_deposit);
     assert!(
@@ -336,8 +304,7 @@ async fn test_simple_transfer(
     #[future] initialized_contracts: anyhow::Result<(Contract, Account, Contract)>,
 ) -> anyhow::Result<()> {
     let transfer_amount = U128::from(NearToken::from_near(100).as_yoctonear());
-    let (contract, alice, _) =
-        initialized_contracts.await?;
+    let (contract, alice, _) = initialized_contracts.await?;
 
     let res = contract
         .call("ft_transfer")
@@ -348,18 +315,10 @@ async fn test_simple_transfer(
         .await?;
     assert!(res.is_success());
 
-    let root_balance = contract
-        .call("ft_balance_of")
-        .args_json((contract.id(),))
-        .view()
-        .await?
-        .json::<U128>()?;
-    let alice_balance = contract
-        .call("ft_balance_of")
-        .args_json((alice.id(),))
-        .view()
-        .await?
-        .json::<U128>()?;
+    let root_balance =
+        contract.call("ft_balance_of").args_json((contract.id(),)).view().await?.json::<U128>()?;
+    let alice_balance =
+        contract.call("ft_balance_of").args_json((alice.id(),)).view().await?.json::<U128>()?;
     assert_eq!(initial_balance.0 - transfer_amount.0, root_balance.0);
     assert_eq!(transfer_amount.0, alice_balance.0);
 
@@ -371,8 +330,7 @@ async fn test_simple_transfer(
 async fn test_close_account_empty_balance(
     #[future] initialized_contracts: anyhow::Result<(Contract, Account, Contract)>,
 ) -> anyhow::Result<()> {
-    let (contract, alice, _) =
-        initialized_contracts.await?;
+    let (contract, alice, _) = initialized_contracts.await?;
 
     let res = alice
         .call(contract.id(), "storage_unregister")
@@ -391,8 +349,7 @@ async fn test_close_account_empty_balance(
 async fn test_close_account_non_empty_balance(
     #[future] initialized_contracts: anyhow::Result<(Contract, Account, Contract)>,
 ) -> anyhow::Result<()> {
-    let (contract, _, _) =
-        initialized_contracts.await?;
+    let (contract, _, _) = initialized_contracts.await?;
 
     let res = contract
         .call("storage_unregister")
@@ -422,8 +379,7 @@ async fn test_close_account_non_empty_balance(
 async fn simulate_close_account_force_non_empty_balance(
     #[future] initialized_contracts: anyhow::Result<(Contract, Account, Contract)>,
 ) -> anyhow::Result<()> {
-    let (contract, _, _) =
-        initialized_contracts.await?;
+    let (contract, _, _) = initialized_contracts.await?;
 
     let res = contract
         .call("storage_unregister")
@@ -446,8 +402,7 @@ async fn simulate_transfer_call_with_burned_amount(
     #[future] initialized_contracts: anyhow::Result<(Contract, Account, Contract)>,
 ) -> anyhow::Result<()> {
     let transfer_amount = U128::from(NearToken::from_near(100).as_yoctonear());
-    let (contract, _, defi_contract) =
-        initialized_contracts.await?;
+    let (contract, _, defi_contract) = initialized_contracts.await?;
 
     // defi contract must be registered as a FT account
     register_user(&contract, defi_contract.id()).await?;
@@ -457,12 +412,7 @@ async fn simulate_transfer_call_with_burned_amount(
         .batch()
         .call(
             Function::new("ft_transfer_call")
-                .args_json((
-                    defi_contract.id(),
-                    transfer_amount,
-                    Option::<String>::None,
-                    "10",
-                ))
+                .args_json((defi_contract.id(), transfer_amount, Option::<String>::None, "10"))
                 .deposit(ONE_YOCTO)
                 .gas(near_sdk::Gas::from_tgas(150)),
         )
@@ -511,8 +461,7 @@ async fn simulate_transfer_call_with_immediate_return_and_no_refund(
     #[future] initialized_contracts: anyhow::Result<(Contract, Account, Contract)>,
 ) -> anyhow::Result<()> {
     let transfer_amount = U128::from(NearToken::from_near(100).as_yoctonear());
-    let (contract, _, defi_contract) =
-        initialized_contracts.await?;
+    let (contract, _, defi_contract) = initialized_contracts.await?;
 
     // defi contract must be registered as a FT account
     register_user(&contract, defi_contract.id()).await?;
@@ -520,24 +469,15 @@ async fn simulate_transfer_call_with_immediate_return_and_no_refund(
     // root invests in defi by calling `ft_transfer_call`
     let res = contract
         .call("ft_transfer_call")
-        .args_json((
-            defi_contract.id(),
-            transfer_amount,
-            Option::<String>::None,
-            "take-my-money",
-        ))
+        .args_json((defi_contract.id(), transfer_amount, Option::<String>::None, "take-my-money"))
         .max_gas()
         .deposit(ONE_YOCTO)
         .transact()
         .await?;
     assert!(res.is_success());
 
-    let root_balance = contract
-        .call("ft_balance_of")
-        .args_json((contract.id(),))
-        .view()
-        .await?
-        .json::<U128>()?;
+    let root_balance =
+        contract.call("ft_balance_of").args_json((contract.id(),)).view().await?.json::<U128>()?;
     let defi_balance = contract
         .call("ft_balance_of")
         .args_json((defi_contract.id(),))
@@ -557,18 +497,12 @@ async fn simulate_transfer_call_when_called_contract_not_registered_with_ft(
     #[future] initialized_contracts: anyhow::Result<(Contract, Account, Contract)>,
 ) -> anyhow::Result<()> {
     let transfer_amount = U128::from(NearToken::from_near(100).as_yoctonear());
-    let (contract, _, defi_contract) =
-        initialized_contracts.await?;
+    let (contract, _, defi_contract) = initialized_contracts.await?;
 
     // call fails because DEFI contract is not registered as FT user
     let res = contract
         .call("ft_transfer_call")
-        .args_json((
-            defi_contract.id(),
-            transfer_amount,
-            Option::<String>::None,
-            "take-my-money",
-        ))
+        .args_json((defi_contract.id(), transfer_amount, Option::<String>::None, "take-my-money"))
         .max_gas()
         .deposit(ONE_YOCTO)
         .transact()
@@ -576,12 +510,8 @@ async fn simulate_transfer_call_when_called_contract_not_registered_with_ft(
     assert!(res.is_failure());
 
     // balances remain unchanged
-    let root_balance = contract
-        .call("ft_balance_of")
-        .args_json((contract.id(),))
-        .view()
-        .await?
-        .json::<U128>()?;
+    let root_balance =
+        contract.call("ft_balance_of").args_json((contract.id(),)).view().await?.json::<U128>()?;
     let defi_balance = contract
         .call("ft_balance_of")
         .args_json((defi_contract.id(),))
@@ -602,8 +532,7 @@ async fn simulate_transfer_call_with_promise_and_refund(
 ) -> anyhow::Result<()> {
     let refund_amount = U128::from(NearToken::from_near(50).as_yoctonear());
     let transfer_amount = U128::from(NearToken::from_near(100).as_yoctonear());
-    let (contract, _, defi_contract) =
-        initialized_contracts.await?;
+    let (contract, _, defi_contract) = initialized_contracts.await?;
 
     // defi contract must be registered as a FT account
     register_user(&contract, defi_contract.id()).await?;
@@ -622,22 +551,15 @@ async fn simulate_transfer_call_with_promise_and_refund(
         .await?;
     assert!(res.is_success());
 
-    let root_balance = contract
-        .call("ft_balance_of")
-        .args_json((contract.id(),))
-        .view()
-        .await?
-        .json::<U128>()?;
+    let root_balance =
+        contract.call("ft_balance_of").args_json((contract.id(),)).view().await?.json::<U128>()?;
     let defi_balance = contract
         .call("ft_balance_of")
         .args_json((defi_contract.id(),))
         .view()
         .await?
         .json::<U128>()?;
-    assert_eq!(
-        initial_balance.0 - transfer_amount.0 + refund_amount.0,
-        root_balance.0
-    );
+    assert_eq!(initial_balance.0 - transfer_amount.0 + refund_amount.0, root_balance.0);
     assert_eq!(transfer_amount.0 - refund_amount.0, defi_balance.0);
 
     Ok(())
@@ -651,8 +573,7 @@ async fn simulate_transfer_call_promise_panics_for_a_full_refund(
 ) -> anyhow::Result<()> {
     let transfer_amount = U128::from(NearToken::from_near(100).as_yoctonear());
 
-    let (contract, _, defi_contract) =
-        initialized_contracts.await?;
+    let (contract, _, defi_contract) = initialized_contracts.await?;
 
     // defi contract must be registered as a FT account
     register_user(&contract, defi_contract.id()).await?;
@@ -682,12 +603,8 @@ async fn simulate_transfer_call_promise_panics_for_a_full_refund(
     }
 
     // balances remain unchanged
-    let root_balance = contract
-        .call("ft_balance_of")
-        .args_json((contract.id(),))
-        .view()
-        .await?
-        .json::<U128>()?;
+    let root_balance =
+        contract.call("ft_balance_of").args_json((contract.id(),)).view().await?.json::<U128>()?;
     let defi_balance = contract
         .call("ft_balance_of")
         .args_json((defi_contract.id(),))

--- a/examples/lockable-fungible-token/Cargo.toml
+++ b/examples/lockable-fungible-token/Cargo.toml
@@ -14,9 +14,7 @@ near-sdk = { path = "../../near-sdk", features = ["legacy"] }
 anyhow = "1.0"
 tokio = { version = "1.14", features = ["full"] }
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
-near-workspaces = { version = "0.18", features = [
-    "unstable",
-], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
+near-workspaces = { version = "0.19", features = ["unstable"] }
 rstest = "0.23.0"
 
 [profile.release]

--- a/examples/lockable-fungible-token/Cargo.toml
+++ b/examples/lockable-fungible-token/Cargo.toml
@@ -14,7 +14,9 @@ near-sdk = { path = "../../near-sdk", features = ["legacy"] }
 anyhow = "1.0"
 tokio = { version = "1.14", features = ["full"] }
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
-near-workspaces = { version = "0.18", features = ["unstable"] }
+near-workspaces = { version = "0.18", features = [
+    "unstable",
+], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
 rstest = "0.23.0"
 
 [profile.release]

--- a/examples/mission-control/Cargo.toml
+++ b/examples/mission-control/Cargo.toml
@@ -12,9 +12,7 @@ near-sdk = { path = "../../near-sdk" }
 
 [dev-dependencies]
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
-near-workspaces = { version = "0.18", features = [
-    "unstable",
-], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
+near-workspaces = { version = "0.19", features = ["unstable"] }
 tokio = { version = "1.14", features = ["full"] }
 anyhow = "1.0"
 near-abi = "0.4.0"

--- a/examples/mission-control/Cargo.toml
+++ b/examples/mission-control/Cargo.toml
@@ -12,7 +12,9 @@ near-sdk = { path = "../../near-sdk" }
 
 [dev-dependencies]
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
-near-workspaces = { version = "0.18", features = ["unstable"] }
+near-workspaces = { version = "0.18", features = [
+    "unstable",
+], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
 tokio = { version = "1.14", features = ["full"] }
 anyhow = "1.0"
 near-abi = "0.4.0"

--- a/examples/mpc-contract/Cargo.toml
+++ b/examples/mpc-contract/Cargo.toml
@@ -12,9 +12,7 @@ near-sdk = { path = "../../near-sdk" }
 hex = "0.4"
 
 [dev-dependencies]
-near-workspaces = { version = "0.18", features = [
-    "unstable",
-], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
+near-workspaces = { version = "0.19", features = ["unstable"] }
 tokio = { version = "1.14", features = ["full"] }
 mpc-contract = { path = "." }
 

--- a/examples/mpc-contract/Cargo.toml
+++ b/examples/mpc-contract/Cargo.toml
@@ -12,7 +12,9 @@ near-sdk = { path = "../../near-sdk" }
 hex = "0.4"
 
 [dev-dependencies]
-near-workspaces = { version = "0.16.0", features = ["unstable"] }
+near-workspaces = { version = "0.18", features = [
+    "unstable",
+], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
 tokio = { version = "1.14", features = ["full"] }
 mpc-contract = { path = "." }
 

--- a/examples/non-fungible-token/Cargo.toml
+++ b/examples/non-fungible-token/Cargo.toml
@@ -9,7 +9,9 @@ anyhow = "1.0"
 near-contract-standards = { path = "../../near-contract-standards" }
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
 tokio = { version = "1.14", features = ["full"] }
-near-workspaces = { version = "0.18", features = ["unstable"] }
+near-workspaces = { version = "0.18", features = [
+    "unstable",
+], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
 rstest = "0.23.0"
 
 [profile.release]

--- a/examples/non-fungible-token/Cargo.toml
+++ b/examples/non-fungible-token/Cargo.toml
@@ -9,9 +9,7 @@ anyhow = "1.0"
 near-contract-standards = { path = "../../near-contract-standards" }
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
 tokio = { version = "1.14", features = ["full"] }
-near-workspaces = { version = "0.18", features = [
-    "unstable",
-], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
+near-workspaces = { version = "0.19", features = ["unstable"] }
 rstest = "0.23.0"
 
 [profile.release]

--- a/examples/non-fungible-token/tests/workspaces/utils.rs
+++ b/examples/non-fungible-token/tests/workspaces/utils.rs
@@ -3,10 +3,10 @@ use std::str::FromStr;
 use near_contract_standards::non_fungible_token::metadata::TokenMetadata;
 use near_contract_standards::non_fungible_token::TokenId;
 
+use near_workspaces::cargo_near_build;
 use near_workspaces::types::NearToken;
 use near_workspaces::{Account, Contract};
 use rstest::fixture;
-use near_workspaces::cargo_near_build;
 pub const TOKEN_ID: &str = "0";
 
 pub async fn helper_mint(
@@ -42,7 +42,7 @@ pub async fn helper_mint(
 }
 
 fn build_contract(path: &str, contract_name: &str) -> Vec<u8> {
-    let artifact = cargo_near_build::build(cargo_near_build::BuildOpts {
+    let artifact = cargo_near_build::build_with_cli(cargo_near_build::BuildOpts {
         manifest_path: Some(
             cargo_near_build::camino::Utf8PathBuf::from_str(path).expect("camino PathBuf from str"),
         ),
@@ -50,8 +50,8 @@ fn build_contract(path: &str, contract_name: &str) -> Vec<u8> {
     })
     .expect(&format!("building `{}` contract for tests", contract_name));
 
-    let contract_wasm = std::fs::read(&artifact.path)
-        .map_err(|err| format!("accessing {} to read wasm contents: {}", artifact.path, err))
+    let contract_wasm = std::fs::read(&artifact)
+        .map_err(|err| format!("accessing {} to read wasm contents: {}", artifact, err))
         .expect("std::fs::read");
     contract_wasm
 }
@@ -146,10 +146,5 @@ pub async fn initialized_contracts(
         .await?;
     assert!(res.is_success());
 
-    return Ok((
-        nft_contract,
-        alice,
-        token_receiver_contract,
-        approval_receiver_contract,
-    ));
+    return Ok((nft_contract, alice, token_receiver_contract, approval_receiver_contract));
 }

--- a/examples/status-message/Cargo.toml
+++ b/examples/status-message/Cargo.toml
@@ -12,9 +12,7 @@ near-sdk = { path = "../../near-sdk" }
 
 [dev-dependencies]
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
-near-workspaces = { version = "0.18", features = [
-    "unstable",
-], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
+near-workspaces = { version = "0.19", features = ["unstable"] }
 tokio = { version = "1.14", features = ["full"] }
 anyhow = "1.0"
 near-abi = "0.4.0"

--- a/examples/status-message/Cargo.toml
+++ b/examples/status-message/Cargo.toml
@@ -12,7 +12,9 @@ near-sdk = { path = "../../near-sdk" }
 
 [dev-dependencies]
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
-near-workspaces = { version = "0.18", features = ["unstable"] }
+near-workspaces = { version = "0.18", features = [
+    "unstable",
+], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
 tokio = { version = "1.14", features = ["full"] }
 anyhow = "1.0"
 near-abi = "0.4.0"

--- a/examples/test-contract/Cargo.toml
+++ b/examples/test-contract/Cargo.toml
@@ -20,9 +20,7 @@ panic = "abort"
 
 [dev-dependencies]
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
-near-workspaces = { version = "0.18", features = [
-    "unstable",
-], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
+near-workspaces = { version = "0.19", features = ["unstable"] }
 tokio = { version = "1.14", features = ["full"] }
 anyhow = "1.0"
 near-abi = "0.4.0"

--- a/examples/test-contract/Cargo.toml
+++ b/examples/test-contract/Cargo.toml
@@ -20,7 +20,9 @@ panic = "abort"
 
 [dev-dependencies]
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
-near-workspaces = { version = "0.18", features = ["unstable"] }
+near-workspaces = { version = "0.18", features = [
+    "unstable",
+], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
 tokio = { version = "1.14", features = ["full"] }
 anyhow = "1.0"
 near-abi = "0.4.0"

--- a/examples/versioned/Cargo.toml
+++ b/examples/versioned/Cargo.toml
@@ -20,9 +20,7 @@ panic = "abort"
 
 [dev-dependencies]
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
-near-workspaces = { version = "0.18", features = [
-    "unstable",
-], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
+near-workspaces = { version = "0.19", features = ["unstable"] }
 tokio = { version = "1.14", features = ["full"] }
 anyhow = "1.0"
 near-abi = "0.4.0"

--- a/examples/versioned/Cargo.toml
+++ b/examples/versioned/Cargo.toml
@@ -20,7 +20,9 @@ panic = "abort"
 
 [dev-dependencies]
 near-sdk = { path = "../../near-sdk", features = ["unit-testing"] }
-near-workspaces = { version = "0.18", features = ["unstable"] }
+near-workspaces = { version = "0.18", features = [
+    "unstable",
+], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
 tokio = { version = "1.14", features = ["full"] }
 anyhow = "1.0"
 near-abi = "0.4.0"

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -63,7 +63,9 @@ rand_chacha = "0.3.1"
 near-rng = "0.1.1"
 near-abi = { version = "0.4.0", features = ["__chunked-entries"] }
 symbolic-debuginfo = "12"
-near-workspaces = { version = "0.18", features = ["unstable"] }
+near-workspaces = { version = "0.18", features = [
+    "unstable",
+], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
 anyhow = "1.0"
 tokio = { version = "1", features = ["full"] }
 strum = "0.25.0"

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -63,9 +63,7 @@ rand_chacha = "0.3.1"
 near-rng = "0.1.1"
 near-abi = { version = "0.4.0", features = ["__chunked-entries"] }
 symbolic-debuginfo = "12"
-near-workspaces = { version = "0.18", features = [
-    "unstable",
-], git = "https://github.com/dj8yfo/workspaces-rs.git", branch = "feat/build-with-ext-cli" }
+near-workspaces = { version = "0.19", features = ["unstable"] }
 anyhow = "1.0"
 tokio = { version = "1", features = ["full"] }
 strum = "0.25.0"


### PR DESCRIPTION
this avoids compiling `wasm-opt` in ci and locally, and installing binary dependency in CI is quite fast : 
![image](https://github.com/user-attachments/assets/d9a85c7b-bfff-4527-9b7c-5bc5e4ef6035)

current `master`
```bash
❯ : cargo tree -i wasm-opt
wasm-opt v0.116.1
└── cargo-near-build v0.4.5
    └── near-workspaces v0.18.0
        [dev-dependencies]
        └── near-sdk v5.12.0 (/home/jerrick/Documents/code/near/near-sdk-rs-worktrees/near-sdk-rs/near-sdk)
            └── near-contract-standards v5.12.0 (/home/jerrick/Documents/code/near/near-sdk-rs-worktrees/near-sdk-rs/near-contract-standards)
            [dev-dependencies]
            ├── near-contract-standards v5.12.0 (/home/jerrick/Documents/code/near/near-sdk-rs-worktrees/near-sdk-rs/near-contract-standards)
            └── near-sdk v5.12.0 (/home/jerrick/Documents/code/near/near-sdk-rs-worktrees/near-sdk-rs/near-sdk) (*)
```
\+ examples

pr's target branch
```bash
❯ : cargo tree -i cargo-near-build
cargo-near-build v0.6.0
└── near-workspaces v0.19.0
    [dev-dependencies]
    └── near-sdk v5.12.0 (/home/jerrick/Documents/code/near/near-sdk-rs-worktrees/near-sdk-rs.worktrees/feat/use_cargo_near_build_ext_cli/near-sdk)
        └── near-contract-standards v5.12.0 (/home/jerrick/Documents/code/near/near-sdk-rs-worktrees/near-sdk-rs.worktrees/feat/use_cargo_near_build_ext_cli/near-contract-standards)
        [dev-dependencies]
        ├── near-contract-standards v5.12.0 (/home/jerrick/Documents/code/near/near-sdk-rs-worktrees/near-sdk-rs.worktrees/feat/use_cargo_near_build_ext_cli/near-contract-standards)
        └── near-sdk v5.12.0 (/home/jerrick/Documents/code/near/near-sdk-rs-worktrees/near-sdk-rs.worktrees/feat/use_cargo_near_build_ext_cli/near-sdk) (*)
```
```bash
❯ : cargo tree -i wasm-opt
error: package ID specification `wasm-opt` did not match any packages
```


---

the pr depends on 
1. https://github.com/near/cargo-near/pull/333
2. https://github.com/near/cargo-near/pull/334 (in `examples/factory-contract`)
3. https://github.com/near/near-workspaces-rs/pull/411
