### PR TITLE
perf: avoid String allocation in approvals lookup

### DIFF
--- a/near-contract-standards/src/non_fungible_token/enumeration/enumeration_impl.rs
+++ b/near-contract-standards/src/non_fungible_token/enumeration/enumeration_impl.rs
@@ -14,7 +14,7 @@ impl NonFungibleToken {
         let approved_account_ids = self
             .approvals_by_id
             .as_ref()
-            .map(|approvals_by_id| approvals_by_id.get(&token_id.to_string()).unwrap_or_default());
+            .map(|approvals_by_id| approvals_by_id.get(&token_id).unwrap_or_default());
 
         Token { token_id, owner_id, metadata, approved_account_ids }
     }


### PR DESCRIPTION
Replace get(&token_id.to_string()) with get(&token_id) in enum_get_token(). TokenId is already a String, and LookupMap::get
 accepts a borrowed key. This removes an unnecessary allocation on the hot path while keeping behavior identical.