### PR TITLE
docs: Clarified how keys are constructed for persistent NEAR SDK collections

### DIFF
--- a/near-sdk/src/collections/lookup_map.rs
+++ b/near-sdk/src/collections/lookup_map.rs
@@ -55,8 +55,8 @@ impl<K, V> LookupMap<K, V> {
 
     /// Inserts a serialized key-value pair into the map.
     /// If the map did not have this key present, `None` is returned. Otherwise returns
-    /// a serialized value. Note, the keys that have the same hash value are undistinguished by
-    /// the implementation.
+    /// a serialized value. Note: keys are addressed by their Borsh-serialized bytes (with the map's
+    /// prefix). Two keys that serialize to identical bytes will be indistinguishable.
     pub fn insert_raw(&mut self, key_raw: &[u8], value_raw: &[u8]) -> Option<Vec<u8>> {
         let storage_key = self.raw_key_to_storage_key(key_raw);
         if env::storage_write(&storage_key, value_raw) {
@@ -159,8 +159,8 @@ where
 
     /// Inserts a key-value pair into the map.
     /// If the map did not have this key present, `None` is returned. Otherwise returns
-    /// a value. Note, the keys that have the same hash value are undistinguished by
-    /// the implementation.
+    /// a value. Note: keys are addressed by their Borsh-serialized bytes (with the map's
+    /// prefix). Two keys that serialize to identical bytes will be indistinguishable.
     ///
     /// # Examples
     ///

--- a/near-sdk/src/collections/lookup_set.rs
+++ b/near-sdk/src/collections/lookup_set.rs
@@ -13,8 +13,8 @@ const ERR_ELEMENT_SERIALIZATION: &str = "Cannot serialize element with Borsh";
 
 /// A non-iterable implementation of a set that stores its content directly on the storage trie.
 ///
-/// This set stores the values under a hash of the set's `prefix` and [`BorshSerialize`] of the
-/// value.
+/// This set stores values under a concatenation of the set's `prefix` and the value's
+/// [`BorshSerialize`] bytes. No hashing is performed.
 #[near(inside_nearsdk)]
 pub struct LookupSet<T> {
     element_prefix: Vec<u8>,

--- a/near-sdk/src/collections/tree_map.rs
+++ b/near-sdk/src/collections/tree_map.rs
@@ -166,8 +166,9 @@ where
 
     /// Inserts a key-value pair into the tree.
     /// If the tree did not have this key present, `None` is returned. Otherwise returns
-    /// a value. Note, the keys that have the same hash value are undistinguished by
-    /// the implementation.
+    /// a value. Note: the underlying storage addresses keys by their Borsh-serialized bytes
+    /// (with internal prefixes). Two keys that serialize to identical bytes will be
+    /// indistinguishable.
     ///
     /// # Examples
     ///

--- a/near-sdk/src/collections/unordered_map/mod.rs
+++ b/near-sdk/src/collections/unordered_map/mod.rs
@@ -124,8 +124,8 @@ impl<K, V> UnorderedMap<K, V> {
 
     /// Inserts a serialized key-value pair into the map.
     /// If the map did not have this key present, `None` is returned. Otherwise returns
-    /// a serialized value. Note, the keys that have the same hash value are undistinguished by
-    /// the implementation.
+    /// a serialized value. Note: keys are addressed by their Borsh-serialized bytes (combined with
+    /// this map's prefixes). Two keys that serialize to identical bytes will be indistinguishable.
     pub fn insert_raw(&mut self, key_raw: &[u8], value_raw: &[u8]) -> Option<Vec<u8>> {
         let index_lookup = self.raw_key_to_index_lookup(key_raw);
         match env::storage_read(&index_lookup) {
@@ -244,8 +244,8 @@ where
 
     /// Inserts a key-value pair into the map.
     /// If the map did not have this key present, `None` is returned. Otherwise returns
-    /// a value. Note, the keys that have the same hash value are undistinguished by
-    /// the implementation.
+    /// a value. Note: keys are addressed by their Borsh-serialized bytes (combined with this map's
+    /// prefixes). Two keys that serialize to identical bytes will be indistinguishable.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
These collections do not hash keys; they address storage entries by concatenating a user-provided prefix with the Borsh-serialized bytes of the key or element using append_slice, as seen in lookup_map.rs::raw_key_to_storage_key, 
unordered_map/mod.rs::raw_key_to_index_lookup, and lookup_set.rs::raw_element_to_storage_key. The prior documentation inherited legacy “same hash value are undistinguished” language which does not reflect the implementation and could confuse users about collision semantics. The updated docs precisely describe that indistinguishability only arises if two distinct logical keys serialize to identical Borsh byte sequences, which aligns with actual behavior and with UnorderedSet’s stated non-hashing approach, ensuring consistency and accuracy across LookupMap, UnorderedMap, TreeMap, and LookupSet.