### PR TITLE
chore: release

### DIFF
--- a/near-sys/CHANGELOG.md
+++ b/near-sys/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.7](https://github.com/near/near-sdk-rs/releases/tag/near-sys-v0.2.7) - 2026-02-05
+
+### Other
+
+- release ([#1466](https://github.com/near/near-sdk-rs/pull/1466))
+- enabling msrv in workspace crates via Cargo.toml ([#1467](https://github.com/near/near-sdk-rs/pull/1467))
+
 ## [0.2.7](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.6...near-sys-v0.2.7) - 2026-02-05
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `near-sdk-macros`: 5.24.1
* `near-sys`: 0.2.7
* `near-sdk`: 5.24.1
* `near-contract-standards`: 5.24.1

<details><summary><i><b>Changelog</b></i></summary><p>


## `near-sys`

<blockquote>


## [0.2.7](https://github.com/near/near-sdk-rs/releases/tag/near-sys-v0.2.7) - 2026-02-05

### Other

- release ([#1466](https://github.com/near/near-sdk-rs/pull/1466))
- enabling msrv in workspace crates via Cargo.toml ([#1467](https://github.com/near/near-sdk-rs/pull/1467))
</blockquote>

## `near-sdk`

<blockquote>

## [5.24.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.24.0...near-sdk-v5.24.1) - 2026-02-05

### Other

- fix invalid secp256k1 public key in documentation example ([#1469](https://github.com/near/near-sdk-rs/pull/1469))
- clarify TreeMap iterator order ([#1461](https://github.com/near/near-sdk-rs/pull/1461))
- enabling msrv in workspace crates via Cargo.toml ([#1467](https://github.com/near/near-sdk-rs/pull/1467))
- update MSRV to 1.86 ([#1465](https://github.com/near/near-sdk-rs/pull/1465))
</blockquote>

## `near-contract-standards`

<blockquote>

## [5.24.1](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.24.0...near-contract-standards-v5.24.1) - 2026-02-05

### Other

- *(contract-standards)* added msrv ([#1472](https://github.com/near/near-sdk-rs/pull/1472))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).