### PR TITLE
perf: avoid cloning self_occurrences vectors in AttrSigInfo::new

### DIFF
--- a/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
@@ -165,8 +165,7 @@ impl AttrSigInfo {
         }
 
         let (method_kind, returns) = visitor.build()?;
-
-        self_occurrences.extend(args.iter().flat_map(|arg| arg.self_occurrences.clone()));
+        self_occurrences.extend(args.iter().flat_map(|arg| arg.self_occurrences.iter().copied()));
 
         original_attrs.clone_from(&non_bindgen_attrs);
 


### PR DESCRIPTION
This change removes unnecessary allocations when aggregating Self spans in AttrSigInfo::new. Previously, the code cloned each ArgInfo::self_occurrences vector and then flattened them into the common self_occurrences collection, which created a temporary Vec per argument. Now we iterate over the existing spans and copy each Span directly into the target vector. This preserves semantics and keeps ArgInfo::self_occurrences intact, while reducing heap allocations and improving the efficiency of span reporting.