### PR TITLE
fix: allow docsrs cfg to bypass non-wasm compile_error

### DIFF
--- a/near-sdk/src/lib.rs
+++ b/near-sdk/src/lib.rs
@@ -148,7 +148,7 @@ compile_error!(
   - `#[cfg(target_family = "wasm")]`
   - `#[cfg(feature = "non-contract-usage")]` (intended for use of `near-sdk` in non-contract environment)
   - `#[cfg(feature = "unit-testing")]` (intended for use of `near-sdk` as one of `[dev-dependencies]`)
-  - `#[cfg(feature = "__abi-generate")`
+  - `#[cfg(feature = "__abi-generate")]`
   - `#[cfg(test)]`
   - `#[cfg(doctest)]`
   - `#[cfg(docsrs)]` (set by docs.rs when building documentation)

--- a/near-sdk/src/lib.rs
+++ b/near-sdk/src/lib.rs
@@ -131,6 +131,7 @@ extern crate quickcheck;
 #[cfg(not(any(
     test,
     doctest,
+    docsrs,
     clippy,
     target_family = "wasm",
     feature = "unit-testing",
@@ -150,6 +151,7 @@ compile_error!(
   - `#[cfg(feature = "__abi-generate")`
   - `#[cfg(test)]`
   - `#[cfg(doctest)]`
+  - `#[cfg(docsrs)]` (set by docs.rs when building documentation)
   - `#[cfg(clippy)]`
 ⚠️ a cfg, which is not one of the above, results in CURRENT compilation error to be emitted.
 "#


### PR DESCRIPTION
docs.rs sets `--cfg docsrs` when building documentation on a native target, which hits the `compile_error!` meant to block non-wasm builds. This prevents any downstream crate (e.g. near-plugins) from rendering docs on docs.rs.

Adding `docsrs` to the bypass list fixes this. Verified locally that the compile_error fires without the flag and is silent with `RUSTFLAGS="--cfg docsrs"`.