### PR TITLE
Add error information on deserialization errors

### DIFF
--- a/near-sdk-macros/src/core_impl/code_generator/attr_sig_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/attr_sig_info.rs
@@ -331,9 +331,7 @@ fn deserialize_data(ty: &SerializerType) -> TokenStream2 {
             match ::near_sdk::serde_json::from_slice(&data) {
                 Ok(deserialized) => deserialized,
                 Err(e) => {
-                    let mut err = String::from("Failed to deserialize callback using JSON. Error: ");
-                    err.push_str(&e.to_string());
-                    ::near_sdk::env::panic_str(&err);
+                    ::near_sdk::env::panic_str(&format!("Failed to deserialize callback using JSON. Error: `{e}`"));
                 },
             }
         },
@@ -341,9 +339,7 @@ fn deserialize_data(ty: &SerializerType) -> TokenStream2 {
             match ::near_sdk::borsh::BorshDeserialize::try_from_slice(&data) {
                 Ok(deserialized) => deserialized,
                 Err(e) => {
-                    let mut err = String::from("Failed to deserialize callback using Borsh. Error: ");
-                    err.push_str(&e.to_string());
-                    ::near_sdk::env::panic_str(&err);
+                    ::near_sdk::env::panic_str(&format!("Failed to deserialize callback using Borsh. Error: `{e}`"));
                 }
             }
         },

--- a/near-sdk-macros/src/core_impl/code_generator/impl_item_method_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/impl_item_method_info.rs
@@ -122,9 +122,7 @@ impl ImplItemMethodInfo {
                         Some(input) => match ::near_sdk::serde_json::from_slice(&input) {
                             Ok(deserialized) => deserialized,
                             Err(e) => {
-                                let mut err = String::from("Failed to deserialize input from JSON. Error: ");
-                                err.push_str(&e.to_string());
-                                ::near_sdk::env::panic_str(&err);
+                                ::near_sdk::env::panic_str(&format!("Failed to deserialize input from JSON. Error: `{e}`"));
                             }
                         },
                         None => ::near_sdk::env::panic_str("Expected input since method has arguments.")
@@ -135,9 +133,7 @@ impl ImplItemMethodInfo {
                         Some(input) => match ::near_sdk::borsh::BorshDeserialize::try_from_slice(&input) {
                             Ok(deserialized) => deserialized,
                             Err(e) => {
-                                let mut err = String::from("Failed to deserialize input from Borsh. Error: ");
-                                err.push_str(&e.to_string());
-                                ::near_sdk::env::panic_str(&err);
+                                ::near_sdk::env::panic_str(&format!("Failed to deserialize input from Borsh. Error: `{e}`"));
                             }
                         },
                         None => ::near_sdk::env::panic_str("Expected input since method has arguments.")

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/arg_mut_ref.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/arg_mut_ref.snap
@@ -16,11 +16,9 @@ pub extern "C" fn method() {
             match ::near_sdk::serde_json::from_slice(&input) {
                 Ok(deserialized) => deserialized,
                 Err(e) => {
-                    let mut err = String::from(
-                        "Failed to deserialize input from JSON. Error: ",
+                    ::near_sdk::env::panic_str(
+                        &format!("Failed to deserialize input from JSON. Error: `{e}`"),
                     );
-                    err.push_str(&e.to_string());
-                    ::near_sdk::env::panic_str(&err);
                 }
             }
         }

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/arg_no_return_no_mut.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/arg_no_return_no_mut.snap
@@ -16,11 +16,9 @@ pub extern "C" fn method() {
             match ::near_sdk::serde_json::from_slice(&input) {
                 Ok(deserialized) => deserialized,
                 Err(e) => {
-                    let mut err = String::from(
-                        "Failed to deserialize input from JSON. Error: ",
+                    ::near_sdk::env::panic_str(
+                        &format!("Failed to deserialize input from JSON. Error: `{e}`"),
                     );
-                    err.push_str(&e.to_string());
-                    ::near_sdk::env::panic_str(&err);
                 }
             }
         }

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/arg_ref.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/arg_ref.snap
@@ -16,11 +16,9 @@ pub extern "C" fn method() {
             match ::near_sdk::serde_json::from_slice(&input) {
                 Ok(deserialized) => deserialized,
                 Err(e) => {
-                    let mut err = String::from(
-                        "Failed to deserialize input from JSON. Error: ",
+                    ::near_sdk::env::panic_str(
+                        &format!("Failed to deserialize input from JSON. Error: `{e}`"),
                     );
-                    err.push_str(&e.to_string());
-                    ::near_sdk::env::panic_str(&err);
                 }
             }
         }

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/args_no_return_mut.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/args_no_return_mut.snap
@@ -20,11 +20,9 @@ pub extern "C" fn method() {
             match ::near_sdk::serde_json::from_slice(&input) {
                 Ok(deserialized) => deserialized,
                 Err(e) => {
-                    let mut err = String::from(
-                        "Failed to deserialize input from JSON. Error: ",
+                    ::near_sdk::env::panic_str(
+                        &format!("Failed to deserialize input from JSON. Error: `{e}`"),
                     );
-                    err.push_str(&e.to_string());
-                    ::near_sdk::env::panic_str(&err);
                 }
             }
         }

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/args_return_mut.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/args_return_mut.snap
@@ -20,11 +20,9 @@ pub extern "C" fn method() {
             match ::near_sdk::serde_json::from_slice(&input) {
                 Ok(deserialized) => deserialized,
                 Err(e) => {
-                    let mut err = String::from(
-                        "Failed to deserialize input from JSON. Error: ",
+                    ::near_sdk::env::panic_str(
+                        &format!("Failed to deserialize input from JSON. Error: `{e}`"),
                     );
-                    err.push_str(&e.to_string());
-                    ::near_sdk::env::panic_str(&err);
                 }
             }
         }

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/args_return_mut_borsh.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/args_return_mut_borsh.snap
@@ -20,11 +20,9 @@ pub extern "C" fn method() {
             match ::near_sdk::borsh::BorshDeserialize::try_from_slice(&input) {
                 Ok(deserialized) => deserialized,
                 Err(e) => {
-                    let mut err = String::from(
-                        "Failed to deserialize input from Borsh. Error: ",
+                    ::near_sdk::env::panic_str(
+                        &format!("Failed to deserialize input from Borsh. Error: `{e}`"),
                     );
-                    err.push_str(&e.to_string());
-                    ::near_sdk::env::panic_str(&err);
                 }
             }
         }

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/callback_args.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/callback_args.snap
@@ -20,11 +20,9 @@ pub extern "C" fn method() {
             match ::near_sdk::serde_json::from_slice(&input) {
                 Ok(deserialized) => deserialized,
                 Err(e) => {
-                    let mut err = String::from(
-                        "Failed to deserialize input from JSON. Error: ",
+                    ::near_sdk::env::panic_str(
+                        &format!("Failed to deserialize input from JSON. Error: `{e}`"),
                     );
-                    err.push_str(&e.to_string());
-                    ::near_sdk::env::panic_str(&err);
                 }
             }
         }
@@ -37,11 +35,9 @@ pub extern "C" fn method() {
     let mut x: u64 = match ::near_sdk::serde_json::from_slice(&data) {
         Ok(deserialized) => deserialized,
         Err(e) => {
-            let mut err = String::from(
-                "Failed to deserialize callback using JSON. Error: ",
+            ::near_sdk::env::panic_str(
+                &format!("Failed to deserialize callback using JSON. Error: `{e}`"),
             );
-            err.push_str(&e.to_string());
-            ::near_sdk::env::panic_str(&err);
         }
     };
     let data: ::std::vec::Vec<u8> = match ::near_sdk::env::promise_result(1u64) {
@@ -51,11 +47,9 @@ pub extern "C" fn method() {
     let z: ::std::vec::Vec<u8> = match ::near_sdk::serde_json::from_slice(&data) {
         Ok(deserialized) => deserialized,
         Err(e) => {
-            let mut err = String::from(
-                "Failed to deserialize callback using JSON. Error: ",
+            ::near_sdk::env::panic_str(
+                &format!("Failed to deserialize callback using JSON. Error: `{e}`"),
             );
-            err.push_str(&e.to_string());
-            ::near_sdk::env::panic_str(&err);
         }
     };
     let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/callback_args_mixed_serialization.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/callback_args_mixed_serialization.snap
@@ -20,11 +20,9 @@ pub extern "C" fn method() {
             match ::near_sdk::borsh::BorshDeserialize::try_from_slice(&input) {
                 Ok(deserialized) => deserialized,
                 Err(e) => {
-                    let mut err = String::from(
-                        "Failed to deserialize input from Borsh. Error: ",
+                    ::near_sdk::env::panic_str(
+                        &format!("Failed to deserialize input from Borsh. Error: `{e}`"),
                     );
-                    err.push_str(&e.to_string());
-                    ::near_sdk::env::panic_str(&err);
                 }
             }
         }
@@ -37,11 +35,9 @@ pub extern "C" fn method() {
     let mut x: u64 = match ::near_sdk::borsh::BorshDeserialize::try_from_slice(&data) {
         Ok(deserialized) => deserialized,
         Err(e) => {
-            let mut err = String::from(
-                "Failed to deserialize callback using Borsh. Error: ",
+            ::near_sdk::env::panic_str(
+                &format!("Failed to deserialize callback using Borsh. Error: `{e}`"),
             );
-            err.push_str(&e.to_string());
-            ::near_sdk::env::panic_str(&err);
         }
     };
     let data: ::std::vec::Vec<u8> = match ::near_sdk::env::promise_result(1u64) {
@@ -51,11 +47,9 @@ pub extern "C" fn method() {
     let z: ::std::vec::Vec<u8> = match ::near_sdk::serde_json::from_slice(&data) {
         Ok(deserialized) => deserialized,
         Err(e) => {
-            let mut err = String::from(
-                "Failed to deserialize callback using JSON. Error: ",
+            ::near_sdk::env::panic_str(
+                &format!("Failed to deserialize callback using JSON. Error: `{e}`"),
             );
-            err.push_str(&e.to_string());
-            ::near_sdk::env::panic_str(&err);
         }
     };
     let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/callback_args_only.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/callback_args_only.snap
@@ -17,11 +17,9 @@ pub extern "C" fn method() {
     let mut x: u64 = match ::near_sdk::serde_json::from_slice(&data) {
         Ok(deserialized) => deserialized,
         Err(e) => {
-            let mut err = String::from(
-                "Failed to deserialize callback using JSON. Error: ",
+            ::near_sdk::env::panic_str(
+                &format!("Failed to deserialize callback using JSON. Error: `{e}`"),
             );
-            err.push_str(&e.to_string());
-            ::near_sdk::env::panic_str(&err);
         }
     };
     let data: ::std::vec::Vec<u8> = match ::near_sdk::env::promise_result(1u64) {
@@ -31,11 +29,9 @@ pub extern "C" fn method() {
     let y: ::std::string::String = match ::near_sdk::serde_json::from_slice(&data) {
         Ok(deserialized) => deserialized,
         Err(e) => {
-            let mut err = String::from(
-                "Failed to deserialize callback using JSON. Error: ",
+            ::near_sdk::env::panic_str(
+                &format!("Failed to deserialize callback using JSON. Error: `{e}`"),
             );
-            err.push_str(&e.to_string());
-            ::near_sdk::env::panic_str(&err);
         }
     };
     let contract: Hello = ::near_sdk::env::state_read().unwrap_or_default();

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/callback_args_results.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/callback_args_results.snap
@@ -16,11 +16,11 @@ pub extern "C" fn method() {
                 match ::near_sdk::serde_json::from_slice(&data) {
                     Ok(deserialized) => deserialized,
                     Err(e) => {
-                        let mut err = String::from(
-                            "Failed to deserialize callback using JSON. Error: ",
+                        ::near_sdk::env::panic_str(
+                            &format!(
+                                "Failed to deserialize callback using JSON. Error: `{e}`"
+                            ),
                         );
-                        err.push_str(&e.to_string());
-                        ::near_sdk::env::panic_str(&err);
                     }
                 },
             )
@@ -37,11 +37,11 @@ pub extern "C" fn method() {
                 match ::near_sdk::serde_json::from_slice(&data) {
                     Ok(deserialized) => deserialized,
                     Err(e) => {
-                        let mut err = String::from(
-                            "Failed to deserialize callback using JSON. Error: ",
+                        ::near_sdk::env::panic_str(
+                            &format!(
+                                "Failed to deserialize callback using JSON. Error: `{e}`"
+                            ),
                         );
-                        err.push_str(&e.to_string());
-                        ::near_sdk::env::panic_str(&err);
                     }
                 },
             )

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/callback_args_vec.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/callback_args_vec.snap
@@ -20,11 +20,9 @@ pub extern "C" fn method() {
             match ::near_sdk::serde_json::from_slice(&input) {
                 Ok(deserialized) => deserialized,
                 Err(e) => {
-                    let mut err = String::from(
-                        "Failed to deserialize input from JSON. Error: ",
+                    ::near_sdk::env::panic_str(
+                        &format!("Failed to deserialize input from JSON. Error: `{e}`"),
                     );
-                    err.push_str(&e.to_string());
-                    ::near_sdk::env::panic_str(&err);
                 }
             }
         }
@@ -49,11 +47,11 @@ pub extern "C" fn method() {
                 match ::near_sdk::serde_json::from_slice(&data) {
                     Ok(deserialized) => deserialized,
                     Err(e) => {
-                        let mut err = String::from(
-                            "Failed to deserialize callback using JSON. Error: ",
+                        ::near_sdk::env::panic_str(
+                            &format!(
+                                "Failed to deserialize callback using JSON. Error: `{e}`"
+                            ),
                         );
-                        err.push_str(&e.to_string());
-                        ::near_sdk::env::panic_str(&err);
                     }
                 }
             },

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/deny_unknown_arguments_return_mut_method.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/deny_unknown_arguments_return_mut_method.snap
@@ -20,11 +20,9 @@ pub extern "C" fn method() {
             match ::near_sdk::serde_json::from_slice(&input) {
                 Ok(deserialized) => deserialized,
                 Err(e) => {
-                    let mut err = String::from(
-                        "Failed to deserialize input from JSON. Error: ",
+                    ::near_sdk::env::panic_str(
+                        &format!("Failed to deserialize input from JSON. Error: `{e}`"),
                     );
-                    err.push_str(&e.to_string());
-                    ::near_sdk::env::panic_str(&err);
                 }
             }
         }

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/init_ignore_state.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/init_ignore_state.snap
@@ -19,11 +19,9 @@ pub extern "C" fn method() {
             match ::near_sdk::serde_json::from_slice(&input) {
                 Ok(deserialized) => deserialized,
                 Err(e) => {
-                    let mut err = String::from(
-                        "Failed to deserialize input from JSON. Error: ",
+                    ::near_sdk::env::panic_str(
+                        &format!("Failed to deserialize input from JSON. Error: `{e}`"),
                     );
-                    err.push_str(&e.to_string());
-                    ::near_sdk::env::panic_str(&err);
                 }
             }
         }

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/init_payable.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/init_payable.snap
@@ -16,11 +16,9 @@ pub extern "C" fn method() {
             match ::near_sdk::serde_json::from_slice(&input) {
                 Ok(deserialized) => deserialized,
                 Err(e) => {
-                    let mut err = String::from(
-                        "Failed to deserialize input from JSON. Error: ",
+                    ::near_sdk::env::panic_str(
+                        &format!("Failed to deserialize input from JSON. Error: `{e}`"),
                     );
-                    err.push_str(&e.to_string());
-                    ::near_sdk::env::panic_str(&err);
                 }
             }
         }

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/simple_init.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/simple_init.snap
@@ -19,11 +19,9 @@ pub extern "C" fn method() {
             match ::near_sdk::serde_json::from_slice(&input) {
                 Ok(deserialized) => deserialized,
                 Err(e) => {
-                    let mut err = String::from(
-                        "Failed to deserialize input from JSON. Error: ",
+                    ::near_sdk::env::panic_str(
+                        &format!("Failed to deserialize input from JSON. Error: `{e}`"),
                     );
-                    err.push_str(&e.to_string());
-                    ::near_sdk::env::panic_str(&err);
                 }
             }
         }


### PR DESCRIPTION
There are many situations when error information is needed when deserialization fails. Currently, the error just states that deserialization failed without any hint to what happened. I added the error to the printed message. 

This is motivated by having received complaints from users, stating that the error, in its current state, is not helpful enough.

---

for 
```rust
        .args(b"{\"greeting\": \"Hello World!\",}".to_vec())
```
this pr changes error from 
```bash
Smart contract panicked: Failed to deserialize input from JSON.
```
to
```bash
Smart contract panicked: Failed to deserialize input from JSON. Error: `trailing comma at line 1 column 29`
```



for 
```rust
        .args(b"{\"wrong_key\": \"Hello World!\"}".to_vec())
```
this pr changes error from
```bash
Smart contract panicked: Failed to deserialize input from JSON.
```
to
```bash
Smart contract panicked: Failed to deserialize input from JSON. Error: `missing field `greeting` at line 1 column 29`
```
