### PR TITLE
docs: Auto-document features on docs.rs + improved wording for the top-level documentation

### DIFF
--- a/near-sdk/src/lib.rs
+++ b/near-sdk/src/lib.rs
@@ -115,7 +115,6 @@
 //! ```
 
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 // Clippy is giving false positive warnings for this in 1.57 version. Remove this if fixed.
 // https://github.com/rust-lang/rust-clippy/issues/8091
 #![allow(clippy::redundant_closure)]


### PR DESCRIPTION
Currently, the `global-contract` feature it hard to discover as while the methods are [visible in the docs](https://docs.rs/near-sdk/5.17.1/near_sdk/struct.Promise.html#method.use_global_contract):

<img width="1016" height="330" alt="image" src="https://github.com/user-attachments/assets/e821f3a6-2f47-4b32-9320-8a53621a1bc0" />

There is no indication that `global-contracts` feature is required. See `tokio` as example:

<img width="479" height="235" alt="image" src="https://github.com/user-attachments/assets/798d89a3-cae9-42ca-b611-479c5e4e4bea" />

To enable this documentation, we just need to enable the nightly feature and hide it behind the conditional compilation flag for docsrs: `#![cfg_attr(docsrs, feature(doc_auto_cfg))]`

https://docs.rs/about/builds#detecting-docsrs