### PR TITLE
feat: Hint developers to use `cargo near build` to build contracts instead of `cargo build`

### DIFF
--- a/near-sdk/src/lib.rs
+++ b/near-sdk/src/lib.rs
@@ -108,6 +108,22 @@
 #[cfg(test)]
 extern crate quickcheck;
 
+// NOTE: If you know what you are doing and want to avoid using `cargo-near`, you can set
+// CARGO_BUILD_RUSTFLAGS='--cfg cargo_near_build' for `cargo build` to pass this gate.
+#[cfg(not(any(
+    test,
+    doctest,
+    clippy,
+    target_family = "wasm",
+    feature = "unit-testing",
+    feature = "__abi-generate"
+)))]
+compile_error!(
+    "⚠️  Use `cargo near build` instead of `cargo build` to compile your contract
+
+💡  Install cargo-near from https://github.com/near/cargo-near"
+);
+
 /// This attribute macro is used on a struct/enum and its implementations
 /// to generate the necessary code to expose `pub` methods from the contract as well
 /// as generating the glue code to be a valid NEAR contract.


### PR DESCRIPTION
It is a more robust version of https://github.com/near/cargo-near/pull/350, which works for all existing contracts that will pull in the latest near-sdk-rs.

<img width="999" alt="image" src="https://github.com/user-attachments/assets/f32bc4a8-e8f5-4f76-87d8-e78f5a2fe604" />

Without this patch `cargo build` will succeed, but this confuses users as they cannot find the wasm file.

This PR ensured that none of the legacy commands will fail:
* `cargo test` will pass thanks to `unit-testing` feature being enabled in all contracts for near-sdk in `dev-dependency`
* `cargo build --target=wasm...` will pass since this check does not trigger compilation error if `target_family="wasm"`
* `cargo near build` will set `__abi_generate` feature for the ABI build, and `target_family="wasm"` for the contract build