### PR TITLE
fix(env): pass mutable buffers to sys out-params in balance and stake getters

### DIFF
--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -323,8 +323,8 @@ pub fn storage_usage() -> StorageUsage {
 /// assert_eq!(account_balance(), NearToken::from_near(100));
 /// ```
 pub fn account_balance() -> NearToken {
-    let data = [0u8; size_of::<NearToken>()];
-    unsafe { sys::account_balance(data.as_ptr() as u64) };
+    let mut data = [0u8; size_of::<NearToken>()];
+    unsafe { sys::account_balance(data.as_mut_ptr() as u64) };
     NearToken::from_yoctonear(u128::from_le_bytes(data))
 }
 
@@ -338,8 +338,8 @@ pub fn account_balance() -> NearToken {
 /// assert_eq!(account_locked_balance(), NearToken::from_yoctonear(0));
 /// ```
 pub fn account_locked_balance() -> NearToken {
-    let data = [0u8; size_of::<NearToken>()];
-    unsafe { sys::account_locked_balance(data.as_ptr() as u64) };
+    let mut data = [0u8; size_of::<NearToken>()];
+    unsafe { sys::account_locked_balance(data.as_mut_ptr() as u64) };
     NearToken::from_yoctonear(u128::from_le_bytes(data))
 }
 
@@ -354,8 +354,8 @@ pub fn account_locked_balance() -> NearToken {
 /// assert_eq!(attached_deposit(), NearToken::from_yoctonear(0));
 /// ```
 pub fn attached_deposit() -> NearToken {
-    let data = [0u8; size_of::<NearToken>()];
-    unsafe { sys::attached_deposit(data.as_ptr() as u64) };
+    let mut data = [0u8; size_of::<NearToken>()];
+    unsafe { sys::attached_deposit(data.as_mut_ptr() as u64) };
     NearToken::from_yoctonear(u128::from_le_bytes(data))
 }
 
@@ -1869,9 +1869,13 @@ pub fn promise_yield_resume(data_id: &CryptoHash, data: impl AsRef<[u8]>) -> boo
 /// ```
 pub fn validator_stake(account_id: &AccountId) -> NearToken {
     let account_id: &str = account_id.as_ref();
-    let data = [0u8; size_of::<NearToken>()];
+    let mut data = [0u8; size_of::<NearToken>()];
     unsafe {
-        sys::validator_stake(account_id.len() as _, account_id.as_ptr() as _, data.as_ptr() as u64)
+        sys::validator_stake(
+            account_id.len() as _,
+            account_id.as_ptr() as _,
+            data.as_mut_ptr() as u64,
+        )
     };
     NearToken::from_yoctonear(u128::from_le_bytes(data))
 }
@@ -1889,8 +1893,8 @@ pub fn validator_stake(account_id: &AccountId) -> NearToken {
 /// );
 /// ```
 pub fn validator_total_stake() -> NearToken {
-    let data = [0u8; size_of::<NearToken>()];
-    unsafe { sys::validator_total_stake(data.as_ptr() as u64) };
+    let mut data = [0u8; size_of::<NearToken>()];
+    unsafe { sys::validator_total_stake(data.as_mut_ptr() as u64) };
     NearToken::from_yoctonear(u128::from_le_bytes(data))
 }
 


### PR DESCRIPTION
Made the output buffers passed to FFI out-parameters explicitly mutable and uses as_mut_ptr() in account_balance(), 
account_locked_balance(), attached_deposit(), validator_stake(), and validator_total_stake() in near-sdk/src/environment/env.rs. The corresponding near_sys functions write into the provided memory (see signatures in near-sys/src/lib.rs), so passing an immutable array pointer via as_ptr() miscommunicated intent and risks violating Rust’s mutability expectations for FFI out-params. Using a mutable buffer and as_mut_ptr() adheres to Rust FFI best practices, clarifies write semantics, and aligns with the unsafe contract that the host function initializes the buffer before it is read.