### PR TITLE
fix: **breaking change** for the recently introduced GlobalContractId JSON serialization - now it expects a tagged enum

### DIFF
--- a/near-sdk/src/store/mod.rs
+++ b/near-sdk/src/store/mod.rs
@@ -16,7 +16,7 @@
 //! ## FAQ: most collections of this [`module`](self) persist on `Drop` and `flush`
 //! Unlike containers in [`near_sdk::collections`](crate::collections) module, most containers in current [`module`](self) cache all changes
 //! and loads and only update values that are changed in storage after it’s dropped through it’s [`Drop`] implementation.
-//! Note that [`LookupSet`](crate::store::LookupSet) is an exception and writes directly to storage on each operation
+//! Note that [`LookupSet`] is an exception and writes directly to storage on each operation
 //! without using an in-memory cache or a `flush`-based persistence mechanism.
 //!
 //! These changes can be updated in storage before the container variable is dropped by using

--- a/near-sdk/src/types/contract_code.rs
+++ b/near-sdk/src/types/contract_code.rs
@@ -20,13 +20,13 @@ pub enum AccountContract {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(u8)]
 pub enum GlobalContractId {
-    #[serde(rename="hash")]
+    #[serde(rename = "hash")]
     CodeHash(
         #[serde_as(as = "::serde_with::base64::Base64")]
         #[cfg_attr(feature = "abi", schemars(with = "String"))]
         CryptoHash,
     ) = 0,
-    #[serde(rename="account_id")]
+    #[serde(rename = "account_id")]
     AccountId(AccountId) = 1,
 }
 
@@ -81,7 +81,10 @@ mod tests {
 
     #[test]
     fn test_global_contract_id_json_serialization_code_hash() {
-        let hash: CryptoHash = "4reLvkAWfqk5fsqio1KLudk46cqRz9erQdaHkWZKMJDZ".parse::<Base58CryptoHash>().unwrap().into();
+        let hash: CryptoHash = "4reLvkAWfqk5fsqio1KLudk46cqRz9erQdaHkWZKMJDZ"
+            .parse::<Base58CryptoHash>()
+            .unwrap()
+            .into();
         let id = GlobalContractId::CodeHash(hash);
 
         let json = serde_json::to_string(&id).unwrap();


### PR DESCRIPTION
Align the serialization with https://github.com/near/nearcore/pull/14828, more context is here:  https://near.zulipchat.com/#narrow/channel/295558-core/topic/DeterministicStateInit.20serialization.20ambiguity/near/564737214

Even though technically it is a breaking change, we decided to not bump the major version for near-sdk-rs, as that will cause more disruption. This change is unlikely to cause any breaking changes in the real contracts implemented so far. We informed NEAR Intents team about this change, as they are likely the only team using it.