### PR TITLE
fix: `IterableSet` and `UnorderedSet` `Drain` trait

### DIFF
--- a/near-sdk/src/store/iterable_set/iter.rs
+++ b/near-sdk/src/store/iterable_set/iter.rs
@@ -359,6 +359,8 @@ where
     H: ToKey,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.elements.next_back()
+        let key = self.elements.next_back()?;
+        self.index.remove(&key);
+        Some(key)
     }
 }

--- a/near-sdk/src/store/unordered_set/iter.rs
+++ b/near-sdk/src/store/unordered_set/iter.rs
@@ -359,6 +359,8 @@ where
     H: ToKey,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.elements.next_back()
+        let key = self.elements.next_back()?;
+        self.index.remove(&key);
+        Some(key)
     }
 }

--- a/near-sdk/src/store/unordered_set/mod.rs
+++ b/near-sdk/src/store/unordered_set/mod.rs
@@ -974,4 +974,56 @@ mod tests {
 
         insta::assert_snapshot!(format!("{:#?}", defs));
     }
+
+    #[test]
+    fn test_drain_next_back_removes_from_index() {
+        let mut set = UnorderedSet::new(b"t");
+
+        // Insert elements
+        for i in 0..5 {
+            set.insert(i);
+        }
+
+        // Drain from the back using next_back()
+        let mut drain = set.drain();
+        let elem = drain.next_back().unwrap();
+        drop(drain);
+
+        // If the bug exists: contains() will return true (stale index entry)
+        // If bug is fixed: contains() will return false
+        assert!(
+            !set.contains(&elem),
+            "Element {} was drained but contains() returns true (stale index)",
+            elem
+        );
+
+        // If the bug exists: insert should fail silently or panic
+        // If bug is fixed: insert should succeed
+        assert!(
+            set.insert(elem),
+            "Cannot re-insert element {} after draining it (stale index)",
+            elem
+        );
+    }
+
+    #[test]
+    fn test_drain_bidirectional() {
+        let mut set = UnorderedSet::new(b"t");
+        for i in 0..5 {
+            set.insert(i);
+        }
+
+        let mut drain = set.drain();
+        let first = drain.next().unwrap();
+        let last = drain.next_back().unwrap();
+        drop(drain);
+
+        // Both should be gone
+        assert!(!set.contains(&first), "Element {} from next() still in index", first);
+        assert!(!set.contains(&last), "Element {} from next_back() still in index", last);
+
+        // Should be able to re-insert both
+        assert!(set.insert(first));
+        assert!(set.insert(last));
+    }
 }


### PR DESCRIPTION
This PR aims to fix bug in `IterableSet` and `UnorderedSet` drain iterators where backward iteration (`next_back()`) failed to remove index entries, causing silent state corruption.

### Problem

Both Set types use dual data structures that must stay synchronized:
- Elements: `Vector<T>` or `FreeList<T>` - primary storage
- Index: `LookupMap<T, Index>` - element position mapping

The `Drain` iterator's `next()` method correctly updated both:
```rust
fn next(&mut self) -> Option<Self::Item> {
    let key = self.elements.next()?;
    self.index.remove(&key);  // removes from index
    Some(key)
}
```

But next_back() only updated elements:
```rust
fn next_back(&mut self) -> Option<Self::Item> {
    self.elements.next_back()  // missing self.index.remove(&key)
}
```

### Impact

Where using `.drain().next_back()`:
- Orphaned entities remain in the index `LookupMap`, which might increase storage costs for accounts
- `contains()` returns true for drained elements
- `insert()` might fail silently for previously drained elements

### Verification

Added tests that expose the bug:
- `test_drain_next_back_removes_from_index()` - Verifies backward drain removes from index
- `test_drain_bidirectional()` - Verifies that forward and backward drain both work