### PR TITLE
chore: release 5.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## [5.13.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.13.0...near-sdk-v5.13.1) - 2025-05-14
+## [5.14.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.13.0...near-sdk-v5.14.0) - 2025-05-14
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [5.13.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.13.0...near-sdk-v5.13.1) - 2025-05-14
+
+### Other
+
+- updates near-workspaces to 0.20 version ([#1358](https://github.com/near/near-sdk-rs/pull/1358))
+- updates near-* dependencies to 0.30 release ([#1356](https://github.com/near/near-sdk-rs/pull/1356))
+
 ## [5.13.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.12.0...near-sdk-v5.13.0) - 2025-05-05
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["near-sdk", "near-sdk-macros", "near-contract-standards", "near-sys"]
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.13.0"
+version = "5.13.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 categories = ["wasm"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["near-sdk", "near-sdk-macros", "near-contract-standards", "near-sys"]
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.13.1"
+version = "5.14.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 categories = ["wasm"]

--- a/near-contract-standards/CHANGELOG.md
+++ b/near-contract-standards/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [5.13.1](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.13.0...near-contract-standards-v5.13.1) - 2025-05-14
+## [5.14.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.13.0...near-contract-standards-v5.14.0) - 2025-05-14
 
 ### Other
 

--- a/near-contract-standards/CHANGELOG.md
+++ b/near-contract-standards/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.13.1](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.13.0...near-contract-standards-v5.13.1) - 2025-05-14
+
+### Other
+
+- updates near-* dependencies to 0.30 release ([#1356](https://github.com/near/near-sdk-rs/pull/1356))
+
 ## [5.13.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.12.0...near-contract-standards-v5.13.0) - 2025-05-05
 
 ### Other

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.13.1", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.14.0", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.13.0", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.13.1", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.13.1" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.14.0" }
 near-sys = { path = "../near-sys", version = "0.2.4" }
 base64 = "0.22"
 borsh = { version = "1.0.0", features = ["derive"] }

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,8 +21,8 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.13.0" }
-near-sys = { path = "../near-sys", version = "0.2.3" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.13.1" }
+near-sys = { path = "../near-sys", version = "0.2.4" }
 base64 = "0.22"
 borsh = { version = "1.0.0", features = ["derive"] }
 bs58 = "0.5"

--- a/near-sys/CHANGELOG.md
+++ b/near-sys/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.3...near-sys-v0.2.4) - 2025-05-14
+
+### Other
+
+- updates near-* dependencies to 0.30 release ([#1356](https://github.com/near/near-sdk-rs/pull/1356))
+
 ## [0.2.3](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.2...near-sys-v0.2.3) - 2025-05-05
 
 ### Added

--- a/near-sys/Cargo.toml
+++ b/near-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sys"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Near Inc <hello@near.org>"]
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION


## 🤖 New release

* `near-sdk-macros`: 5.13.0 -> 5.14.0
* `near-sys`: 0.2.3 -> 0.2.4 (✓ API compatible changes)
* `near-sdk`: 5.13.0 -> 5.14.0 (✓ API compatible changes)
* `near-contract-standards`: 5.13.0 -> 5.14.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `near-sys`

<blockquote>

## [0.2.4](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.3...near-sys-v0.2.4) - 2025-05-14

### Other

- updates near-* dependencies to 0.30 release ([#1356](https://github.com/near/near-sdk-rs/pull/1356))
</blockquote>

## `near-sdk`

<blockquote>

## [5.14.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.13.0...near-sdk-v5.14.0) - 2025-05-14

### Other

- updates near-workspaces to 0.20 version ([#1358](https://github.com/near/near-sdk-rs/pull/1358))
- updates near-* dependencies to 0.30 release ([#1356](https://github.com/near/near-sdk-rs/pull/1356))
</blockquote>

## `near-contract-standards`

<blockquote>

## [5.14.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.13.0...near-contract-standards-v5.14.0) - 2025-05-14

### Other

- updates near-* dependencies to 0.30 release ([#1356](https://github.com/near/near-sdk-rs/pull/1356))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).