### PR TITLE
feat: allow crypto-related `env::*` functions for non-contract-usage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,10 @@ jobs:
           - os: warp-macos-latest-arm64-6x
             rs: "1.86.0"
             name: macos
-        features: ["", "--features unstable,legacy,__abi-generate,deterministic-account-ids"]
+        features:
+          - ""
+          - "--features unstable,legacy,__abi-generate,deterministic-account-ids"
+          - "--features unstable,deterministic-account-ids,non-contract-usage"
     steps:
       - uses: actions/checkout@v4
 

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -106,7 +106,14 @@ unit-testing = [
     "near-crypto",
     "near-parameters",
 ]
-non-contract-usage = ["ed25519-dalek", "near-crypto", "ripemd", "sha2", "sha3"]
+non-contract-usage = [
+    "ed25519-dalek",
+    "near-crypto",
+    "near-primitives-core",
+    "ripemd",
+    "sha2",
+    "sha3",
+]
 
 __abi-embed = ["near-sdk-macros/__abi-embed"]
 __abi-generate = ["abi", "near-sdk-macros/__abi-generate"]

--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -607,21 +607,10 @@ pub fn keccak512(value: impl AsRef<[u8]>) -> Vec<u8> {
 /// );
 /// ```
 pub fn sha256_array(value: impl AsRef<[u8]>) -> CryptoHash {
-    #[cfg(all(
-        feature = "non-contract-usage",
-        not(target_arch = "wasm32"),
-        not(feature = "unit-testing"),
-    ))]
-    {
-        use sha2::Digest;
-
-        sha2::Sha256::digest(value).into()
-    }
-
     #[cfg(any(
-        not(feature = "non-contract-usage"),
         target_arch = "wasm32",
-        feature = "unit-testing",
+        not(feature = "non-contract-usage"),
+        all(feature = "unit-testing", not(test)),
     ))]
     {
         let value = value.as_ref();
@@ -632,6 +621,17 @@ pub fn sha256_array(value: impl AsRef<[u8]>) -> CryptoHash {
             sys::sha256(value.len() as _, value.as_ptr() as _, ATOMIC_OP_REGISTER);
             read_register_fixed(ATOMIC_OP_REGISTER)
         }
+    }
+
+    #[cfg(all(
+        not(target_arch = "wasm32"),
+        feature = "non-contract-usage",
+        any(not(feature = "unit-testing"), test),
+    ))]
+    {
+        use sha2::Digest;
+
+        sha2::Sha256::digest(value).into()
     }
 }
 
@@ -650,21 +650,10 @@ pub fn sha256_array(value: impl AsRef<[u8]>) -> CryptoHash {
 /// );
 /// ```
 pub fn keccak256_array(value: impl AsRef<[u8]>) -> CryptoHash {
-    #[cfg(all(
-        feature = "non-contract-usage",
-        not(target_arch = "wasm32"),
-        not(feature = "unit-testing"),
-    ))]
-    {
-        use sha3::Digest;
-
-        sha3::Keccak256::digest(value).into()
-    }
-
     #[cfg(any(
-        not(feature = "non-contract-usage"),
         target_arch = "wasm32",
-        feature = "unit-testing",
+        not(feature = "non-contract-usage"),
+        all(feature = "unit-testing", not(test)),
     ))]
     {
         let value = value.as_ref();
@@ -675,6 +664,17 @@ pub fn keccak256_array(value: impl AsRef<[u8]>) -> CryptoHash {
             sys::keccak256(value.len() as _, value.as_ptr() as _, ATOMIC_OP_REGISTER);
             read_register_fixed(ATOMIC_OP_REGISTER)
         }
+    }
+
+    #[cfg(all(
+        not(target_arch = "wasm32"),
+        feature = "non-contract-usage",
+        any(not(feature = "unit-testing"), test),
+    ))]
+    {
+        use sha3::Digest;
+
+        sha3::Keccak256::digest(value).into()
     }
 }
 
@@ -693,21 +693,10 @@ pub fn keccak256_array(value: impl AsRef<[u8]>) -> CryptoHash {
 /// );
 /// ```
 pub fn keccak512_array(value: impl AsRef<[u8]>) -> [u8; 64] {
-    #[cfg(all(
-        feature = "non-contract-usage",
-        not(target_arch = "wasm32"),
-        not(feature = "unit-testing"),
-    ))]
-    {
-        use sha3::Digest;
-
-        sha3::Keccak512::digest(value).into()
-    }
-
     #[cfg(any(
-        not(feature = "non-contract-usage"),
         target_arch = "wasm32",
-        feature = "unit-testing",
+        not(feature = "non-contract-usage"),
+        all(feature = "unit-testing", not(test)),
     ))]
     {
         let value = value.as_ref();
@@ -719,6 +708,17 @@ pub fn keccak512_array(value: impl AsRef<[u8]>) -> [u8; 64] {
             sys::keccak512(value.len() as _, value.as_ptr() as _, ATOMIC_OP_REGISTER);
             read_register_fixed(ATOMIC_OP_REGISTER)
         }
+    }
+
+    #[cfg(all(
+        not(target_arch = "wasm32"),
+        feature = "non-contract-usage",
+        any(not(feature = "unit-testing"), test),
+    ))]
+    {
+        use sha3::Digest;
+
+        sha3::Keccak512::digest(value).into()
     }
 }
 
@@ -737,21 +737,10 @@ pub fn keccak512_array(value: impl AsRef<[u8]>) -> [u8; 64] {
 /// );
 /// ```
 pub fn ripemd160_array(value: impl AsRef<[u8]>) -> [u8; 20] {
-    #[cfg(all(
-        feature = "non-contract-usage",
-        not(target_arch = "wasm32"),
-        not(feature = "unit-testing"),
-    ))]
-    {
-        use sha2::Digest;
-
-        ripemd::Ripemd160::digest(value).into()
-    }
-
     #[cfg(any(
-        not(feature = "non-contract-usage"),
         target_arch = "wasm32",
-        feature = "unit-testing",
+        not(feature = "non-contract-usage"),
+        all(feature = "unit-testing", not(test)),
     ))]
     {
         let value = value.as_ref();
@@ -762,6 +751,17 @@ pub fn ripemd160_array(value: impl AsRef<[u8]>) -> [u8; 20] {
             sys::ripemd160(value.len() as _, value.as_ptr() as _, ATOMIC_OP_REGISTER);
             read_register_fixed(ATOMIC_OP_REGISTER)
         }
+    }
+
+    #[cfg(all(
+        not(target_arch = "wasm32"),
+        feature = "non-contract-usage",
+        any(not(feature = "unit-testing"), test),
+    ))]
+    {
+        use sha2::Digest;
+
+        ripemd::Ripemd160::digest(value).into()
     }
 }
 
@@ -779,10 +779,30 @@ pub fn ecrecover(
     v: u8,
     malleability_flag: bool,
 ) -> Option<[u8; 64]> {
+    #[cfg(any(
+        target_arch = "wasm32",
+        not(feature = "non-contract-usage"),
+        all(feature = "unit-testing", not(test)),
+    ))]
+    {
+        unsafe {
+            let return_code = sys::ecrecover(
+                hash.len() as _,
+                hash.as_ptr() as _,
+                signature.len() as _,
+                signature.as_ptr() as _,
+                v as u64,
+                malleability_flag as u64,
+                ATOMIC_OP_REGISTER,
+            );
+            if return_code == 0 { None } else { Some(read_register_fixed(ATOMIC_OP_REGISTER)) }
+        }
+    }
+
     #[cfg(all(
-        feature = "non-contract-usage",
         not(target_arch = "wasm32"),
-        not(feature = "unit-testing"),
+        feature = "non-contract-usage",
+        any(not(feature = "unit-testing"), test),
     ))]
     {
         use near_crypto::Secp256K1Signature;
@@ -801,26 +821,6 @@ pub fn ecrecover(
         }
 
         signature.recover(hash).ok()?.as_ref().try_into().ok()
-    }
-
-    #[cfg(any(
-        not(feature = "non-contract-usage"),
-        target_arch = "wasm32",
-        feature = "unit-testing",
-    ))]
-    {
-        unsafe {
-            let return_code = sys::ecrecover(
-                hash.len() as _,
-                hash.as_ptr() as _,
-                signature.len() as _,
-                signature.as_ptr() as _,
-                v as u64,
-                malleability_flag as u64,
-                ATOMIC_OP_REGISTER,
-            );
-            if return_code == 0 { None } else { Some(read_register_fixed(ATOMIC_OP_REGISTER)) }
-        }
     }
 }
 
@@ -872,25 +872,10 @@ pub fn ed25519_verify(
 ) -> bool {
     let message = message.as_ref();
 
-    #[cfg(all(
-        feature = "non-contract-usage",
-        not(target_arch = "wasm32"),
-        not(feature = "unit-testing"),
-    ))]
-    {
-        use ed25519_dalek::{Signature, Verifier, VerifyingKey};
-
-        let Ok(verifying_key) = VerifyingKey::from_bytes(public_key) else {
-            return false;
-        };
-        let signature = Signature::from_bytes(signature);
-        verifying_key.verify(message, &signature).is_ok()
-    }
-
     #[cfg(any(
-        not(feature = "non-contract-usage"),
         target_arch = "wasm32",
-        feature = "unit-testing",
+        not(feature = "non-contract-usage"),
+        all(feature = "unit-testing", not(test)),
     ))]
     {
         unsafe {
@@ -903,6 +888,21 @@ pub fn ed25519_verify(
                 public_key.as_ptr() as _,
             ) == 1
         }
+    }
+
+    #[cfg(all(
+        not(target_arch = "wasm32"),
+        feature = "non-contract-usage",
+        any(not(feature = "unit-testing"), test),
+    ))]
+    {
+        use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+
+        let Ok(verifying_key) = VerifyingKey::from_bytes(public_key) else {
+            return false;
+        };
+        let signature = Signature::from_bytes(signature);
+        verifying_key.verify(message, &signature).is_ok()
     }
 }
 
@@ -2698,7 +2698,6 @@ mod tests {
         assert!(is_valid_account_id(b"near"));
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn hash_smoke_tests() {
         assert_eq!(
@@ -2728,7 +2727,6 @@ mod tests {
         );
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn random_seed_smoke_test() {
         crate::testing_env!(
@@ -2780,7 +2778,6 @@ mod tests {
         }
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn signer_public_key() {
         let key: PublicKey =
@@ -2934,6 +2931,7 @@ mod tests {
 
         assert!(!super::alt_bn128_pairing_check(invalid_pair));
     }
+
     #[test]
     fn bls12381_p1_sum_0_100() {
         let buffer: [u8; 0] = [];

--- a/near-sdk/src/state_init.rs
+++ b/near-sdk/src/state_init.rs
@@ -59,7 +59,10 @@ impl From<StateInitV1> for StateInit {
     }
 }
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "unit-testing"))]
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    any(feature = "unit-testing", feature = "non-contract-usage")
+))]
 const _: () = {
     use near_primitives_core::deterministic_account_id::{
         DeterministicAccountStateInit, DeterministicAccountStateInitV1,
@@ -73,10 +76,24 @@ const _: () = {
         }
     }
 
+    impl From<StateInit> for DeterministicAccountStateInit {
+        fn from(value: StateInit) -> Self {
+            match value {
+                StateInit::V1(state_init) => Self::V1(state_init.into()),
+            }
+        }
+    }
+
     impl From<DeterministicAccountStateInitV1> for StateInitV1 {
         fn from(
             DeterministicAccountStateInitV1 { code, data }: DeterministicAccountStateInitV1,
         ) -> Self {
+            Self { code: code.into(), data }
+        }
+    }
+
+    impl From<StateInitV1> for DeterministicAccountStateInitV1 {
+        fn from(StateInitV1 { code, data }: StateInitV1) -> Self {
             Self { code: code.into(), data }
         }
     }

--- a/near-sdk/src/types/contract_code.rs
+++ b/near-sdk/src/types/contract_code.rs
@@ -48,11 +48,15 @@ impl From<AccountId> for GlobalContractId {
     }
 }
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "unit-testing"))]
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    any(feature = "unit-testing", feature = "non-contract-usage")
+))]
 const _: () = {
     use near_primitives_core::{
         account::AccountContract as NearAccountContract,
         global_contract::GlobalContractIdentifier as NearGlobalContractIdentifier,
+        hash::CryptoHash,
     };
 
     impl From<NearAccountContract> for AccountContract {
@@ -68,6 +72,17 @@ const _: () = {
         }
     }
 
+    impl From<AccountContract> for NearAccountContract {
+        fn from(value: AccountContract) -> Self {
+            match value {
+                AccountContract::None => Self::None,
+                AccountContract::Local(contract) => Self::Local(CryptoHash(contract.into())),
+                AccountContract::Global(contract) => Self::Global(CryptoHash(contract.into())),
+                AccountContract::GlobalByAccount(account_id) => Self::GlobalByAccount(account_id),
+            }
+        }
+    }
+
     impl From<NearGlobalContractIdentifier> for GlobalContractId {
         fn from(value: NearGlobalContractIdentifier) -> Self {
             match value {
@@ -75,6 +90,17 @@ const _: () = {
                     Self::CodeHash(code_hash.0.into())
                 }
                 NearGlobalContractIdentifier::AccountId(account_id) => Self::AccountId(account_id),
+            }
+        }
+    }
+
+    impl From<GlobalContractId> for NearGlobalContractIdentifier {
+        fn from(value: GlobalContractId) -> Self {
+            match value {
+                GlobalContractId::CodeHash(code_hash) => {
+                    Self::CodeHash(CryptoHash(code_hash.into()))
+                }
+                GlobalContractId::AccountId(account_id) => Self::AccountId(account_id),
             }
         }
     }

--- a/near-sdk/src/types/public_key.rs
+++ b/near-sdk/src/types/public_key.rs
@@ -53,39 +53,53 @@ impl std::str::FromStr for CurveType {
     }
 }
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "unit-testing"))]
-#[cfg(test)]
-impl TryFrom<PublicKey> for near_crypto::PublicKey {
-    type Error = ParsePublicKeyError;
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    any(feature = "unit-testing", feature = "non-contract-usage")
+))]
+const _: () = {
+    impl TryFrom<PublicKey> for near_crypto::PublicKey {
+        type Error = ParsePublicKeyError;
 
-    fn try_from(public_key: PublicKey) -> Result<Self, Self::Error> {
-        let curve_type = CurveType::from_u8(public_key.data[0])?;
-        let expected_len = curve_type.data_len();
+        fn try_from(public_key: PublicKey) -> Result<Self, Self::Error> {
+            let curve_type = CurveType::from_u8(public_key.data[0])?;
+            let expected_len = curve_type.data_len();
 
-        let key_bytes = public_key.into_bytes();
-        if key_bytes.len() != expected_len + 1 {
-            return Err(ParsePublicKeyError {
-                kind: ParsePublicKeyErrorKind::InvalidLength(key_bytes.len()),
-            });
-        }
-
-        let data = &key_bytes.as_slice()[1..];
-        match curve_type {
-            CurveType::ED25519 => {
-                let public_key = near_crypto::PublicKey::ED25519(
-                    near_crypto::ED25519PublicKey::try_from(data).unwrap(),
-                );
-                Ok(public_key)
+            let key_bytes = public_key.into_bytes();
+            if key_bytes.len() != expected_len + 1 {
+                return Err(ParsePublicKeyError {
+                    kind: ParsePublicKeyErrorKind::InvalidLength(key_bytes.len()),
+                });
             }
-            CurveType::SECP256K1 => {
-                let public_key = near_crypto::PublicKey::SECP256K1(
-                    near_crypto::Secp256K1PublicKey::try_from(data).unwrap(),
-                );
-                Ok(public_key)
+
+            let data = &key_bytes.as_slice()[1..];
+            match curve_type {
+                CurveType::ED25519 => {
+                    let public_key = near_crypto::PublicKey::ED25519(
+                        near_crypto::ED25519PublicKey::try_from(data).unwrap(),
+                    );
+                    Ok(public_key)
+                }
+                CurveType::SECP256K1 => {
+                    let public_key = near_crypto::PublicKey::SECP256K1(
+                        near_crypto::Secp256K1PublicKey::try_from(data).unwrap(),
+                    );
+                    Ok(public_key)
+                }
             }
         }
     }
-}
+
+    impl From<near_crypto::PublicKey> for PublicKey {
+        fn from(value: near_crypto::PublicKey) -> Self {
+            let curve_type = match value {
+                near_crypto::PublicKey::ED25519(_) => CurveType::ED25519,
+                near_crypto::PublicKey::SECP256K1(_) => CurveType::SECP256K1,
+            };
+            Self { data: [[curve_type as u8].as_slice(), value.key_data()].concat() }
+        }
+    }
+};
 
 /// Public key in a binary format with base58 string serialization with human-readable curve.
 /// The key types currently supported are `secp256k1` and `ed25519`.


### PR DESCRIPTION
This PR allows third-party projects to use crypto-related `env::*` functions from near-sdk even if `non-contract-usage` feature is enabled.

For example, this lets other projects to use `StateInit::derive_account_id` without enabling a heavy `unit-testing` feature.

Implementations for these `env::*` functions follow the behavior from `near-vm-runner` crate but without unnecessary conversions.