### PR TITLE
chore: release v5.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+## [5.15.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.14.0...near-sdk-v5.15.0) - 2025-06-16
+
+### Added
+
+- Added a new `.to_json()` method for Events in addition to `.emit()` ([#1360](https://github.com/near/near-sdk-rs/pull/1360))
+- Hint developers to use `cargo near build` to build contracts instead of `cargo build` ([#1361](https://github.com/near/near-sdk-rs/pull/1361))
+- Include detailed error information on deserialization errors for function input arguments to improve troubleshooting experience for devs ([#1363](https://github.com/near/near-sdk-rs/pull/1363))
+
+### Other
+
+- expand cfgs' compilation error with complete reason of the error ([#1367](https://github.com/near/near-sdk-rs/pull/1367))
+- Added "How to Deploy a Smart Contract on NEAR | Full Guide for Windows, Mac & Linux (Step-by-Step)" video to the README ([#1366](https://github.com/near/near-sdk-rs/pull/1366))
+- Added explanation for borsh(...) parameters in #[near(serializers = [...])] ([#1359](https://github.com/near/near-sdk-rs/pull/1359))
+
 ## [5.14.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.13.0...near-sdk-v5.14.0) - 2025-05-14
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["near-sdk", "near-sdk-macros", "near-contract-standards", "near-sys"]
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.14.0"
+version = "5.15.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 categories = ["wasm"]

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.14.0", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.15.0", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.14.0" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.15.0" }
 near-sys = { path = "../near-sys", version = "0.2.4" }
 base64 = "0.22"
 borsh = { version = "1.0.0", features = ["derive"] }


### PR DESCRIPTION



## 🤖 New release

* `near-sdk-macros`: 5.14.0 -> 5.15.0
* `near-sdk`: 5.14.0 -> 5.15.0 (✓ API compatible changes)
* `near-contract-standards`: 5.14.0 -> 5.15.0

<details><summary><i><b>Changelog</b></i></summary><p>


## `near-sdk`

<blockquote>

## [5.15.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.14.0...near-sdk-v5.15.0) - 2025-06-16

### Added

- Added a new `.to_json()` method for Events in addition to `.emit()` ([#1360](https://github.com/near/near-sdk-rs/pull/1360))
- Hint developers to use `cargo near build` to build contracts instead of `cargo build` ([#1361](https://github.com/near/near-sdk-rs/pull/1361))
- Include detailed error information on deserialization errors for function input arguments to improve troubleshooting experience for devs ([#1363](https://github.com/near/near-sdk-rs/pull/1363))

### Other

- expand cfgs' compilation error with complete reason of the error ([#1367](https://github.com/near/near-sdk-rs/pull/1367))
- Added "How to Deploy a Smart Contract on NEAR | Full Guide for Windows, Mac & Linux (Step-by-Step)" video to the README ([#1366](https://github.com/near/near-sdk-rs/pull/1366))
- Added explanation for borsh(...) parameters in #[near(serializers = [...])] ([#1359](https://github.com/near/near-sdk-rs/pull/1359))
</blockquote>

## `near-contract-standards`

<blockquote>

## [5.14.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.13.0...near-contract-standards-v5.14.0) - 2025-05-14

### Other

- updates near-* dependencies to 0.30 release ([#1356](https://github.com/near/near-sdk-rs/pull/1356))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).