### PR TITLE
test: add tests for #[init] + #[private] macro combination

### DIFF
--- a/examples/test-contract/src/lib.rs
+++ b/examples/test-contract/src/lib.rs
@@ -1,19 +1,25 @@
 use near_sdk::{env, near};
 
+#[derive(Default)]
 #[near(contract_state)]
-pub struct TestContract {}
-
-impl Default for TestContract {
-    fn default() -> Self {
-        Self {}
-    }
+pub struct TestContract {
+    value: u32,
 }
 
 #[near]
 impl TestContract {
     #[init]
     pub fn new() -> Self {
-        Self {}
+        Self { value: 0 }
+    }
+
+    /// A private init method that can only be called by the contract itself.
+    /// This is useful for factory patterns where a deployed contract should
+    /// only be initialized by itself via a scheduled function call.
+    #[init]
+    #[private]
+    pub fn new_private(value: u32) -> Self {
+        Self { value }
     }
 
     #[init(ignore_state)]
@@ -25,7 +31,11 @@ impl TestContract {
 
         let _old_contract: OldContract = env::state_read().expect("Old state doesn't exist");
 
-        Self {}
+        Self { value: 0 }
+    }
+
+    pub fn get_value(&self) -> u32 {
+        self.value
     }
 
     pub fn test_panic_macro(&mut self) {
@@ -57,11 +67,60 @@ mod tests {
 
         let res = contract.view("__contract_abi").await?;
 
-        let abi_root =
-            serde_json::from_slice::<AbiRoot>(&zstd::decode_all(&res.result[..])?)?;
+        let abi_root = serde_json::from_slice::<AbiRoot>(&zstd::decode_all(&res.result[..])?)?;
 
         assert_eq!(abi_root.schema_version, "0.4.0");
         assert_eq!(abi_root.metadata.name, Some("test-contract".to_string()));
+
+        Ok(())
+    }
+
+    /// Tests that a private init method cannot be called by an external account.
+    /// The method should fail with "Method new_private is private".
+    #[tokio::test]
+    async fn private_init_cannot_be_called_by_external_account() -> anyhow::Result<()> {
+        let wasm = near_workspaces::compile_project("./").await?;
+        let worker = near_workspaces::sandbox().await?;
+        let contract = worker.dev_deploy(&wasm).await?;
+
+        // Create an external account (alice)
+        let alice = worker.dev_create_account().await?;
+
+        // External account tries to call the private init method - should fail
+        let res = alice
+            .call(contract.id(), "new_private")
+            .args_json((42u32,))
+            .max_gas()
+            .transact()
+            .await?;
+
+        assert!(res.is_failure());
+        let failure_message = format!("{:?}", res.into_result().unwrap_err());
+        assert!(
+            failure_message.contains("Method new_private is private"),
+            "Expected 'Method new_private is private' error, got: {}",
+            failure_message
+        );
+
+        Ok(())
+    }
+
+    /// Tests that a private init method can be called by the contract itself.
+    /// This simulates the contract calling its own init method (e.g., via a callback).
+    #[tokio::test]
+    async fn private_init_can_be_called_by_current_account() -> anyhow::Result<()> {
+        let wasm = near_workspaces::compile_project("./").await?;
+        let worker = near_workspaces::sandbox().await?;
+        let contract = worker.dev_deploy(&wasm).await?;
+
+        // Contract calls its own private init method - should succeed
+        let res = contract.call("new_private").args_json((42u32,)).max_gas().transact().await?;
+
+        assert!(res.is_success(), "Private init should succeed when called by self: {:?}", res);
+
+        // Verify the state was set correctly
+        let value: u32 = contract.view("get_value").await?.json()?;
+        assert_eq!(value, 42);
 
         Ok(())
     }

--- a/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
@@ -367,4 +367,31 @@ mod tests {
         let actual = method_info.method_wrapper();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
+
+    #[test]
+    fn private_init_generates_same_code_as_init_private() {
+        let impl_type: Type = syn::parse_str("Hello").unwrap();
+
+        // #[init] #[private] order
+        let mut method1: ImplItemFn = parse_quote! {
+            #[init]
+            #[private]
+            pub fn new() -> Self { }
+        };
+        let method_info1 =
+            ImplItemMethodInfo::new(&mut method1, None, impl_type.clone()).unwrap().unwrap();
+        let code1 = pretty_print_syn_str(&method_info1.method_wrapper()).unwrap();
+
+        // #[private] #[init] order (reversed)
+        let mut method2: ImplItemFn = parse_quote! {
+            #[private]
+            #[init]
+            pub fn new() -> Self { }
+        };
+        let method_info2 =
+            ImplItemMethodInfo::new(&mut method2, None, impl_type).unwrap().unwrap();
+        let code2 = pretty_print_syn_str(&method_info2.method_wrapper()).unwrap();
+
+        assert_eq!(code1, code2, "Attribute order should not affect generated code");
+    }
 }


### PR DESCRIPTION
Closes #1414

- Add snapshot test verifying attribute order doesn't affect generated code
- Add E2E tests for private init method access control