### PR TITLE
fix: resolve flaky test_storage_deposit_minimal_deposit

### DIFF
--- a/examples/fungible-token/tests/workspaces.rs
+++ b/examples/fungible-token/tests/workspaces.rs
@@ -170,9 +170,6 @@ async fn test_storage_deposit_minimal_deposit(
         .await?
         .into_result()?;
 
-    let new_account_balance_before_deposit = new_account.view_account().await?.balance;
-    let contract_balance_before_deposit = contract.view_account().await?.balance;
-
     let minimal_deposit = near_sdk::env::storage_byte_cost().saturating_mul(125);
     new_account
         .call(contract.id(), "storage_deposit")
@@ -183,23 +180,20 @@ async fn test_storage_deposit_minimal_deposit(
         .await?
         .into_result()?;
 
-    let new_account_balance_diff = new_account_balance_before_deposit
-        .saturating_sub(new_account.view_account().await?.balance);
-    // new_account is charged the transaction fee, so it should loose a bit more than minimal_deposit
-    assert!(new_account_balance_diff > minimal_deposit);
-    assert!(
-        new_account_balance_diff < minimal_deposit.saturating_add(NearToken::from_millinear(1))
-    );
-
-    let contract_balance_diff =
-        contract.view_account().await?.balance.saturating_sub(contract_balance_before_deposit);
-    // contract receives a gas rewards for the function call, so the difference should be slightly more than minimal_deposit
-    assert!(contract_balance_diff > minimal_deposit);
-    // adjust the upper limit of the assertion to be more flexible for small variations in the gas reward received
-    assert!(
-        contract_balance_diff
-            < minimal_deposit.saturating_add(NearToken::from_yoctonear(50_000_000_000_000_000_000))
-    );
+    #[derive(near_sdk::serde::Serialize, near_sdk::serde::Deserialize)]
+    #[serde(crate = "near_sdk::serde")]
+    struct StorageBalanceOf {
+        total: U128,
+        available: U128,
+    }
+    let storage_balance: StorageBalanceOf = contract
+        .call("storage_balance_of")
+        .args_json(near_sdk::serde_json::json!({"account_id": new_account.id()}))
+        .view()
+        .await?
+        .json()?;
+    assert_eq!(storage_balance.total, minimal_deposit.as_yoctonear().into());
+    assert_eq!(storage_balance.available, 0.into());
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Replaces non-deterministic balance-diff assertions in `test_storage_deposit_minimal_deposit` with a deterministic `storage_balance_of` view call
- The test was flaky because it compared account balance changes against hard-coded gas cost tolerances that could be exceeded by sandbox gas price variations
- The new approach verifies that the storage registration actually succeeded (correct `total` and `available` values) rather than testing NEAR protocol gas mechanics, matching the pattern already used in `test_storage_deposit_refunds_excessive_deposit`

Closes #1353

## Test plan
- [ ] CI passes on the `test_storage_deposit_minimal_deposit` test (no more flakiness since assertions are now deterministic)