### PR TITLE
feat: add `ext_self()` and document cross-contract call patterns

### DIFF
--- a/examples/adder/src/lib.rs
+++ b/examples/adder/src/lib.rs
@@ -1,4 +1,4 @@
-use near_sdk::{Promise, env, near};
+use near_sdk::{Promise, near};
 
 #[derive(Debug, PartialEq, Eq)]
 #[near(serializers=[borsh, json])]
@@ -12,12 +12,12 @@ pub struct Adder {}
 impl Adder {
     /// Call functions a, b, and c, d,  asynchronously and handle results with `add_callback_vec`.
     pub fn call_all() -> Promise {
-        Self::ext(env::current_account_id())
+        Self::ext_self()
             .a()
-            .and(Self::ext(env::current_account_id()).b())
-            .and(Self::ext(env::current_account_id()).c())
-            .and(Self::ext(env::current_account_id()).d())
-            .then(Self::ext(env::current_account_id()).add_callback_vec())
+            .and(Self::ext_self().b())
+            .and(Self::ext_self().c())
+            .and(Self::ext_self().d())
+            .then(Self::ext_self().add_callback_vec())
     }
 
     /// Adds two pairs point-wise.

--- a/examples/callback-results/src/lib.rs
+++ b/examples/callback-results/src/lib.rs
@@ -10,27 +10,27 @@ pub struct Callback;
 impl Callback {
     /// Call functions a, b, c, and d asynchronously and handle results with `handle_callbacks`.
     pub fn call_all(fail_b: bool, c_value: u8, d_value: u8) -> Promise {
-        Self::ext(env::current_account_id())
+        Self::ext_self()
             .a()
-            .and(Self::ext(env::current_account_id()).b(fail_b))
-            .and(Self::ext(env::current_account_id()).c(c_value))
-            .and(Self::ext(env::current_account_id()).d(d_value))
-            .then(Self::ext(env::current_account_id()).handle_callbacks())
+            .and(Self::ext_self().b(fail_b))
+            .and(Self::ext_self().c(c_value))
+            .and(Self::ext_self().d(d_value))
+            .then(Self::ext_self().handle_callbacks())
     }
 
     /// Call functions a, b, c, and d asynchronously and handle results with `handle_callbacks_reverse`.
     pub fn call_all_reverse(fail_b: bool, c_value: u8, d_value: u8) -> Promise {
-        Self::ext(env::current_account_id())
+        Self::ext_self()
             .b(fail_b)
-            .and(Self::ext(env::current_account_id()).c(c_value))
-            .and(Self::ext(env::current_account_id()).d(d_value))
-            .and(Self::ext(env::current_account_id()).a())
-            .then(Self::ext(env::current_account_id()).handle_callbacks_reverse())
+            .and(Self::ext_self().c(c_value))
+            .and(Self::ext_self().d(d_value))
+            .and(Self::ext_self().a())
+            .then(Self::ext_self().handle_callbacks_reverse())
     }
 
     /// Calls function c with a value that will always succeed
     pub fn a() -> Promise {
-        Self::ext(env::current_account_id()).c(A_VALUE)
+        Self::ext_self().c(A_VALUE)
     }
 
     /// Returns a static string if `fail` is false, panicking otherwise.

--- a/examples/factory-contract-global/src/lib.rs
+++ b/examples/factory-contract-global/src/lib.rs
@@ -109,7 +109,7 @@ impl GlobalFactoryContract {
         // 3) return that message as its own result.
         ext_status_message::ext(account_id.clone())
             .set_status(message)
-            .then(Self::ext(env::current_account_id()).get_result(account_id))
+            .then(Self::ext_self().get_result(account_id))
     }
 
     #[handle_result]

--- a/examples/factory-contract/high-level/src/lib.rs
+++ b/examples/factory-contract/high-level/src/lib.rs
@@ -34,7 +34,7 @@ impl FactoryContract {
         // Note, for a contract to simply call another contract (1) is sufficient.
         ext_status_message::ext(account_id.clone())
             .set_status(message)
-            .then(Self::ext(env::current_account_id()).get_result(account_id))
+            .then(Self::ext_self().get_result(account_id))
     }
 
     #[handle_result]

--- a/near-contract-standards/src/fungible_token/core.rs
+++ b/near-contract-standards/src/fungible_token/core.rs
@@ -7,6 +7,8 @@ use near_sdk::json_types::U128;
 ///
 /// # Examples
 ///
+/// ## Implementing the trait
+///
 /// ```
 /// use near_sdk::{near, PanicOnDefault, AccountId, PromiseOrValue};
 /// use near_sdk::collections::LazyOption;
@@ -47,6 +49,34 @@ use near_sdk::json_types::U128;
 ///         self.token.ft_balance_of(account_id)
 ///     }
 /// }
+/// ```
+///
+/// ## Cross-contract calls
+///
+/// The `#[ext_contract]` annotation on this trait also generates the [`ext_ft_core`] module,
+/// which can be used to make type-safe cross-contract calls to **any** contract that
+/// implements this interface (e.g. `wrap.near`):
+///
+/// ```ignore
+/// use near_contract_standards::fungible_token::core::ext_ft_core;
+/// use near_sdk::{Gas, NearToken};
+///
+/// // Transfer tokens on an external FT contract
+/// ext_ft_core::ext("wrap.near".parse().unwrap())
+///     .with_attached_deposit(NearToken::from_yoctonear(1))
+///     .with_static_gas(Gas::from_tgas(5))
+///     .ft_transfer(receiver_id, amount, memo);
+///
+/// // Chain with a callback to the current contract
+/// ext_ft_core::ext("wrap.near".parse().unwrap())
+///     .with_attached_deposit(NearToken::from_yoctonear(1))
+///     .with_static_gas(Gas::from_tgas(10))
+///     .ft_transfer(receiver_id, amount, memo)
+///     .then(
+///         Self::ext_self()
+///             .with_static_gas(Gas::from_tgas(5))
+///             .on_ft_transfer_complete()
+///     );
 /// ```
 ///
 #[ext_contract(ext_ft_core)]

--- a/near-contract-standards/src/fungible_token/mod.rs
+++ b/near-contract-standards/src/fungible_token/mod.rs
@@ -5,6 +5,11 @@
 //! # Examples
 //! See [`FungibleTokenCore`] and [`FungibleTokenResolver`] for example usage and [`FungibleToken`]
 //! for core standard implementation.
+//!
+//! # Cross-contract calls
+//! The traits in this module are annotated with `#[ext_contract]`, which means they can also be
+//! used for type-safe cross-contract calls to external contracts that implement these interfaces.
+//! See the documentation on [`FungibleTokenCore`] for examples.
 
 pub mod core;
 pub mod core_impl;

--- a/near-contract-standards/src/non_fungible_token/core/mod.rs
+++ b/near-contract-standards/src/non_fungible_token/core/mod.rs
@@ -23,6 +23,8 @@ use near_sdk::ext_contract;
 ///
 /// # Examples
 ///
+/// ## Implementing the trait
+///
 /// ```
 /// use near_sdk::{PanicOnDefault, AccountId, PromiseOrValue, near};
 /// use near_contract_standards::non_fungible_token::{core::NonFungibleTokenCore, NonFungibleToken, TokenId, Token};
@@ -48,6 +50,23 @@ use near_sdk::ext_contract;
 ///        self.tokens.nft_token(token_id)
 ///    }
 ///}
+/// ```
+///
+/// ## Cross-contract calls
+///
+/// The `#[ext_contract]` annotation on this trait also generates the [`ext_nft_core`] module,
+/// which can be used to make type-safe cross-contract calls to **any** contract that
+/// implements this interface:
+///
+/// ```ignore
+/// use near_contract_standards::non_fungible_token::core::ext_nft_core;
+/// use near_sdk::{Gas, NearToken};
+///
+/// // Transfer an NFT on an external contract
+/// ext_nft_core::ext(nft_contract_id)
+///     .with_attached_deposit(NearToken::from_yoctonear(1))
+///     .with_static_gas(Gas::from_tgas(5))
+///     .nft_transfer(receiver_id, token_id, None, None);
 /// ```
 ///
 #[ext_contract(ext_nft_core)]

--- a/near-sdk-macros/src/core_impl/code_generator/ext.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/ext.rs
@@ -31,11 +31,33 @@ pub(crate) fn generate_ext_structs(
             }
         }
     };
+    // `ext_self` is only generated for contract structs, not for ext_contract modules,
+    // since it calls env::current_account_id() which only makes sense for self-callbacks.
+    let ext_self_code = if generic_details.is_some() {
+        quote! {
+            /// Convenience method for creating a cross-contract call to the current contract.
+            ///
+            /// Equivalent to `Self::ext(near_sdk::env::current_account_id())`.
+            pub fn ext_self() -> #name {
+                #name {
+                    promise_or_create_on: ::near_sdk::PromiseOrValue::Value(
+                        ::near_sdk::env::current_account_id(),
+                    ),
+                    deposit: ::near_sdk::NearToken::from_near(0),
+                    static_gas: ::near_sdk::Gas::from_gas(0),
+                    gas_weight: ::near_sdk::GasWeight::default(),
+                }
+            }
+        }
+    } else {
+        quote! {}
+    };
     if let Some(generics) = generic_details {
         // If ext generation is on struct, make ext function associated with struct not module
         ext_code = quote! {
             impl #generics #ident #generics {
                 #ext_code
+                #ext_self_code
             }
         };
     }

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_gen.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_gen.snap
@@ -1,6 +1,5 @@
 ---
 source: near-sdk-macros/src/core_impl/code_generator/ext.rs
-assertion_line: 172
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 #[must_use]
@@ -37,6 +36,19 @@ impl Test {
     pub fn ext_on(promise: ::near_sdk::Promise) -> TestExt {
         TestExt {
             promise_or_create_on: ::near_sdk::PromiseOrValue::Promise(promise),
+            deposit: ::near_sdk::NearToken::from_near(0),
+            static_gas: ::near_sdk::Gas::from_gas(0),
+            gas_weight: ::near_sdk::GasWeight::default(),
+        }
+    }
+    /// Convenience method for creating a cross-contract call to the current contract.
+    ///
+    /// Equivalent to `Self::ext(near_sdk::env::current_account_id())`.
+    pub fn ext_self() -> TestExt {
+        TestExt {
+            promise_or_create_on: ::near_sdk::PromiseOrValue::Value(
+                ::near_sdk::env::current_account_id(),
+            ),
             deposit: ::near_sdk::NearToken::from_near(0),
             static_gas: ::near_sdk::Gas::from_gas(0),
             gas_weight: ::near_sdk::GasWeight::default(),

--- a/near-sdk/src/lib.rs
+++ b/near-sdk/src/lib.rs
@@ -330,7 +330,7 @@ compile_error!(
 /// ### What gets generated where
 ///
 /// - **`#[near(contract_state)]`** generates the `<ContractType>Ext` struct definition
-///   with its fields and the `ext()` / `ext_on()` constructor methods.
+///   with its fields and the `ext()` / `ext_self()` / `ext_on()` constructor methods.
 /// - **`#[near]` on impl blocks** generates method wrappers on `<ContractType>Ext`
 ///   that mirror each public method in the impl block, returning a [`Promise`].
 ///
@@ -357,11 +357,12 @@ compile_error!(
 ///     }
 ///
 ///     pub fn call_with_callback(&self) -> Promise {
-///         // Chain multiple calls: call self, then callback
-///         Self::ext(env::current_account_id())
+///         // Chain multiple calls: call self, then callback.
+///         // `ext_self()` is a shorthand for `ext(env::current_account_id())`.
+///         Self::ext_self()
 ///             .some_method()
 ///             .then(
-///                 Self::ext(env::current_account_id())
+///                 Self::ext_self()
 ///                     .callback_method()
 ///             )
 ///     }


### PR DESCRIPTION
## Summary

- Adds `Self::ext_self()` as a generated convenience method on `#[near(contract_state)]` structs, equivalent to `Self::ext(env::current_account_id())`. Only generated for contract structs, not for `#[ext_contract]` modules where it wouldn't make sense.
- Documents that contract standards traits (`FungibleTokenCore`, `NonFungibleTokenCore`) generate modules (`ext_ft_core`, `ext_nft_core`) that can be used for **type-safe cross-contract calls** to any contract implementing the interface — not just for implementing your own contract.
- Updates all examples (`adder`, `callback-results`, `factory-contract`, `factory-contract-global`) to use `ext_self()`.

Closes #1498
Relates to #413

## Test plan

- [x] All `near-sdk-macros` snapshot and unit tests pass (47/47)
- [x] All four updated examples compile against wasm32 target
- [x] `near-contract-standards` compiles against wasm32 target
- [x] Module snapshot for `ext_contract` unchanged (no `ext_self` generated for trait modules)