### PR TITLE
fix: include authorized_id in transfer events for approved transfers

### DIFF
--- a/near-contract-standards/src/non_fungible_token/core/core_impl.rs
+++ b/near-contract-standards/src/non_fungible_token/core/core_impl.rs
@@ -259,7 +259,7 @@ impl NonFungibleToken {
             old_owner_id: owner_id,
             new_owner_id: receiver_id,
             token_ids: &[token_id],
-            authorized_id: sender_id.filter(|sender_id| *sender_id == owner_id).map(|f| f.deref()),
+            authorized_id: sender_id.map(|f| f.deref()),
             memo: memo.as_deref(),
         }
         .emit();
@@ -475,5 +475,24 @@ impl NonFungibleTokenResolver for NonFungibleToken {
         }
         NonFungibleToken::emit_transfer(&receiver_id, &previous_owner_id, &token_id, None, None);
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn emits_authorized_id_for_approved_transfer() {
+        let owner_id: AccountId = "owner.near".parse().unwrap();
+        let receiver_id: AccountId = "receiver.near".parse().unwrap();
+        let approved: AccountId = "thirdparty.near".parse().unwrap();
+
+        NonFungibleToken::emit_transfer(&owner_id, &receiver_id, "1", Some(&approved), None);
+
+        assert_eq!(
+            near_sdk::test_utils::get_logs()[0],
+            r#"EVENT_JSON:{"standard":"nep171","version":"1.0.0","event":"nft_transfer","data":[{"old_owner_id":"owner.near","new_owner_id":"receiver.near","token_ids":["1"],"authorized_id":"thirdparty.near"}]}"#
+        );
     }
 }


### PR DESCRIPTION
The authorized_id field in nft_transfer events was always omitted due to an incorrect filter in emit_transfer(). According to NEP-171, authorized_id must be present when the transfer is executed by an approved account. This change passes through the approved account directly and adds a unit test to assert the log includes authorized_id for approved transfers, improving spec compliance and restoring compatibility for indexers relying on this field.