### PR TITLE
fix: avoid panic in nft_is_approved for missing tokens

### DIFF
--- a/near-contract-standards/src/non_fungible_token/approval/approval_impl.rs
+++ b/near-contract-standards/src/non_fungible_token/approval/approval_impl.rs
@@ -121,8 +121,6 @@ impl NonFungibleTokenApproval for NonFungibleToken {
         approved_account_id: AccountId,
         approval_id: Option<u64>,
     ) -> bool {
-        expect_token_found(self.owner_by_id.get(&token_id));
-
         let approvals_by_id = if let Some(a) = self.approvals_by_id.as_ref() {
             a
         } else {


### PR DESCRIPTION
The nft_is_approved view method was reading owner_by_id and panicking with "Token not found" when the token did not exist. This behavior is stricter than the NEP-approval standard, which models nft_is_approved as a boolean check and expects false when there is no matching approval. Removing the owner_by_id lookup avoids an unnecessary storage read and makes the method consistently return false for non-existent tokens or tokens without approvals, aligning it with the rest of the NFT view API and the approval management spec.