### PR TITLE
Replace x86 compile_error with deprecation warning

### DIFF
--- a/near-sdk-macros/src/lib.rs
+++ b/near-sdk-macros/src/lib.rs
@@ -317,6 +317,33 @@ pub fn near_bindgen(attr: TokenStream, item: TokenStream) -> TokenStream {
     #[cfg(not(feature = "__abi-embed-checked"))]
     let abi_embedded = quote! {};
     let item = proc_macro2::TokenStream::from(item);
+
+    // Generate a warning for non-wasm, non-cargo-near builds
+    let warning_ident = Ident::new(
+        &format!("__near_sdk_build_warning_{}", ident),
+        Span::call_site(),
+    );
+    let build_warning = quote! {
+        #[cfg(all(
+            not(target_family = "wasm"),
+            not(test),
+            not(clippy),
+        ))]
+        #[allow(unexpected_cfgs)]
+        const _: () = {
+            #[deprecated(note = "\n\n\
+                ⚠️⚠️⚠️  NEAR CONTRACT BUILD WARNING  ⚠️⚠️⚠️\n\n\
+                It looks like you're building a NEAR contract without `cargo near`.\n\
+                If you intended to build your contract, use `cargo near build` instead.\n\n\
+                💡 Install cargo-near: https://github.com/near/cargo-near\n")]
+            #[allow(non_upper_case_globals)]
+            const #warning_ident: () = ();
+
+            #[warn(deprecated)]
+            const __trigger: () = #warning_ident;
+        };
+    };
+
     TokenStream::from(quote! {
         #item
         #ext_gen
@@ -324,6 +351,7 @@ pub fn near_bindgen(attr: TokenStream, item: TokenStream) -> TokenStream {
         #metadata
         #metadata_impl_gen
         #impl_contract_state
+        #build_warning
     })
 }
 

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -113,6 +113,10 @@ __abi-generate = ["abi", "near-sdk-macros/__abi-generate"]
 
 __macro-docs = []
 
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ["cfg(near)"]
+
 [package.metadata.docs.rs]
 features = [
     "global-contracts",

--- a/near-sdk/src/lib.rs
+++ b/near-sdk/src/lib.rs
@@ -128,30 +128,25 @@
 #[cfg(test)]
 extern crate quickcheck;
 
-#[cfg(not(any(
-    test,
-    doctest,
-    clippy,
+// NOTE: compile_error! replaced with a deprecation warning in the #[near_bindgen] macro.
+// The warning approach lets x86 builds succeed (for clippy, tests, shared types)
+// while still nudging developers toward `cargo near build`.
+// The hard error is preserved for wasm32 builds without `cargo near` (which sets --cfg near).
+#[cfg(all(
     target_family = "wasm",
-    feature = "unit-testing",
-    feature = "non-contract-usage",
-    feature = "__abi-generate"
-)))]
+    not(near),
+    not(any(
+        test,
+        doctest,
+        clippy,
+        feature = "unit-testing",
+        feature = "non-contract-usage",
+        feature = "__abi-generate"
+    ))
+))]
 compile_error!(
-    r#"1. 🔨️  Use `cargo near build` instead of `cargo build` to compile your contract
+    r#"Use `cargo near build` instead of `cargo build --target wasm32-unknown-unknown` to compile your contract.
 💡  Install cargo-near from https://github.com/near/cargo-near
-
-2. ✅ Use `cargo check --target wasm32-unknown-unknown` instead of `cargo check` to error-check your contract
-
-3. ⚙️ Only following cfg-s are considered VALID for `near-sdk`:
-  - `#[cfg(target_family = "wasm")]`
-  - `#[cfg(feature = "non-contract-usage")]` (intended for use of `near-sdk` in non-contract environment)
-  - `#[cfg(feature = "unit-testing")]` (intended for use of `near-sdk` as one of `[dev-dependencies]`)
-  - `#[cfg(feature = "__abi-generate")`
-  - `#[cfg(test)]`
-  - `#[cfg(doctest)]`
-  - `#[cfg(clippy)]`
-⚠️ a cfg, which is not one of the above, results in CURRENT compilation error to be emitted.
 "#
 );
 


### PR DESCRIPTION
## Context

Right now, `cargo build` on x86 fails with a hard `compile_error!` telling you to use `cargo near build`. This was added to protect against accidentally building contracts with plain cargo (see #1361), but it also blocks legitimate x86 use cases: running clippy across a mixed workspace, sharing types between contracts and indexers/relayers, running tests, etc. Every project hitting this ends up enabling `non-contract-usage` as a workaround, which defeats the purpose of the guard.

## Approach

The actual dangerous mistake is `cargo build --target wasm32-unknown-unknown` without `cargo near` — that produces a wasm artifact missing ABI embedding and wasm-opt post-processing. A plain `cargo build` on x86 doesn't produce a wasm file at all, so we still want to warn developers (they might be confused about where their .wasm went, or might deploy a stale artifact from a previous build), but a hard error is too aggressive since it also blocks legitimate workflows.

This PR:
- **Keeps the hard `compile_error!`** for wasm32 builds without `cargo near` (which would set `--cfg near` via RUSTFLAGS)
- **Replaces the x86 hard error** with a deprecation warning emitted from the `#[near_bindgen]` macro expansion, so devs still see a prominent nudge toward `cargo near build` but aren't blocked
- Warning is suppressed during `cargo test`, `cargo clippy`, and when targeting wasm32

Requires a small companion change in `cargo-near` to pass `RUSTFLAGS="--cfg near"` during wasm builds.