### PR TITLE
chore: release v5.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [5.15.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.15.0...near-sdk-v5.15.1) - 2025-07-01
+
+### Other
+
+- New `non-contract-usage` feature flag to be able to use near-sdk-rs in thirdparty projects that don't use it for contract building ([#1370](https://github.com/near/near-sdk-rs/pull/1370))
+
 ## [5.15.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.14.0...near-sdk-v5.15.0) - 2025-06-16
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["near-sdk", "near-sdk-macros", "near-contract-standards", "near-sys"]
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.15.0"
+version = "5.15.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 categories = ["wasm"]

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.15.0", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.15.1", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.15.0" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.15.1" }
 near-sys = { path = "../near-sys", version = "0.2.4" }
 base64 = "0.22"
 borsh = { version = "1.0.0", features = ["derive"] }


### PR DESCRIPTION



## 🤖 New release

* `near-sdk-macros`: 5.15.0 -> 5.15.1
* `near-sdk`: 5.15.0 -> 5.15.1 (✓ API compatible changes)
* `near-contract-standards`: 5.15.0 -> 5.15.1

<details><summary><i><b>Changelog</b></i></summary><p>


## `near-sdk`

<blockquote>

## [5.15.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.15.0...near-sdk-v5.15.1) - 2025-07-01

### Other

- New `non-contract-usage` feature flag to be able to use near-sdk-rs in thirdparty projects that don't use it for contract building ([#1370](https://github.com/near/near-sdk-rs/pull/1370))
</blockquote>

## `near-contract-standards`

<blockquote>

## [5.14.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.13.0...near-contract-standards-v5.14.0) - 2025-05-14

### Other

- updates near-* dependencies to 0.30 release ([#1356](https://github.com/near/near-sdk-rs/pull/1356))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).