### PR TITLE
chore: release v5.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.17.2](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.17.1...near-sdk-v5.17.2) - 2025-08-30
+
+### Other
+
+- Auto-document features on docs.rs + improved wording for the top-level documentation ([#1386](https://github.com/near/near-sdk-rs/pull/1386))
+
 ## [5.17.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.17.0...near-sdk-v5.17.1) - 2025-08-19
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["near-sdk", "near-sdk-macros", "near-contract-standards", "near-sys"]
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.17.1"
+version = "5.17.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 categories = ["wasm"]

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.17.1", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.17.2", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["abi", "unstable"]
 # Provide near_bidgen macros.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.17.1" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.17.2" }
 near-sys = { path = "../near-sys", version = "0.2.5" }
 base64 = "0.22"
 borsh = { version = "1.0.0", features = ["derive"] }


### PR DESCRIPTION



## 🤖 New release

* `near-sdk-macros`: 5.17.1 -> 5.17.2
* `near-sdk`: 5.17.1 -> 5.17.2 (✓ API compatible changes)
* `near-contract-standards`: 5.17.1 -> 5.17.2

<details><summary><i><b>Changelog</b></i></summary><p>


## `near-sdk`

<blockquote>

## [5.17.2](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.17.1...near-sdk-v5.17.2) - 2025-08-30

### Other

- Auto-document features on docs.rs + improved wording for the top-level documentation ([#1386](https://github.com/near/near-sdk-rs/pull/1386))
</blockquote>

## `near-contract-standards`

<blockquote>

## [5.14.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.13.0...near-contract-standards-v5.14.0) - 2025-05-14

### Other

- updates near-* dependencies to 0.30 release ([#1356](https://github.com/near/near-sdk-rs/pull/1356))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).