### PR TITLE
fix: update release-plz and skip publish verification for wasm32

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -25,14 +25,16 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
-      # Pinned to last version using taiki-e/install-action for binary installation.
-      # Newer versions use cargo-binstall which compiles from source and fails with
-      # CARGO_BUILD_TARGET=wasm32-unknown-unknown (gix-sec uses Unix APIs).
-      # See: https://github.com/release-plz/action/pull/239
+      # Set build target via .cargo/config.toml instead of CARGO_BUILD_TARGET env var.
+      # cargo-binstall reads CARGO_BUILD_TARGET and would try to install a wasm32 binary,
+      # but it ignores .cargo/config.toml, so this lets the action install release-plz
+      # natively while cargo still builds for wasm32.
+      - name: Set cargo build target
+        run: echo -e '[build]\ntarget = "wasm32-unknown-unknown"' >> .cargo/config.toml
+
       - name: Run release-plz
-        uses: release-plz/action@5ab144c9d67d4346240190d0f95ed08668677928
+        uses: release-plz/action@0.5
         env:
           # https://marcoieni.github.io/release-plz/github-action.html#triggering-further-workflow-runs
           GITHUB_TOKEN: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          CARGO_BUILD_TARGET: wasm32-unknown-unknown

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -25,16 +25,25 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
-      # Set build target via .cargo/config.toml instead of CARGO_BUILD_TARGET env var.
-      # cargo-binstall reads CARGO_BUILD_TARGET and would try to install a wasm32 binary,
-      # but it ignores .cargo/config.toml, so this lets the action install release-plz
-      # natively while cargo still builds for wasm32.
-      - name: Set cargo build target
-        run: echo -e '[build]\ntarget = "wasm32-unknown-unknown"' >> .cargo/config.toml
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
 
-      - name: Run release-plz
-        uses: release-plz/action@0.5
+      - name: Install release-plz
+        run: cargo-binstall release-plz cargo-semver-checks --no-confirm
+
+      # Install release-plz and cargo-semver-checks without CARGO_BUILD_TARGET
+      # so cargo-binstall downloads native binaries. Set the target only when
+      # running release-plz so cargo builds for wasm32.
+      - name: Release-plz release-pr
+        run: release-plz release-pr --git-token "$GITHUB_TOKEN" --repo-url "https://github.com/$GITHUB_REPOSITORY" -o json
         env:
-          # https://marcoieni.github.io/release-plz/github-action.html#triggering-further-workflow-runs
           GITHUB_TOKEN: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_BUILD_TARGET: wasm32-unknown-unknown
+
+      - name: Release-plz release
+        run: release-plz release --git-token "$GITHUB_TOKEN" -o json
+        env:
+          GITHUB_TOKEN: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_BUILD_TARGET: wasm32-unknown-unknown

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -22,28 +22,10 @@ jobs:
 
       - name: Install Rust toolchain 1.86 for builds
         uses: dtolnay/rust-toolchain@1.86
-        with:
-          targets: wasm32-unknown-unknown
 
-      - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@main
-
-      - name: Install release-plz
-        run: cargo-binstall release-plz cargo-semver-checks --no-confirm
-
-      # Install release-plz and cargo-semver-checks without CARGO_BUILD_TARGET
-      # so cargo-binstall downloads native binaries. Set the target only when
-      # running release-plz so cargo builds for wasm32.
-      - name: Release-plz release-pr
-        run: release-plz release-pr --git-token "$GITHUB_TOKEN" --repo-url "https://github.com/$GITHUB_REPOSITORY" -o json
+      - name: Run release-plz
+        uses: release-plz/action@0.5
         env:
+          # https://marcoieni.github.io/release-plz/github-action.html#triggering-further-workflow-runs
           GITHUB_TOKEN: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          CARGO_BUILD_TARGET: wasm32-unknown-unknown
-
-      - name: Release-plz release
-        run: release-plz release --git-token "$GITHUB_TOKEN" -o json
-        env:
-          GITHUB_TOKEN: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          CARGO_BUILD_TARGET: wasm32-unknown-unknown

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,9 @@
 [workspace]
 # Use `near-sdk` crate CHANGELOG as top-level one
 changelog_update = false
+# Skip cargo publish verification build (which requires wasm32 target).
+# CI already builds and tests all crates on every PR.
+publish_no_verify = true
 
 [[package]]
 name = "near-sdk"


### PR DESCRIPTION
## Summary
- Update release-plz action from pinned v0.3.151 to `@0.5` (currently v0.3.157)
- Add `publish_no_verify = true` to `release-plz.toml` and remove `CARGO_BUILD_TARGET` from the workflow

The v5.26.1 release failed due to a gix slotmap bug (fixed in v0.3.156) and couldn't recover on re-run because it didn't recognize already-published crates (fixed in v0.3.155). Updating was blocked because `CARGO_BUILD_TARGET=wasm32-unknown-unknown` caused cargo-binstall to try installing a wasm32 binary of release-plz. Skipping the publish verification build via config removes the need for the env var entirely.