### PR TITLE
fix(ci): prevent corrupted GITHUB_ENV in compare_sizes workflow

### DIFF
--- a/.github/workflows/compare_sizes.yml
+++ b/.github/workflows/compare_sizes.yml
@@ -33,7 +33,12 @@ jobs:
             # Capture error output for the failure notification
             {
               echo 'ERROR_OUTPUT<<EOF'
-              tail -50 /tmp/report_err.txt
+              if [ -s /tmp/report_err.txt ]; then
+                tail -n 50 /tmp/report_err.txt
+              else
+                echo 'No stderr captured, showing last 50 lines of stdout instead:'
+                tail -n 50 /tmp/report.txt
+              fi
               echo 'EOF'
             } >> "$GITHUB_ENV"
             exit 1


### PR DESCRIPTION
The previous implementation streamed compare_sizes.py output directly to GITHUB_ENV. If the script failed mid-execution, the multiline environment variable delimiter would be left unclosed, causing GitHub Actions to fail with "Matching delimiter not found" error.

Changes:
- Capture script output to temp file before writing to GITHUB_ENV
- Use static EOF delimiter instead of random base64 string
- Add error output capture for better failure diagnostics
- Include error details in PR comment when build fails

https://claude.ai/code/session_011XKTvzJragCpLZTiWJrQsf