### PR TITLE
fix(iterable-map): different asserts for `expensive-debug` feature in `test_show`

### DIFF
--- a/near-sdk/src/store/iterable_map/mod.rs
+++ b/near-sdk/src/store/iterable_map/mod.rs
@@ -1151,8 +1151,7 @@ mod test_map {
 
         let map_str = format!("{:?}", map);
 
-        #[cfg(feature = "expensive-debug")]
-        {
+        if cfg!(feature = "expensive-debug") {
             assert_eq!(
                 map_str,
                 "IterableMap { keys: [1, 3], values: LookupMap { prefix: [98, 109] } }"
@@ -1161,9 +1160,7 @@ mod test_map {
                 format!("{:?}", empty),
                 "IterableMap { keys: [], values: LookupMap { prefix: [99, 109] } }"
             );
-        }
-        #[cfg(not(feature = "expensive-debug"))]
-        {
+        } else {
             assert_eq!(
                 map_str,
                 "IterableMap { keys: Vector { len: 2, prefix: [98, 118] }, values: LookupMap { prefix: [98, 109] } }"


### PR DESCRIPTION
```bash
$ cargo test --all-features
```

Gave this output, because `expensive-debug` was enabled as well, but test didn't account for that
<img width="778" height="294" alt="image" src="https://github.com/user-attachments/assets/535c3369-ffea-4eb3-aae1-4f6d71cfb78e" />
