### PR TITLE
fix(macros): remove duplicate default-impl check in ItemTraitInfo::new

### DIFF
--- a/near-sdk-macros/src/core_impl/info_extractor/item_trait_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/item_trait_info.rs
@@ -34,15 +34,6 @@ impl ItemTraitInfo {
                         Ok(method_info) => methods.push(method_info),
                         Err(e) => errors.push(e),
                     };
-
-                    if method.default.is_some() {
-                        errors.push(Error::new(
-                            method.span(),
-                            "Traits that are used to describe external contract should not include
-                             default implementations because this is not a valid use case of traits
-                             to describe external contracts.",
-                        ));
-                    }
                 }
                 _ => {}
             }


### PR DESCRIPTION
Previously both TraitItemMethodInfo::new() and ItemTraitInfo::new() reported an error when a trait method had a default implementation, producing two similar diagnostics for the same issue. This change removes the redundant check from 
ItemTraitInfo::new() and relies on TraitItemMethodInfo::new() to validate trait methods. The result is a single, consistent error without changing overall behavior.