### PR TITLE
feat: re-export `near-account-id`

### DIFF
--- a/near-sdk/src/types/mod.rs
+++ b/near-sdk/src/types/mod.rs
@@ -12,7 +12,7 @@ mod contract_code;
 #[cfg(feature = "global-contracts")]
 pub use contract_code::*;
 
-pub use near_account_id::{AccountId, AccountIdRef};
+pub use near_account_id::{self as account_id, AccountId, AccountIdRef};
 /// A wrapper struct for `u64` that represents gas. And provides helpful methods to convert to and from tera-gas and giga-gas.
 pub use near_gas::NearGas as Gas;
 /// A wrapper struct for `u128` that represents tokens. And provides helpful methods to convert with a proper precision.


### PR DESCRIPTION
This PR re-exports `near-account-id` as `account_id` in `near_sdk` to allow dependent crates to use types directly from there instead of adding one more dependency for `near-account-id` and pinning a version for it:
```rust
use near_sdk::account_id::{AccountType, ParseAccountError};

match account_id.get_account_type() {
    AccountType::NamedAccount => /* ... */,
    // ...
}
```