### PR TITLE
refactor(unordered_map): relax iterator bounds to BorshDeserialize

### DIFF
--- a/near-sdk/src/collections/unordered_map/iter.rs
+++ b/near-sdk/src/collections/unordered_map/iter.rs
@@ -1,18 +1,18 @@
 use super::UnorderedMap;
 use crate::collections::vector;
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::BorshDeserialize;
 use std::iter::FusedIterator;
 
 impl<'a, K, V> IntoIterator for &'a UnorderedMap<K, V>
 where
-    K: BorshSerialize + BorshDeserialize,
-    V: BorshSerialize + BorshDeserialize,
+    K: BorshDeserialize,
+    V: BorshDeserialize,
 {
     type Item = (K, V);
     type IntoIter = Iter<'a, K, V>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.iter()
+        Iter::new(self)
     }
 }
 
@@ -24,8 +24,8 @@ pub struct Iter<'a, K, V> {
 
 impl<'a, K, V> Iter<'a, K, V>
 where
-    K: BorshSerialize + BorshDeserialize,
-    V: BorshSerialize + BorshDeserialize,
+    K: BorshDeserialize,
+    V: BorshDeserialize,
 {
     pub(super) fn new(map: &'a UnorderedMap<K, V>) -> Self {
         Self { keys: map.keys.iter(), values: map.values.iter() }
@@ -34,8 +34,8 @@ where
 
 impl<'a, K, V> Iterator for Iter<'a, K, V>
 where
-    K: BorshSerialize + BorshDeserialize,
-    V: BorshSerialize + BorshDeserialize,
+    K: BorshDeserialize,
+    V: BorshDeserialize,
 {
     type Item = (K, V);
 
@@ -58,21 +58,21 @@ where
 
 impl<'a, K, V> ExactSizeIterator for Iter<'a, K, V>
 where
-    K: BorshSerialize + BorshDeserialize,
-    V: BorshSerialize + BorshDeserialize,
+    K: BorshDeserialize,
+    V: BorshDeserialize,
 {
 }
 impl<'a, K, V> FusedIterator for Iter<'a, K, V>
 where
-    K: BorshSerialize + BorshDeserialize,
-    V: BorshSerialize + BorshDeserialize,
+    K: BorshDeserialize,
+    V: BorshDeserialize,
 {
 }
 
 impl<'a, K, V> DoubleEndedIterator for Iter<'a, K, V>
 where
-    K: BorshSerialize + BorshDeserialize,
-    V: BorshSerialize + BorshDeserialize,
+    K: BorshDeserialize,
+    V: BorshDeserialize,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         <Self as DoubleEndedIterator>::nth_back(self, 0)


### PR DESCRIPTION
I made this change in order to remove unnecessary trait constraints on iterators, because it allows iteration when keys/values only implement deserialization and reduces compile-time coupling without impacting behavior or performance.