### PR TITLE
feat: then_concurrent() for Promise API

### DIFF
--- a/near-sdk/src/lib.rs
+++ b/near-sdk/src/lib.rs
@@ -1070,7 +1070,7 @@ pub use environment::env;
 pub use near_sys as sys;
 
 mod promise;
-pub use promise::{Allowance, Promise, PromiseOrValue};
+pub use promise::{Allowance, ConcurrentPromises, Promise, PromiseOrValue};
 
 // Private types just used within macro generation, not stable to be used.
 #[doc(hidden)]

--- a/near-sdk/src/promise.rs
+++ b/near-sdk/src/promise.rs
@@ -693,7 +693,6 @@ impl<T: schemars::JsonSchema> schemars::JsonSchema for PromiseOrValue<T> {
 ///
 /// You can also use [`ConcurrentPromises::take`] to retrieve the list of
 /// promises as a vector.
-#[cfg_attr(feature = "abi", derive(schemars::JsonSchema))]
 pub struct ConcurrentPromises {
     promises: Vec<Promise>,
 }

--- a/near-sdk/src/promise.rs
+++ b/near-sdk/src/promise.rs
@@ -729,17 +729,6 @@ impl ConcurrentPromises {
     }
 }
 
-#[cfg(feature = "abi")]
-impl<T: schemars::JsonSchema> schemars::JsonSchema for ConcurrentPromises {
-    fn schema_name() -> String {
-        "ConcurrentPromises".to_string()
-    }
-
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        T::json_schema(gen)
-    }
-}
-
 #[cfg(not(target_arch = "wasm32"))]
 #[cfg(test)]
 mod tests {

--- a/near-sdk/src/promise.rs
+++ b/near-sdk/src/promise.rs
@@ -690,9 +690,6 @@ impl<T: schemars::JsonSchema> schemars::JsonSchema for PromiseOrValue<T> {
 ///
 /// Use [`ConcurrentPromises::split_off`] to divide the list of promises into
 /// subgroups that can be joined independently.
-///
-/// You can also use [`ConcurrentPromises::take`] to retrieve the list of
-/// promises as a vector.
 pub struct ConcurrentPromises {
     promises: Vec<Promise>,
 }
@@ -719,12 +716,6 @@ impl ConcurrentPromises {
     pub fn split_off(&mut self, at: usize) -> ConcurrentPromises {
         let right_side = self.promises.split_off(at);
         ConcurrentPromises { promises: right_side }
-    }
-
-    /// Take the contained concurrent promises out of the convenience wrapper
-    /// [`ConcurrentPromises`].
-    pub fn take(self) -> Vec<Promise> {
-        self.promises
     }
 }
 


### PR DESCRIPTION
Send the same outgoing data dependency to many function calls that run after.

This has always been possible with the low-level API but the Promise API was not expressive enough.

Specifically, in `near_sys::promise_then`, one can use the same promise index more than once.

https://github.com/near/near-sdk-rs/blob/985c16b8fffc623096d0b7e60b26746842a2d712/near-sys/src/lib.rs#L77-L87

However, using the SDK's promise API, [`Promise::then`](https://docs.rs/near-sdk/latest/near_sdk/struct.Promise.html#method.then) consumes the promise, which makes calling `then` twice impossible.

This adds method `then_concurrent` to allow more complex dependencies. This method returns `ConcurrentPromises` that can be joined and chained again.

See the included doc comments and tests for examples.