### PR TITLE
feat: forward `allow` attribute

### DIFF
--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_fn_non_bindgen_attrs.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_fn_non_bindgen_attrs.snap
@@ -1,9 +1,10 @@
 ---
 source: near-sdk-macros/src/core_impl/code_generator/ext.rs
-assertion_line: 197
+assertion_line: 203
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 #[cfg(target_os = "linux")]
+#[allow(clippy::too_many_arguments)]
 pub fn method(self) -> ::near_sdk::Promise {
     let __args = ::std::vec![];
     match self.promise_or_create_on {

--- a/near-sdk/compilation_tests/all.rs
+++ b/near-sdk/compilation_tests/all.rs
@@ -43,4 +43,5 @@ fn compilation_tests() {
     t.pass("compilation_tests/contract_metadata_bindgen.rs");
     t.pass("compilation_tests/types.rs");
     t.compile_fail("compilation_tests/nested_near_error.rs");
+    t.pass("compilation_tests/allow_attr_forwarding.rs");
 }

--- a/near-sdk/compilation_tests/allow_attr_forwarding.rs
+++ b/near-sdk/compilation_tests/allow_attr_forwarding.rs
@@ -1,0 +1,31 @@
+//! Contract that verifies #[allow] attributes on methods are respected
+//! through the #[near] macro expansion, including the generated ext wrappers.
+//! See https://github.com/near/near-sdk-rs/issues/1505
+
+use near_sdk::near;
+
+#[near(contract_state)]
+#[derive(Default)]
+struct Contract {
+    value: u32,
+}
+
+#[near]
+impl Contract {
+    #[allow(clippy::too_many_arguments)]
+    pub fn many_args(
+        &self,
+        arg1: u32,
+        arg2: u32,
+        arg3: u32,
+        arg4: u32,
+        arg5: u32,
+        arg6: u32,
+        arg7: u32,
+        arg8: u32,
+    ) -> u32 {
+        arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7 + arg8
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
I see that we stopped forwarding all non-bindgen attributes in #959 with a good reasoning behind, but I think it's safe to forward `allow` attribute, since it's used only for linting and shouldn't cause any problems or breaking changes. However, I don't have a strong opinion here, so feel free to close this PR if I've missed something, since crate-level `#![allow(...)]` still works

closes #1505
