### PR TITLE
docs: fix reference to UnorderedSet

### DIFF
--- a/near-sdk/src/collections/lookup_set.rs
+++ b/near-sdk/src/collections/lookup_set.rs
@@ -1,4 +1,4 @@
-//! A persistent set without iterators. Unlike `near_sdk::collections::LookupSet` this set
+//! A persistent set without iterators. Unlike `near_sdk::collections::UnorderedSet` this set
 //! doesn't store values separately in a vector, so it can't iterate over the values. But it
 //! makes this implementation more efficient in the number of reads and writes.
 use std::marker::PhantomData;


### PR DESCRIPTION
The module docs incorrectly compared LookupSet to itself, which obscures the intended contrast. This aligns the wording with lookup_map.rs where the non-iterable type is contrasted with its iterable counterpart, and clarifies that UnorderedSet stores elements in a vector enabling iteration.