### PR TITLE
fix(test-utils): correct VMContext.input comment to describe raw bytes

### DIFF
--- a/near-sdk/src/test_utils/context.rs
+++ b/near-sdk/src/test_utils/context.rs
@@ -48,7 +48,7 @@ pub struct VMContext {
     /// via host function `promise_set_refund_to`.
     pub refund_to_account_id: AccountId,
     /// The input to the contract call.
-    /// Encoded as base64 string to be able to pass input in borsh binary format.
+    /// Raw input bytes for the contract call (e.g. JSON or Borsh-serialized).
     pub input: Rc<[u8]>,
     /// The current block height.
     pub block_index: BlockHeight,


### PR DESCRIPTION
The previous comment claimed the input is a base64 string. In our runtime and mocks the input is stored and consumed as raw bytes (JSON or Borsh-serialized). Base64 is only an external JSON-RPC transport detail and does not apply to VMContext. This change updates the comment to prevent confusion.