### PR TITLE
ci: add cargo-near install to compare_sizes.yml

### DIFF
--- a/.github/workflows/compare_sizes.yml
+++ b/.github/workflows/compare_sizes.yml
@@ -29,6 +29,8 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}
           # restore-keys: |
           #   ${{ runner.os }}-build-${{ env.cache-name }}
+      - name: Install cargo-near CLI (dependency for docker builds in generate report)
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.14.0/cargo-near-installer.sh | sh
       - name: Generate report
         run: |
           yes | pip install GitPython docker appdirs


### PR DESCRIPTION
this has been somewhat skipped in #1350 ; 

this is  needed to live test/fine tune in ci modified `ci/compare_sizes/compare_sizes.py` in scope of #1343,

 because `/compare` directives appear to trigger `.github/workflows/compare_sizes.yml` workflow from default branch, and not from commented-on issue/pr (there's no associated GITHUB_COMMIT for an issue at all https://github.com/near/near-sdk-rs/actions/runs/14844334355)
 
 
which is mentioned in comments https://github.com/near/near-sdk-rs/pull/1343#issuecomment-2824364811 and https://github.com/near/near-sdk-rs/pull/1343#issuecomment-2851363615