### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.24.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.24.0...near-sdk-v5.24.1) - 2026-02-05
+
+### Other
+
+- fix invalid secp256k1 public key in documentation example ([#1469](https://github.com/near/near-sdk-rs/pull/1469))
+- clarify TreeMap iterator order ([#1461](https://github.com/near/near-sdk-rs/pull/1461))
+- enabling msrv in workspace crates via Cargo.toml ([#1467](https://github.com/near/near-sdk-rs/pull/1467))
+- update MSRV to 1.86 ([#1465](https://github.com/near/near-sdk-rs/pull/1465))
+
 ## [5.24.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.23.0...near-sdk-v5.24.0) - 2025-12-26
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["near-sdk", "near-sdk-macros", "near-contract-standards", "near-sys"]
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.24.0"
+version = "5.24.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 categories = ["wasm"]

--- a/near-contract-standards/CHANGELOG.md
+++ b/near-contract-standards/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.24.1](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.24.0...near-contract-standards-v5.24.1) - 2026-02-05
+
+### Other
+
+- *(contract-standards)* added msrv ([#1472](https://github.com/near/near-sdk-rs/pull/1472))
+
 ## [5.24.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.23.0...near-contract-standards-v5.24.0) - 2025-12-26
 
 ### Added

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -14,7 +14,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.24.0", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.24.1", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -23,8 +23,8 @@ required-features = ["abi", "unstable"]
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_with = { version = "3", features = ["base64", "hex", "json"] }
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.24.0" }
-near-sys = { path = "../near-sys", version = "0.2.6" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.24.1" }
+near-sys = { path = "../near-sys", version = "0.2.7" }
 base64 = "0.22"
 borsh = { version = "1.0.0", features = ["derive"] }
 bs58 = "0.5"

--- a/near-sys/CHANGELOG.md
+++ b/near-sys/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.7](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.6...near-sys-v0.2.7) - 2026-02-05
+
+### Other
+
+- enabling msrv in workspace crates via Cargo.toml ([#1467](https://github.com/near/near-sdk-rs/pull/1467))
+
 ## [0.2.6](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.5...near-sys-v0.2.6) - 2025-12-01
 
 ### Added

--- a/near-sys/Cargo.toml
+++ b/near-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sys"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Near Inc <hello@near.org>"]
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `near-sdk-macros`: 5.24.0 -> 5.24.1
* `near-sys`: 0.2.6 -> 0.2.7 (✓ API compatible changes)
* `near-sdk`: 5.24.0 -> 5.24.1 (✓ API compatible changes)
* `near-contract-standards`: 5.24.0 -> 5.24.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `near-sys`

<blockquote>


## [0.2.7](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.6...near-sys-v0.2.7) - 2026-02-05

### Other

- enabling msrv in workspace crates via Cargo.toml ([#1467](https://github.com/near/near-sdk-rs/pull/1467))
</blockquote>

## `near-sdk`

<blockquote>

## [5.24.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.24.0...near-sdk-v5.24.1) - 2026-02-05

### Other

- fix invalid secp256k1 public key in documentation example ([#1469](https://github.com/near/near-sdk-rs/pull/1469))
- clarify TreeMap iterator order ([#1461](https://github.com/near/near-sdk-rs/pull/1461))
- enabling msrv in workspace crates via Cargo.toml ([#1467](https://github.com/near/near-sdk-rs/pull/1467))
- update MSRV to 1.86 ([#1465](https://github.com/near/near-sdk-rs/pull/1465))
</blockquote>

## `near-contract-standards`

<blockquote>

## [5.24.1](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.24.0...near-contract-standards-v5.24.1) - 2026-02-05

### Other

- *(contract-standards)* added msrv ([#1472](https://github.com/near/near-sdk-rs/pull/1472))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).