### PR TITLE
fix(upgrade): correct deploy_code time gate and unlock timestamp message

### DIFF
--- a/near-contract-standards/src/upgrade/mod.rs
+++ b/near-contract-standards/src/upgrade/mod.rs
@@ -65,13 +65,10 @@ impl Upgradable for Upgrade {
     }
 
     fn deploy_code(&mut self) -> Promise {
-        if self.staging_timestamp < env::block_timestamp() {
+        if env::block_timestamp() < self.staging_timestamp {
             env::panic_str(
-                format!(
-                    "Deploy code too early: staging ends on {}",
-                    self.staging_timestamp + self.staging_duration
-                )
-                .as_str(),
+                format!("Deploy code too early: staging ends on {}", self.staging_timestamp)
+                    .as_str(),
             );
         }
         let code = env::storage_read(b"upgrade")


### PR DESCRIPTION
The staging logic treats the timestamp passed to stage_code() as the unlock time, validated to be at least staging_duration in the future. deploy_code() incorrectly panicked when the current time was already past the unlock time and also reported the end time as unlock + duration.
This change inverts the check to panic only while it’s still too early (now < unlock) and updates the error message to show the correct unlock time. This aligns the deploy guard with the staging validation and the intended semantics discussed in NEP upgradability design.