### PR TITLE
chore: release v5.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.21.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.20.1...near-sdk-v5.21.0) - 2025-12-09
+
+### Added
+
+- Cache host funcs to save gas on repetitive calls (calling host is more expensive than caching inside Wasm) ([#1431](https://github.com/near/near-sdk-rs/pull/1431))
+
+### Other
+
+- Corrected VMContext.input doc comment to describe raw bytes ([#1435](https://github.com/near/near-sdk-rs/pull/1435))
+- correct LookupSet docs to refer to set elements ([#1433](https://github.com/near/near-sdk-rs/pull/1433))
+- Avoid cloning self_occurrences vectors in AttrSigInfo::new ([#1436](https://github.com/near/near-sdk-rs/pull/1436))
+- Added tests for #[init] + #[private] macro combination ([#1432](https://github.com/near/near-sdk-rs/pull/1432))
+
 ## [5.20.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.20.0...near-sdk-v5.20.1) - 2025-12-05
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["near-sdk", "near-sdk-macros", "near-contract-standards", "near-sys"]
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.20.1"
+version = "5.21.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 categories = ["wasm"]

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -13,7 +13,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.20.1", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.21.0", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -22,7 +22,7 @@ required-features = ["abi", "unstable"]
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_with = { version = "3", features = ["base64", "hex", "json"] }
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.20.1" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.21.0" }
 near-sys = { path = "../near-sys", version = "0.2.6" }
 base64 = "0.22"
 borsh = { version = "1.0.0", features = ["derive"] }


### PR DESCRIPTION



## 🤖 New release

* `near-sdk-macros`: 5.20.1 -> 5.21.0
* `near-sdk`: 5.20.1 -> 5.21.0 (✓ API compatible changes)
* `near-contract-standards`: 5.20.1 -> 5.21.0

<details><summary><i><b>Changelog</b></i></summary><p>


## `near-sdk`

<blockquote>

## [5.21.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.20.1...near-sdk-v5.21.0) - 2025-12-09

### Added

- Cache host funcs to save gas on repetitive calls (calling host is more expensive than caching inside Wasm) ([#1431](https://github.com/near/near-sdk-rs/pull/1431))

### Other

- Corrected VMContext.input doc comment to describe raw bytes ([#1435](https://github.com/near/near-sdk-rs/pull/1435))
- correct LookupSet docs to refer to set elements ([#1433](https://github.com/near/near-sdk-rs/pull/1433))
- Avoid cloning self_occurrences vectors in AttrSigInfo::new ([#1436](https://github.com/near/near-sdk-rs/pull/1436))
- Added tests for #[init] + #[private] macro combination ([#1432](https://github.com/near/near-sdk-rs/pull/1432))
</blockquote>

## `near-contract-standards`

<blockquote>

## [5.20.1](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.20.0...near-contract-standards-v5.20.1) - 2025-12-05

### Fixed

- Corrected deploy_code time gate in upgradability standard implementation ([#1429](https://github.com/near/near-sdk-rs/pull/1429))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).