### PR TITLE
feat: `arbitrary` feature

### DIFF
--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -32,9 +32,11 @@ hex = { version = "0.4", optional = true }
 # Used for caching, might be worth porting only functionality needed.
 once_cell = { version = "1.17", default-features = false }
 
-near-account-id = { version = "2.0.0", features = ["serde", "borsh"] }
+near-account-id = { version = "2.3.0", features = ["serde", "borsh"] }
 near-gas = { version = "0.3", features = ["serde", "borsh"] }
 near-token = { version = "0.3", features = ["serde", "borsh"] }
+
+arbitrary = { version = "1.4", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wee_alloc = { version = "0.4.5", default-features = false, optional = true }
@@ -75,6 +77,8 @@ insta = "1.39.0"
 
 [features]
 default = ["wee_alloc"]
+
+arbitrary = ["dep:arbitrary", "near-account-id/arbitrary"]
 expensive-debug = []
 deterministic-account-ids = [
     "global-contracts",

--- a/near-sdk/src/state_init.rs
+++ b/near-sdk/src/state_init.rs
@@ -6,6 +6,7 @@ use serde_with::{base64::Base64, serde_as};
 
 use crate::{env, GlobalContractId};
 
+#[cfg_attr(feature = "arbitrary", derive(::arbitrary::Arbitrary))]
 #[near(inside_nearsdk, serializers = [
     json,
     borsh(use_discriminant = true),
@@ -28,6 +29,7 @@ impl StateInit {
     }
 }
 
+#[cfg_attr(feature = "arbitrary", derive(::arbitrary::Arbitrary))]
 #[near(inside_nearsdk, serializers = [json, borsh])]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StateInitV1 {

--- a/near-sdk/src/types/contract_code.rs
+++ b/near-sdk/src/types/contract_code.rs
@@ -3,6 +3,7 @@ use near_sdk_macros::near;
 
 use crate::CryptoHash;
 
+#[cfg_attr(feature = "arbitrary", derive(::arbitrary::Arbitrary))]
 #[derive(Debug, Clone, PartialEq, PartialOrd, Ord, Eq)]
 pub enum AccountContract {
     None,
@@ -11,6 +12,7 @@ pub enum AccountContract {
     GlobalByAccount(AccountId),
 }
 
+#[cfg_attr(feature = "arbitrary", derive(::arbitrary::Arbitrary))]
 #[near(inside_nearsdk, serializers = [
     json,
     borsh(use_discriminant = true),


### PR DESCRIPTION
This PR adds `arbitrary` feature that enables derivation of `arbitrary::Arbitrary` trait on some types and transitively enables `near-account-id/arbitrary`