### PR TITLE
feat: update gas defaults to 1 PGas

### DIFF
--- a/examples/adder/src/lib.rs
+++ b/examples/adder/src/lib.rs
@@ -60,7 +60,7 @@ mod tests {
         let res = contract
             .call("call_all")
             .args_json(())
-            .gas(near_sdk::Gas::from_tgas(300))
+            .gas(near_sdk::Gas::from_tgas(1_000))
             .transact()
             .await?;
         println!("res: {:#?}", res);

--- a/examples/callback-results/src/lib.rs
+++ b/examples/callback-results/src/lib.rs
@@ -122,7 +122,7 @@ mod tests {
         let res = contract
             .call("call_all")
             .args_json((false, 1u8, 0u8))
-            .gas(near_sdk::Gas::from_tgas(300))
+            .gas(near_sdk::Gas::from_tgas(1_000))
             .transact()
             .await?;
         assert_eq!(res.json::<(bool, bool, bool)>()?, (false, false, true));
@@ -131,7 +131,7 @@ mod tests {
         let res = contract
             .call("call_all")
             .args_json((true, 0u8, 1u8))
-            .gas(near_sdk::Gas::from_tgas(300))
+            .gas(near_sdk::Gas::from_tgas(1_000))
             .transact()
             .await?;
         assert_eq!(res.json::<(bool, bool, bool)>()?, (true, true, false));
@@ -140,7 +140,7 @@ mod tests {
         let res = contract
             .call("call_all")
             .args_json((true, 0u8, 0u8))
-            .gas(near_sdk::Gas::from_tgas(300))
+            .gas(near_sdk::Gas::from_tgas(1_000))
             .transact()
             .await?;
         assert_eq!(res.json::<(bool, bool, bool)>()?, (true, true, true));
@@ -167,7 +167,7 @@ mod tests {
         let res = contract
             .call("call_all_reverse")
             .args_json((true, 0u8, 0u8))
-            .gas(near_sdk::Gas::from_tgas(300))
+            .gas(near_sdk::Gas::from_tgas(1_000))
             .transact()
             .await?;
         assert_eq!(res.json::<(bool, bool, bool)>()?, (true, true, true));

--- a/examples/mpc-contract/src/lib.rs
+++ b/examples/mpc-contract/src/lib.rs
@@ -177,7 +177,7 @@ mod tests {
         let tx_status = alice
             .call(contract.id(), "sign")
             .args_json(serde_json::json!({ "message": message }))
-            .gas(Gas::from_tgas(300))
+            .gas(Gas::from_tgas(1_000))
             .transact_async()
             .await?;
 

--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -444,7 +444,7 @@ pub fn attached_deposit() -> NearToken {
 /// use near_sdk::env::prepaid_gas;
 /// use near_sdk::Gas;
 ///
-/// assert_eq!(prepaid_gas(), Gas::from_tgas(300));
+/// assert_eq!(prepaid_gas(), Gas::from_tgas(1_000));
 /// ```
 pub fn prepaid_gas() -> Gas {
     maybe_cached!(Gas: { Gas::from_gas(unsafe { sys::prepaid_gas() }) })

--- a/near-sdk/src/test_utils/context.rs
+++ b/near-sdk/src/test_utils/context.rs
@@ -106,7 +106,7 @@ impl VMContextBuilder {
                 account_locked_balance: NearToken::from_near(0),
                 storage_usage: 1024 * 300,
                 attached_deposit: NearToken::from_near(0),
-                prepaid_gas: Gas::from_tgas(300),
+                prepaid_gas: Gas::from_tgas(1_000),
                 random_seed: [0u8; 32],
                 view_config: None,
                 output_data_receivers: vec![],


### PR DESCRIPTION
## Summary

- Update default `prepaid_gas` in test VMContext from 300 TGas to 1 PGas
- Update doc examples referencing the old gas limit
- Update example contracts using 300 TGas as max gas

Ref: near/devex#4