### PR TITLE
fix: correct NEP330 build info output path error message

### DIFF
--- a/near-sdk-macros/src/core_impl/contract_metadata/build_info.rs
+++ b/near-sdk-macros/src/core_impl/contract_metadata/build_info.rs
@@ -30,7 +30,7 @@ const ERR_UNSET_OR_EMPTY_SOURCE_SNAPSHOT: &str = "`NEP330_BUILD_INFO_SOURCE_CODE
                                                     required, when `NEP330_BUILD_INFO_BUILD_ENVIRONMENT` \
                                                     is set, but it's either not set or empty!";
 
-const ERR_INVALID_UNICODE_OUTPUT_WASM_PATH: &str = "`NEP331_BUILD_INFO_OUTPUT_WASM_PATH` was \
+const ERR_INVALID_UNICODE_OUTPUT_WASM_PATH: &str = "`NEP330_BUILD_INFO_OUTPUT_WASM_PATH` was \
                                                     provided, but it contained invalid UTF8!";
 
 impl BuildInfo {


### PR DESCRIPTION
The error message for invalid UTF-8 in the NEP330 build info output wasm path was referring to NEP331_BUILD_INFO_OUTPUT_WASM_PATH while the actual environment variable key is NEP330_BUILD_INFO_OUTPUT_WASM_PATH. This patch updates the string constant to use the correct key name so that runtime errors and logs accurately reflect the real configuration knob.