### PR TITLE
chore: release v5.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.18.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.17.2...near-sdk-v5.18.0) - 2025-11-27
+
+### Added
+
+- relax owned String requirements ([#1404](https://github.com/near/near-sdk-rs/pull/1404))
+- Add Event::to_event_log() utility function ([#1394](https://github.com/near/near-sdk-rs/pull/1394))
+- be explicit about detached `Promise`s ([#1400](https://github.com/near/near-sdk-rs/pull/1400))
+- *(near-sdk-macros)* `#[near(contract_state(key = b"CUSTOM"))]` ([#1399](https://github.com/near/near-sdk-rs/pull/1399))
+- optimize `Promise::and` ([#1396](https://github.com/near/near-sdk-rs/pull/1396))
+- use #[serde_as] for #[near(serializers = [json])] ([#1393](https://github.com/near/near-sdk-rs/pull/1393))
+- Introduce new method `::ext_on(promise)` for all Ext Contract Traits for using high-level APIs for batching actions into a single promise receipt ([#1413](https://github.com/near/near-sdk-rs/pull/1413))
+
+### Fixed
+
+- Pass mutable buffers to sys out-params in balance and stake getters ([#1412](https://github.com/near/near-sdk-rs/pull/1412))
+- Fixed the `TreeMap::range()` method to respect lower Bound::Unbounded ([#1408](https://github.com/near/near-sdk-rs/pull/1408))
+- *(serde)* avoid String allocation in error mapping for integers and hash ([#1411](https://github.com/near/near-sdk-rs/pull/1411))
+- Fix serde_as and ordering of the fields in AsNep297Event ([#1405](https://github.com/near/near-sdk-rs/pull/1405))
+- Added support for #[private] attribute for #[init] methods ([#1410](https://github.com/near/near-sdk-rs/pull/1410))
+- allow PanicOnDefault on eums ([#1401](https://github.com/near/near-sdk-rs/pull/1401))
+
+### Other
+
+- Use CryptoHash wherever applicable and other small papercut fixes ([#1387](https://github.com/near/near-sdk-rs/pull/1387))
+- fix example header format for readme.md ([#1407](https://github.com/near/near-sdk-rs/pull/1407))
+
 ## [5.17.2](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.17.1...near-sdk-v5.17.2) - 2025-08-30
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["near-sdk", "near-sdk-macros", "near-contract-standards", "near-sys"]
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.17.2"
+version = "5.18.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 categories = ["wasm"]

--- a/near-contract-standards/CHANGELOG.md
+++ b/near-contract-standards/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.18.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.17.2...near-contract-standards-v5.18.0) - 2025-11-27
+
+### Added
+
+- be explicit about detached `Promise`s ([#1400](https://github.com/near/near-sdk-rs/pull/1400))
+
+### Fixed
+
+- *(near-contract-standards)* do not distribute remaining gas for ft/nft_resolve_transfer() calback ([#1391](https://github.com/near/near-sdk-rs/pull/1391))
+
 ## [5.14.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.13.0...near-contract-standards-v5.14.0) - 2025-05-14
 
 ### Other

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.17.2", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.18.0", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -22,7 +22,7 @@ required-features = ["abi", "unstable"]
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_with = { version = "3", features = ["base64", "hex", "json"] }
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.17.2" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.18.0" }
 near-sys = { path = "../near-sys", version = "0.2.5" }
 base64 = "0.22"
 borsh = { version = "1.0.0", features = ["derive"] }


### PR DESCRIPTION



## 🤖 New release

* `near-sdk-macros`: 5.17.2 -> 5.18.0
* `near-sdk`: 5.17.2 -> 5.18.0 (✓ API compatible changes)
* `near-contract-standards`: 5.17.2 -> 5.18.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `near-sdk`

<blockquote>

## [5.18.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.17.2...near-sdk-v5.18.0) - 2025-11-27

### Added

- relax owned String requirements ([#1404](https://github.com/near/near-sdk-rs/pull/1404))
- Add Event::to_event_log() utility function ([#1394](https://github.com/near/near-sdk-rs/pull/1394))
- be explicit about detached `Promise`s ([#1400](https://github.com/near/near-sdk-rs/pull/1400))
- *(near-sdk-macros)* `#[near(contract_state(key = b"CUSTOM"))]` ([#1399](https://github.com/near/near-sdk-rs/pull/1399))
- optimize `Promise::and` ([#1396](https://github.com/near/near-sdk-rs/pull/1396))
- use #[serde_as] for #[near(serializers = [json])] ([#1393](https://github.com/near/near-sdk-rs/pull/1393))
- Introduce new method `::ext_on(promise)` for all Ext Contract Traits for using high-level APIs for batching actions into a single promise receipt ([#1413](https://github.com/near/near-sdk-rs/pull/1413))

### Fixed

- Pass mutable buffers to sys out-params in balance and stake getters ([#1412](https://github.com/near/near-sdk-rs/pull/1412))
- Fixed the `TreeMap::range()` method to respect lower Bound::Unbounded ([#1408](https://github.com/near/near-sdk-rs/pull/1408))
- *(serde)* avoid String allocation in error mapping for integers and hash ([#1411](https://github.com/near/near-sdk-rs/pull/1411))
- Fix serde_as and ordering of the fields in AsNep297Event ([#1405](https://github.com/near/near-sdk-rs/pull/1405))
- Added support for #[private] attribute for #[init] methods ([#1410](https://github.com/near/near-sdk-rs/pull/1410))
- allow PanicOnDefault on eums ([#1401](https://github.com/near/near-sdk-rs/pull/1401))

### Other

- Use CryptoHash wherever applicable and other small papercut fixes ([#1387](https://github.com/near/near-sdk-rs/pull/1387))
- fix example header format for readme.md ([#1407](https://github.com/near/near-sdk-rs/pull/1407))
</blockquote>

## `near-contract-standards`

<blockquote>

## [5.18.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.17.2...near-contract-standards-v5.18.0) - 2025-11-27

### Added

- be explicit about detached `Promise`s ([#1400](https://github.com/near/near-sdk-rs/pull/1400))

### Fixed

- *(near-contract-standards)* do not distribute remaining gas for ft/nft_resolve_transfer() calback ([#1391](https://github.com/near/near-sdk-rs/pull/1391))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).