### PR TITLE
fix(ci): pin release-plz/action to last working SHA

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -24,10 +24,6 @@ jobs:
         uses: dtolnay/rust-toolchain@1.86
         with:
           targets: wasm32-unknown-unknown
-      - name: Install Rust toolchain stable for release-plz
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
 
       # Pinned to last version using taiki-e/install-action for binary installation.
       # Newer versions use cargo-binstall which compiles from source and fails with


### PR DESCRIPTION
## Summary

Pin `release-plz/action` to commit `5ab144c9d67d4346240190d0f95ed08668677928` (last version using `taiki-e/install-action` for prebuilt binaries).

## Problem

The `release-plz` CI has been failing since Jan 28 due to an upstream change:

| Date | Event |
|------|-------|
| Jan 23 | ✅ Last successful run - used `taiki-e/install-action` (prebuilt binary) |
| Jan 24 | `release-plz/action` [PR #239](https://github.com/release-plz/action/pull/239) switched to `cargo-binstall --strategies=crate-meta-data,compile` |
| Jan 28 | ❌ First failure - binstall compiles from source, hits MSRV conflicts |
| Feb 5 | ❌ PR #1485 added stable toolchain, but now hits `gix-sec` wasm32 compile error |

The `--strategies=crate-meta-data,compile` **excludes the `github-release` strategy**, so binstall can't download prebuilt binaries. When `crate-meta-data` fails (release-plz doesn't publish binstall metadata), it falls back to `cargo install --target wasm32-unknown-unknown`, which fails because `gix-sec` uses Unix APIs (`std::os::unix`) unavailable on wasm32.

### Why not pre-install release-plz?

The action uses `cargo binstall --force`, which reinstalls even if the binary exists.

## Solution

Pin to the last working SHA that uses `taiki-e/install-action` instead of `cargo-binstall`.