### PR TITLE
chore: release v5.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.18.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.18.0...near-sdk-v5.18.1) - 2025-11-28
+
+### Fixed
+
+- Fixed docs.rs compilation error ([#1415](https://github.com/near/near-sdk-rs/pull/1415))
+
 ## [5.18.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.17.2...near-sdk-v5.18.0) - 2025-11-27
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["near-sdk", "near-sdk-macros", "near-contract-standards", "near-sys"]
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.18.0"
+version = "5.18.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 categories = ["wasm"]

--- a/near-contract-standards/CHANGELOG.md
+++ b/near-contract-standards/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.18.1](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.18.0...near-contract-standards-v5.18.1) - 2025-11-28
+
+### Fixed
+
+- Fixed docs.rs compilation error ([#1415](https://github.com/near/near-sdk-rs/pull/1415))
+
 ## [5.18.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.17.2...near-contract-standards-v5.18.0) - 2025-11-27
 
 ### Added

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.18.0", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.18.1", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -22,7 +22,7 @@ required-features = ["abi", "unstable"]
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_with = { version = "3", features = ["base64", "hex", "json"] }
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.18.0" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.18.1" }
 near-sys = { path = "../near-sys", version = "0.2.5" }
 base64 = "0.22"
 borsh = { version = "1.0.0", features = ["derive"] }


### PR DESCRIPTION



## 🤖 New release

* `near-sdk-macros`: 5.18.0 -> 5.18.1
* `near-sdk`: 5.18.0 -> 5.18.1 (✓ API compatible changes)
* `near-contract-standards`: 5.18.0 -> 5.18.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `near-sdk`

<blockquote>

## [5.18.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.18.0...near-sdk-v5.18.1) - 2025-11-28

### Fixed

- Fixed docs.rs compilation error ([#1415](https://github.com/near/near-sdk-rs/pull/1415))
</blockquote>

## `near-contract-standards`

<blockquote>

## [5.18.1](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.18.0...near-contract-standards-v5.18.1) - 2025-11-28

### Fixed

- Fixed docs.rs compilation error ([#1415](https://github.com/near/near-sdk-rs/pull/1415))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).