### PR TITLE
fix: clarify deployer account comment in global factory example

### DIFF
--- a/examples/factory-contract-global/src/lib.rs
+++ b/examples/factory-contract-global/src/lib.rs
@@ -28,7 +28,7 @@ impl GlobalFactoryContract {
         Promise::new(env::current_account_id()).deploy_global_contract(code)
     }
 
-    /// Deploy a global contract, identifiable by the predecessor's account ID
+    /// Deploy a global contract, identifiable by the provided deployer account ID
     #[payable]
     pub fn deploy_global_contract_by_account_id(
         &mut self,


### PR DESCRIPTION
The comment above deploy_global_contract_by_account_id claimed the global contract is identified by the predecessor account, which is not how the API works. In practice the example uses the explicitly provided account_id as the deployer/owner, matching the Global Contracts “reference by account” model in NEAR docs.