### PR TITLE
fix: keep iterable Drain in sync with backing maps

### DIFF
--- a/near-sdk/src/store/iterable_map/iter.rs
+++ b/near-sdk/src/store/iterable_map/iter.rs
@@ -498,6 +498,19 @@ where
     }
 }
 
+impl<'a, K, V, H> Drop for Drain<'a, K, V, H>
+where
+    K: BorshSerialize + BorshDeserialize + Ord,
+    V: BorshSerialize,
+    H: ToKey,
+{
+    fn drop(&mut self) {
+        for key in &mut self.keys {
+            self.values.set(key, None);
+        }
+    }
+}
+
 impl<'a, K, V, H> ExactSizeIterator for Drain<'a, K, V, H>
 where
     K: BorshSerialize + Ord + BorshDeserialize + Clone,

--- a/near-sdk/src/store/iterable_map/mod.rs
+++ b/near-sdk/src/store/iterable_map/mod.rs
@@ -736,6 +736,32 @@ mod tests {
         assert_eq!(map.keys().collect::<Vec<_>>(), [&0, &3, &2]);
     }
 
+    #[test]
+    fn drain_count_clears_all_values() {
+        let mut map = IterableMap::new(b"b");
+
+        map.insert(1u8, 10u8);
+        map.insert(2, 20);
+        map.insert(3, 30);
+
+        let count = map.drain().count();
+        assert_eq!(count, 3);
+
+        assert!(map.is_empty());
+        assert_eq!(map.len(), 0);
+
+        assert_eq!(map.get(&1), None);
+        assert_eq!(map.get(&2), None);
+        assert_eq!(map.get(&3), None);
+        assert!(!map.contains_key(&1));
+        assert!(!map.contains_key(&2));
+        assert!(!map.contains_key(&3));
+
+        assert_eq!(map.remove(&1), None);
+        assert_eq!(map.remove(&2), None);
+        assert_eq!(map.remove(&3), None);
+    }
+
     #[derive(Arbitrary, Debug)]
     enum Op {
         Insert(u8, u8),

--- a/near-sdk/src/store/iterable_set/iter.rs
+++ b/near-sdk/src/store/iterable_set/iter.rs
@@ -339,6 +339,18 @@ where
     }
 }
 
+impl<'a, T, H> Drop for Drain<'a, T, H>
+where
+    T: BorshSerialize + BorshDeserialize + Ord,
+    H: ToKey,
+{
+    fn drop(&mut self) {
+        for element in &mut self.elements {
+            self.index.set(element, None);
+        }
+    }
+}
+
 impl<'a, T, H> ExactSizeIterator for Drain<'a, T, H>
 where
     T: BorshSerialize + Ord + BorshDeserialize + Clone,

--- a/near-sdk/src/store/unordered_map/iter.rs
+++ b/near-sdk/src/store/unordered_map/iter.rs
@@ -499,6 +499,19 @@ where
     }
 }
 
+impl<'a, K, V, H> Drop for Drain<'a, K, V, H>
+where
+    K: BorshSerialize + BorshDeserialize + Ord,
+    V: BorshSerialize,
+    H: ToKey,
+{
+    fn drop(&mut self) {
+        for key in &mut self.keys {
+            self.values.set(key, None);
+        }
+    }
+}
+
 impl<'a, K, V, H> ExactSizeIterator for Drain<'a, K, V, H>
 where
     K: BorshSerialize + Ord + BorshDeserialize + Clone,

--- a/near-sdk/src/store/unordered_set/iter.rs
+++ b/near-sdk/src/store/unordered_set/iter.rs
@@ -339,6 +339,18 @@ where
     }
 }
 
+impl<'a, T, H> Drop for Drain<'a, T, H>
+where
+    T: BorshSerialize + BorshDeserialize + Ord,
+    H: ToKey,
+{
+    fn drop(&mut self) {
+        for element in &mut self.elements {
+            self.index.set(element, None);
+        }
+    }
+}
+
 impl<'a, T, H> ExactSizeIterator for Drain<'a, T, H>
 where
     T: BorshSerialize + Ord + BorshDeserialize + Clone,


### PR DESCRIPTION
When drain() on IterableMap, IterableSet, UnorderedMap or UnorderedSet was not fully consumed, or when drain().count() was called, the collection could end up in an inconsistent state. The keys/elements containers were cleared, but the underlying LookupMap/index still held entries, so len() reported zero while contains_key/get still saw values and subsequent remove could panic due to stale indices.

This change adds Drop implementations for the Drain iterators of these collections. On drop we now clear remaining keys/elements from the corresponding LookupMap/index without deserializing values, so the state is always consistent with the documented guarantee that drain clears all values even if the iterator is only partially consumed.