### PR TITLE
feat(near-sdk-macros): ext_on(promise)

### DIFF
--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_basic.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_basic.snap
@@ -1,12 +1,15 @@
 ---
 source: near-sdk-macros/src/core_impl/code_generator/item_trait_info.rs
+assertion_line: 56
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 pub mod external_cross_contract {
     use super::*;
     #[must_use]
     pub struct ExternalCrossContractExt {
-        pub(crate) account_id: ::near_sdk::AccountId,
+        pub(crate) promise_or_create_on: ::near_sdk::PromiseOrValue<
+            ::near_sdk::AccountId,
+        >,
         pub(crate) deposit: ::near_sdk::NearToken,
         pub(crate) static_gas: ::near_sdk::Gas,
         pub(crate) gas_weight: ::near_sdk::GasWeight,
@@ -28,7 +31,15 @@ pub mod external_cross_contract {
     /// API for calling this contract's functions in a subsequent execution.
     pub fn ext(account_id: ::near_sdk::AccountId) -> ExternalCrossContractExt {
         ExternalCrossContractExt {
-            account_id,
+            promise_or_create_on: ::near_sdk::PromiseOrValue::Value(account_id),
+            deposit: ::near_sdk::NearToken::from_near(0),
+            static_gas: ::near_sdk::Gas::from_gas(0),
+            gas_weight: ::near_sdk::GasWeight::default(),
+        }
+    }
+    pub fn ext_on(promise: ::near_sdk::Promise) -> ExternalCrossContractExt {
+        ExternalCrossContractExt {
+            promise_or_create_on: ::near_sdk::PromiseOrValue::Promise(promise),
             deposit: ::near_sdk::NearToken::from_near(0),
             static_gas: ::near_sdk::Gas::from_gas(0),
             gas_weight: ::near_sdk::GasWeight::default(),
@@ -52,7 +63,12 @@ pub mod external_cross_contract {
                     }
                 }
             };
-            ::near_sdk::Promise::new(self.account_id)
+            match self.promise_or_create_on {
+                ::near_sdk::PromiseOrValue::Promise(p) => p,
+                ::near_sdk::PromiseOrValue::Value(account_id) => {
+                    ::near_sdk::Promise::new(account_id)
+                }
+            }
                 .function_call_weight(
                     ::std::string::String::from("merge_sort"),
                     __args,
@@ -63,7 +79,12 @@ pub mod external_cross_contract {
         }
         pub fn merge(self) -> ::near_sdk::Promise {
             let __args = ::std::vec![];
-            ::near_sdk::Promise::new(self.account_id)
+            match self.promise_or_create_on {
+                ::near_sdk::PromiseOrValue::Promise(p) => p,
+                ::near_sdk::PromiseOrValue::Value(account_id) => {
+                    ::near_sdk::Promise::new(account_id)
+                }
+            }
                 .function_call_weight(
                     ::std::string::String::from("merge"),
                     __args,

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_basic_borsh.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_basic_borsh.snap
@@ -1,5 +1,6 @@
 ---
 source: near-sdk-macros/src/core_impl/code_generator/ext.rs
+assertion_line: 221
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 pub fn borsh_test(self, a: String) -> ::near_sdk::Promise {
@@ -19,7 +20,12 @@ pub fn borsh_test(self, a: String) -> ::near_sdk::Promise {
             }
         }
     };
-    ::near_sdk::Promise::new(self.account_id)
+    match self.promise_or_create_on {
+        ::near_sdk::PromiseOrValue::Promise(p) => p,
+        ::near_sdk::PromiseOrValue::Value(account_id) => {
+            ::near_sdk::Promise::new(account_id)
+        }
+    }
         .function_call_weight(
             ::std::string::String::from("borsh_test"),
             __args,

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_basic_json.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_basic_json.snap
@@ -1,5 +1,6 @@
 ---
 source: near-sdk-macros/src/core_impl/code_generator/ext.rs
+assertion_line: 209
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 pub fn method(self, k: &String) -> ::near_sdk::Promise {
@@ -19,7 +20,12 @@ pub fn method(self, k: &String) -> ::near_sdk::Promise {
             }
         }
     };
-    ::near_sdk::Promise::new(self.account_id)
+    match self.promise_or_create_on {
+        ::near_sdk::PromiseOrValue::Promise(p) => p,
+        ::near_sdk::PromiseOrValue::Value(account_id) => {
+            ::near_sdk::Promise::new(account_id)
+        }
+    }
         .function_call_weight(
             ::std::string::String::from("method"),
             __args,

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_fn_non_bindgen_attrs.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_fn_non_bindgen_attrs.snap
@@ -1,11 +1,17 @@
 ---
 source: near-sdk-macros/src/core_impl/code_generator/ext.rs
+assertion_line: 197
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 #[cfg(target_os = "linux")]
 pub fn method(self) -> ::near_sdk::Promise {
     let __args = ::std::vec![];
-    ::near_sdk::Promise::new(self.account_id)
+    match self.promise_or_create_on {
+        ::near_sdk::PromiseOrValue::Promise(p) => p,
+        ::near_sdk::PromiseOrValue::Value(account_id) => {
+            ::near_sdk::Promise::new(account_id)
+        }
+    }
         .function_call_weight(
             ::std::string::String::from("method"),
             __args,
@@ -14,4 +20,3 @@ pub fn method(self) -> ::near_sdk::Promise {
             self.gas_weight,
         )
 }
-

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_gen.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_gen.snap
@@ -1,10 +1,11 @@
 ---
 source: near-sdk-macros/src/core_impl/code_generator/ext.rs
+assertion_line: 172
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 #[must_use]
 pub struct TestExt {
-    pub(crate) account_id: ::near_sdk::AccountId,
+    pub(crate) promise_or_create_on: ::near_sdk::PromiseOrValue<::near_sdk::AccountId>,
     pub(crate) deposit: ::near_sdk::NearToken,
     pub(crate) static_gas: ::near_sdk::Gas,
     pub(crate) gas_weight: ::near_sdk::GasWeight,
@@ -27,11 +28,18 @@ impl Test {
     /// API for calling this contract's functions in a subsequent execution.
     pub fn ext(account_id: ::near_sdk::AccountId) -> TestExt {
         TestExt {
-            account_id,
+            promise_or_create_on: ::near_sdk::PromiseOrValue::Value(account_id),
+            deposit: ::near_sdk::NearToken::from_near(0),
+            static_gas: ::near_sdk::Gas::from_gas(0),
+            gas_weight: ::near_sdk::GasWeight::default(),
+        }
+    }
+    pub fn ext_on(promise: ::near_sdk::Promise) -> TestExt {
+        TestExt {
+            promise_or_create_on: ::near_sdk::PromiseOrValue::Promise(promise),
             deposit: ::near_sdk::NearToken::from_near(0),
             static_gas: ::near_sdk::Gas::from_gas(0),
             gas_weight: ::near_sdk::GasWeight::default(),
         }
     }
 }
-

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/module_ext_gen.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/module_ext_gen.snap
@@ -1,10 +1,11 @@
 ---
 source: near-sdk-macros/src/core_impl/code_generator/ext.rs
+assertion_line: 180
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 #[must_use]
 pub struct TestExt {
-    pub(crate) account_id: ::near_sdk::AccountId,
+    pub(crate) promise_or_create_on: ::near_sdk::PromiseOrValue<::near_sdk::AccountId>,
     pub(crate) deposit: ::near_sdk::NearToken,
     pub(crate) static_gas: ::near_sdk::Gas,
     pub(crate) gas_weight: ::near_sdk::GasWeight,
@@ -26,10 +27,17 @@ impl TestExt {
 /// API for calling this contract's functions in a subsequent execution.
 pub fn ext(account_id: ::near_sdk::AccountId) -> TestExt {
     TestExt {
-        account_id,
+        promise_or_create_on: ::near_sdk::PromiseOrValue::Value(account_id),
         deposit: ::near_sdk::NearToken::from_near(0),
         static_gas: ::near_sdk::Gas::from_gas(0),
         gas_weight: ::near_sdk::GasWeight::default(),
     }
 }
-
+pub fn ext_on(promise: ::near_sdk::Promise) -> TestExt {
+    TestExt {
+        promise_or_create_on: ::near_sdk::PromiseOrValue::Promise(promise),
+        deposit: ::near_sdk::NearToken::from_near(0),
+        static_gas: ::near_sdk::Gas::from_gas(0),
+        gas_weight: ::near_sdk::GasWeight::default(),
+    }
+}

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/serialize_with_borsh.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/serialize_with_borsh.snap
@@ -1,12 +1,15 @@
 ---
 source: near-sdk-macros/src/core_impl/code_generator/item_trait_info.rs
+assertion_line: 72
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 pub mod test {
     use super::*;
     #[must_use]
     pub struct TestExt {
-        pub(crate) account_id: ::near_sdk::AccountId,
+        pub(crate) promise_or_create_on: ::near_sdk::PromiseOrValue<
+            ::near_sdk::AccountId,
+        >,
         pub(crate) deposit: ::near_sdk::NearToken,
         pub(crate) static_gas: ::near_sdk::Gas,
         pub(crate) gas_weight: ::near_sdk::GasWeight,
@@ -28,7 +31,15 @@ pub mod test {
     /// API for calling this contract's functions in a subsequent execution.
     pub fn ext(account_id: ::near_sdk::AccountId) -> TestExt {
         TestExt {
-            account_id,
+            promise_or_create_on: ::near_sdk::PromiseOrValue::Value(account_id),
+            deposit: ::near_sdk::NearToken::from_near(0),
+            static_gas: ::near_sdk::Gas::from_gas(0),
+            gas_weight: ::near_sdk::GasWeight::default(),
+        }
+    }
+    pub fn ext_on(promise: ::near_sdk::Promise) -> TestExt {
+        TestExt {
+            promise_or_create_on: ::near_sdk::PromiseOrValue::Promise(promise),
             deposit: ::near_sdk::NearToken::from_near(0),
             static_gas: ::near_sdk::Gas::from_gas(0),
             gas_weight: ::near_sdk::GasWeight::default(),
@@ -52,7 +63,12 @@ pub mod test {
                     }
                 }
             };
-            ::near_sdk::Promise::new(self.account_id)
+            match self.promise_or_create_on {
+                ::near_sdk::PromiseOrValue::Promise(p) => p,
+                ::near_sdk::PromiseOrValue::Value(account_id) => {
+                    ::near_sdk::Promise::new(account_id)
+                }
+            }
                 .function_call_weight(
                     ::std::string::String::from("test"),
                     __args,


### PR DESCRIPTION
Currently, if you need to call multiple methods in a single Promise on the same contract, the only option is to write them manually:
```rust
ext_storage_management::ext(wnear_id)
    .with_attached_deposit(amount)
    .storage_deposit(receiver_id.clone(), None)
    .function_call_weight(
        "ft_transfer",
        serde_json::to_vec(&json!({
            "receiver_id": receiver_id,
            "amount": amount,
        })).unwrap(),
        NearToken::from_yoctonear(1),
        Gas::from_tgas(15),
        GasWeight(1),
    )
```

This PR lets to create `#[ext_contract]` on existing promises via `ext_on()` method:
```rust
let p = ext_storage_management::ext(wnear_id)
    .with_attached_deposit(amount)
    .storage_deposit(receiver_id.clone(), None);

ext_ft_core::ext_on(p)
    .with_attached_deposit(amount)
    .ft_transfer(receiver_id, amount, None)
```