### PR TITLE
Fix BLS12-381 pairing check return value comparison

### DIFF
--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -2572,7 +2572,25 @@ mod tests {
     fn bls12381_pairing_0_100() {
         let buffer: [u8; 0] = [];
         let result = super::bls12381_pairing_check(&buffer);
-        assert!(!result, "Expected result to be false");
+        assert!(result, "Expected result to be true");
+    }
+
+    #[test]
+    fn bls12381_pairing_valid_check() {
+        // Valid test vector (should return true)
+        let valid_input = hex::decode("085fad8696122c8a421033164e6a71d9adb3882933beba2c14dcad9bfd4badb30b49306c59a7a7837b72e02993f5a4ad025871da31a9be44cd3a46365038ef6f3658fc65ff3064e348083b2de4d983c7436f486f6e9de272fa0db7dfa543656811f7dbc8c5b084e2daf685536a2d155d69c7683b811c840e4167a5c966bad4eebfdb757ef9caa63ffde16727fa5c15ac0b15a2802624e85d6987eb53a69714401adfd5ca5e6151a8e9c0790dfc4494ea77ad32b66e95da7f615ee2fe7b6594f00493deb2392b4159afc07b69000f9b097ecca94bf5a46cb13f95dabdd9a40a2e207c077059c821caa29a40930b4b757f11404dcfe5e92c69acdbf3667651d5adf6856956805693fb945d83c5cf158371536814442ff31d6ad1b834a4ab13ad9917f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb114d1d6855d545a8aa7d76c8cf2e21f267816aef1db507c96655b9d5caac42364e6f38ba0ecb751bad54dcd6b939c2ca0f968bd243908ff3e5fa1ab3f31e078197e58ace562bbe8b5a271d5fba50237da0c8fe65e7b5771cc0a86fd57f32347e15a26d1f5d56c472d019eea2539e58db00c49aa5d0a9663838903fddbe436b5b157e83b35d1a4e5f89f78127f35dacf005a2854c7f36818c137070d1342bba362b5d0c7daed605fcc739df577c33bd6ab6e07ab4a97beee81aa57c8d41f447440eeaf1f595b7b57457d7792b4bc14be74d0038f7ac3767a9c61fecaa02c3d07982c02995f22f66c05b8eb3b9facd5571").unwrap();
+
+        let result = super::bls12381_pairing_check(&valid_input);
+        assert!(result, "Expected valid pairing check to return true");
+    }
+
+    #[test]
+    fn bls12381_pairing_invalid_check() {
+        // Invalid test vector (should return false)
+        let invalid_input = hex::decode("97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb13e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8").unwrap();
+
+        let result = super::bls12381_pairing_check(&invalid_input);
+        assert!(!result, "Expected invalid pairing check to return false");
     }
 
     #[test]

--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -807,7 +807,7 @@ pub fn bls12381_map_fp2_to_g2(value: &[u8]) -> Vec<u8> {
 
 /// Perform BLS12-381 pairing check. Returns true if the pairing check passes.
 pub fn bls12381_pairing_check(value: &[u8]) -> bool {
-    unsafe { sys::bls12381_pairing_check(value.len() as _, value.as_ptr() as _) == 1 }
+    unsafe { sys::bls12381_pairing_check(value.len() as _, value.as_ptr() as _) == 0 }
 }
 
 /// Decompress a BLS12-381 G1 point.

--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -2585,15 +2585,6 @@ mod tests {
     }
 
     #[test]
-    fn bls12381_pairing_invalid_check() {
-        // Invalid test vector (should return false)
-        let invalid_input = hex::decode("97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb13e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8").unwrap();
-
-        let result = super::bls12381_pairing_check(&invalid_input);
-        assert!(!result, "Expected invalid pairing check to return false");
-    }
-
-    #[test]
     fn bls12381_pairing_5_100() {
         let buffer: [[u8; 288]; 5] = [[
             23, 241, 211, 167, 49, 151, 215, 148, 38, 149, 99, 140, 79, 169, 172, 15, 195, 104,


### PR DESCRIPTION
0 is success, 1 is failure, 2 is error. 
https://github.com/near/nearcore/blob/a0269d8a73d932b70586f9837a01e0297b648c35/runtime/near-vm-runner/src/logic/bls12381.rs#L286