### PR TITLE
fix: align FreeList Debug representation

### DIFF
--- a/near-sdk/src/store/free_list/mod.rs
+++ b/near-sdk/src/store/free_list/mod.rs
@@ -58,8 +58,8 @@ where
     T: BorshSerialize + BorshDeserialize + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Bucket")
-            .field("next_vacant", &self.first_free)
+        f.debug_struct("FreeList")
+            .field("first_free", &self.first_free)
             .field("occupied_count", &self.occupied_count)
             .field("elements", &self.elements)
             .finish()


### PR DESCRIPTION
Update FreeList Debug implementation to use the actual type and field names (FreeList, first_free) instead of the generic Bucket/next_vacant labels. This makes logs and debug output less confusing when inspecting FreeList state.