### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.19.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.18.1...near-sdk-v5.19.0) - 2025-12-01
+
+### Added
+
+- Added support for refund_to and current_contract_code, updated deps to match nearcore 2.10 release ([#1423](https://github.com/near/near-sdk-rs/pull/1423))
+
+### Other
+
+- Clarified how keys are constructed for persistent NEAR SDK collections ([#1417](https://github.com/near/near-sdk-rs/pull/1417))
+
 ## [5.18.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.18.0...near-sdk-v5.18.1) - 2025-11-28
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["near-sdk", "near-sdk-macros", "near-contract-standards", "near-sys"]
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.18.1"
+version = "5.19.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 categories = ["wasm"]

--- a/near-contract-standards/CHANGELOG.md
+++ b/near-contract-standards/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.19.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.18.1...near-contract-standards-v5.19.0) - 2025-12-01
+
+### Other
+
+- avoid String allocation in approvals lookup ([#1422](https://github.com/near/near-sdk-rs/pull/1422))
+
 ## [5.18.1](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.18.0...near-contract-standards-v5.18.1) - 2025-11-28
 
 ### Fixed

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.18.1", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.19.0", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -22,8 +22,8 @@ required-features = ["abi", "unstable"]
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_with = { version = "3", features = ["base64", "hex", "json"] }
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.18.1" }
-near-sys = { path = "../near-sys", version = "0.2.5" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.19.0" }
+near-sys = { path = "../near-sys", version = "0.2.6" }
 base64 = "0.22"
 borsh = { version = "1.0.0", features = ["derive"] }
 bs58 = "0.5"

--- a/near-sys/CHANGELOG.md
+++ b/near-sys/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.5...near-sys-v0.2.6) - 2025-12-01
+
+### Added
+
+- Added support for refund_to and current_contract_code, updated deps to match nearcore 2.10 release ([#1423](https://github.com/near/near-sdk-rs/pull/1423))
+
 ## [0.2.4](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.3...near-sys-v0.2.4) - 2025-05-14
 
 ### Other

--- a/near-sys/Cargo.toml
+++ b/near-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sys"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Near Inc <hello@near.org>"]
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `near-sdk-macros`: 5.18.1 -> 5.19.0
* `near-sys`: 0.2.5 -> 0.2.6 (✓ API compatible changes)
* `near-sdk`: 5.18.1 -> 5.19.0 (✓ API compatible changes)
* `near-contract-standards`: 5.18.1 -> 5.19.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `near-sys`

<blockquote>


## [0.2.6](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.5...near-sys-v0.2.6) - 2025-12-01

### Added

- Added support for refund_to and current_contract_code, updated deps to match nearcore 2.10 release ([#1423](https://github.com/near/near-sdk-rs/pull/1423))
</blockquote>

## `near-sdk`

<blockquote>

## [5.19.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.18.1...near-sdk-v5.19.0) - 2025-12-01

### Added

- Added support for refund_to and current_contract_code, updated deps to match nearcore 2.10 release ([#1423](https://github.com/near/near-sdk-rs/pull/1423))

### Other

- Clarified how keys are constructed for persistent NEAR SDK collections ([#1417](https://github.com/near/near-sdk-rs/pull/1417))
</blockquote>

## `near-contract-standards`

<blockquote>

## [5.19.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.18.1...near-contract-standards-v5.19.0) - 2025-12-01

### Other

- avoid String allocation in approvals lookup ([#1422](https://github.com/near/near-sdk-rs/pull/1422))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).