### PR TITLE
fix(store): clarify LookupSet persistence behavior

### DIFF
--- a/near-sdk/src/store/lookup_set/mod.rs
+++ b/near-sdk/src/store/lookup_set/mod.rs
@@ -255,7 +255,7 @@ mod tests {
     fn test_flush_on_drop() {
         let mut set = LookupSet::<_, Keccak256>::with_hasher(b"m");
 
-        // Set a value, which does not write to storage yet
+        // Set a value and ensure it remains readable after this instance is dropped
         set.insert(5u8);
         assert!(set.contains(&5u8));
 
@@ -284,7 +284,7 @@ mod tests {
         assert!(!set.contains(&8));
         set.insert(8);
 
-        // Drop the set which should flush all data
+        // Drop the set to end this instance's lifetime
         drop(set);
 
         let dup_set = LookupSet::<u8, _>::new(b"m");
@@ -334,7 +334,7 @@ mod tests {
         // Initialized value which state is `Deleted`
         assert!(!set.remove(&8));
 
-        // Drop the set which should flush all data
+        // Drop the set to end this instance's lifetime
         set.insert(8u8);
         drop(set);
 

--- a/near-sdk/src/store/mod.rs
+++ b/near-sdk/src/store/mod.rs
@@ -13,9 +13,11 @@
 //! mentioned above shows that running the contains method on a native [`std::collections::HashSet<i32>`] **consumes 41% more gas**
 //! compared to a near [`crate::store::IterableSet<i32>`].
 //!
-//! ## FAQ: collections of this [`module`](self) only persist on `Drop` and `flush`
-//! Unlike containers in [`near_sdk::collections`](crate::collections) module, most containers in current [`module`](self) will cache all changes
+//! ## FAQ: most collections of this [`module`](self) persist on `Drop` and `flush`
+//! Unlike containers in [`near_sdk::collections`](crate::collections) module, most containers in current [`module`](self) cache all changes
 //! and loads and only update values that are changed in storage after it’s dropped through it’s [`Drop`] implementation.
+//! Note that [`LookupSet`](crate::store::LookupSet) is an exception and writes directly to storage on each operation
+//! without using an in-memory cache or a `flush`-based persistence mechanism.
 //!
 //! These changes can be updated in storage before the container variable is dropped by using
 //! the container's `flush` method, e.g. [`IterableMap::flush`](crate::store::IterableMap::flush) ([`IterableMap::drop`](crate::store::IterableMap::drop) uses it in implementation too).


### PR DESCRIPTION
store::LookupSet was implemented as a non‑caching collection that writes directly to storage on each operation, but the store module level FAQ and a few test comments still implied Drop/flush-based persistence and cache-like states. This mismatch could confuse users who rely on the docs to reason about gas costs and storage semantics.

This change updates the store module documentation to state that most, but not all, collections persist changes on Drop/flush and explicitly calls out LookupSet as an exception that writes directly to storage. It also cleans up misleading comments in 
LookupSet tests so they no longer suggest deferred writes or cache-backed state transitions, while leaving the test logic and behavior unchanged.