### PR TITLE
use `--cfg near` for contract builds

### DIFF
--- a/.github/workflows/compare_sizes.yml
+++ b/.github/workflows/compare_sizes.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install cargo-near CLI
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.19.1/cargo-near-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.20.2/cargo-near-installer.sh | sh
 
       - name: Build example
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,7 +39,7 @@ jobs:
           cache-all-crates: true
 
       - name: Install cargo-near CLI
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.17.0/cargo-near-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.20.2/cargo-near-installer.sh | sh
 
       - name: Llvm version
         run: llvm-config --version

--- a/.github/workflows/sizes_baseline.yml
+++ b/.github/workflows/sizes_baseline.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install cargo-near CLI
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.19.1/cargo-near-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.20.2/cargo-near-installer.sh | sh
 
       - name: Build example
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,18 +55,20 @@ jobs:
       - name: Print rustc && rustdoc version
         run: rustc --version && rustdoc --version
 
+      # Powerset check across all features for the off-chain / non-NEAR path (cfg(near) not set).
+      - name: Cargo hack check wasm32 powerset (off-chain, no --cfg near)
+        run: cargo hack check -p ${{ matrix.crate }} --target "wasm32-unknown-unknown" --feature-powerset --exclude-features schemars-v0_8,abi,__near-sdk-unit-testing
+      - name: Cargo hack check wasm32 powerset, no dev-deps (off-chain)
+        run: cargo hack check -p ${{ matrix.crate }} --target "wasm32-unknown-unknown" --feature-powerset --exclude-features schemars-v0_8,abi,__near-sdk-unit-testing --no-dev-deps
       - name: Cargo hack check non-wasm32 powerset
         run: cargo hack check -p ${{ matrix.crate }} --feature-powerset --no-dev-deps
 
-      - name: Cargo hack check wasm32 powerset (without sdk)
-        run: cargo hack check -p ${{ matrix.crate }} --target "wasm32-unknown-unknown" --feature-powerset --exclude-features schemars-v0_8,abi,__near-sdk-unit-testing --no-dev-deps
-
-      - name: Cargo hack check wasm32 powerset (for sdk)
-        env: 
+      # Same powerset but with `--cfg near` set — exercises the on-chain host-function path.
+      # cargo-near sets this automatically; we test it here so the contract path doesn't bitrot.
+      - name: Cargo hack check wasm32 powerset (on-chain, --cfg near)
+        env:
           RUSTFLAGS: "-D warnings --cfg near"
-        run: cargo hack check -p ${{ matrix.crate }} --target "wasm32-unknown-unknown" --feature-powerset --exclude-features schemars-v0_8,abi,__near-sdk-unit-testing
-
-
+        run: cargo hack check -p ${{ matrix.crate }} --target "wasm32-unknown-unknown" --feature-powerset --exclude-features schemars-v0_8,abi,__near-sdk-unit-testing --no-dev-deps
 
   test:
     runs-on: ${{ matrix.platform.os }}
@@ -237,7 +239,7 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
         run: |
-          cargo doc -p near-sdk --features unstable,legacy,unit-testing,__macro-docs,__abi-generate
+          cargo doc -p near-sdk --features unstable,legacy,unit-testing,__macro-docs,__abi-generate,deterministic-account-ids
           cargo doc -p near-sdk-macros --features __abi-generate
           cargo doc -p near-contract-standards --no-deps --features abi
           cargo doc -p near-sys

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
           rustup override set ${{ matrix.platform.rs }}
 
       - name: Install cargo-near CLI
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.17.0/cargo-near-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.20.2/cargo-near-installer.sh | sh
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -48,7 +48,7 @@ jobs:
           rustup override set ${{ matrix.toolchain }}
 
       - name: Install cargo-near CLI
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.17.0/cargo-near-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.20.2/cargo-near-installer.sh | sh
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2

--- a/.github/workflows/test_examples_small.yml
+++ b/.github/workflows/test_examples_small.yml
@@ -43,7 +43,7 @@ jobs:
           rustup override set ${{ matrix.toolchain }}
 
       - name: Install cargo-near CLI
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.17.0/cargo-near-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.20.2/cargo-near-installer.sh | sh
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2

--- a/examples/adder/.cargo/config.toml
+++ b/examples/adder/.cargo/config.toml
@@ -1,5 +1,0 @@
-[build]
-rustflags = ["--cfg", "near"]
-
-[target.wasm32-unknown-unknown]
-rustflags = ["-C", "link-arg=-s", "--cfg", "near"]

--- a/examples/callback-results/.cargo/config.toml
+++ b/examples/callback-results/.cargo/config.toml
@@ -1,5 +1,0 @@
-[build]
-rustflags = ["--cfg", "near"]
-
-[target.wasm32-unknown-unknown]
-rustflags = ["-C", "link-arg=-s", "--cfg", "near"]

--- a/examples/cross-contract-calls/.cargo/config.toml
+++ b/examples/cross-contract-calls/.cargo/config.toml
@@ -1,5 +1,0 @@
-[build]
-rustflags = ["--cfg", "near"]
-
-[target.wasm32-unknown-unknown]
-rustflags = ["-C", "link-arg=-s", "--cfg", "near"]

--- a/examples/factory-contract-global/.cargo/config.toml
+++ b/examples/factory-contract-global/.cargo/config.toml
@@ -1,5 +1,0 @@
-[build]
-rustflags = ["--cfg", "near"]
-
-[target.wasm32-unknown-unknown]
-rustflags = ["-C", "link-arg=-s", "--cfg", "near"]

--- a/examples/factory-contract/.cargo/config.toml
+++ b/examples/factory-contract/.cargo/config.toml
@@ -1,5 +1,0 @@
-[build]
-rustflags = ["--cfg", "near"]
-
-[target.wasm32-unknown-unknown]
-rustflags = ["-C", "link-arg=-s", "--cfg", "near"]

--- a/examples/factory-contract/tests/workspaces.rs
+++ b/examples/factory-contract/tests/workspaces.rs
@@ -1,15 +1,10 @@
+use std::str::FromStr;
+
+use near_workspaces::cargo_near_build;
 use near_workspaces::types::{AccountId, NearToken};
 use test_case::test_case;
 
-/// Build the current crate as a wasm contract with `--cfg near` set.
-///
-/// `near_workspaces::compile_project` goes through `cargo_near_build::build_with_cli`,
-/// which hardcodes `RUSTFLAGS="-C link-arg=-s"` (overriding any per-package
-/// `.cargo/config.toml`). Until `cargo-near` ships `--cfg near` injection, we inject it
-/// here so example contracts get the host-function path instead of the pure-Rust fallback.
-async fn build_with_cfg_near(path: &str) -> anyhow::Result<Vec<u8>> {
-    use near_workspaces::cargo_near_build;
-    use std::str::FromStr;
+async fn build_contract(path: &str) -> anyhow::Result<Vec<u8>> {
     let path = path.to_string();
     tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<u8>> {
         let manifest = cargo_near_build::camino::Utf8PathBuf::from_str(&path)
@@ -18,7 +13,6 @@ async fn build_with_cfg_near(path: &str) -> anyhow::Result<Vec<u8>> {
         let artifact = cargo_near_build::build_with_cli(cargo_near_build::BuildOpts {
             no_locked: true,
             manifest_path: Some(manifest),
-            env: vec![("RUSTFLAGS".into(), "-C link-arg=-s --cfg near".into())],
             ..Default::default()
         })
         .map_err(|e| anyhow::anyhow!("cargo near build: {e:?}"))?;
@@ -31,7 +25,7 @@ async fn build_with_cfg_near(path: &str) -> anyhow::Result<Vec<u8>> {
 #[test_case("./low-level")]
 #[tokio::test]
 async fn test_deploy_status_message(contract_path: &str) -> anyhow::Result<()> {
-    let wasm = build_with_cfg_near(contract_path).await?;
+    let wasm = build_contract(contract_path).await?;
     let worker = near_workspaces::sandbox().await?;
     let contract = worker.dev_deploy(&wasm).await?;
 

--- a/examples/fungible-token/.cargo/config.toml
+++ b/examples/fungible-token/.cargo/config.toml
@@ -1,5 +1,0 @@
-[build]
-rustflags = ["--cfg", "near"]
-
-[target.wasm32-unknown-unknown]
-rustflags = ["-C", "link-arg=-s", "--cfg", "near"]

--- a/examples/fungible-token/tests/workspaces.rs
+++ b/examples/fungible-token/tests/workspaces.rs
@@ -27,10 +27,6 @@ fn build_contract(path: &str, contract_name: &str) -> Vec<u8> {
         manifest_path: Some(
             cargo_near_build::camino::Utf8PathBuf::from_str(path).expect("camino PathBuf from str"),
         ),
-        // `cargo near build` hardcodes RUSTFLAGS="-C link-arg=-s", overriding any per-package
-        // .cargo/config.toml. Until cargo-near ships `--cfg near` injection, we set it here,
-        // so example contracts get the host-function path instead of the pure-Rust fallback.
-        env: vec![("RUSTFLAGS".into(), "-C link-arg=-s --cfg near".into())],
         ..Default::default()
     })
     .expect(&format!("building `{}` contract for tests", contract_name));

--- a/examples/lockable-fungible-token/.cargo/config.toml
+++ b/examples/lockable-fungible-token/.cargo/config.toml
@@ -1,5 +1,0 @@
-[build]
-rustflags = ["--cfg", "near"]
-
-[target.wasm32-unknown-unknown]
-rustflags = ["-C", "link-arg=-s", "--cfg", "near"]

--- a/examples/lockable-fungible-token/tests/workspaces.rs
+++ b/examples/lockable-fungible-token/tests/workspaces.rs
@@ -15,10 +15,6 @@ fn build_contract(path: &str, contract_name: &str) -> Vec<u8> {
         manifest_path: Some(
             cargo_near_build::camino::Utf8PathBuf::from_str(path).expect("camino PathBuf from str"),
         ),
-        // `cargo near build` hardcodes RUSTFLAGS="-C link-arg=-s", overriding any per-package
-        // .cargo/config.toml. Until cargo-near ships `--cfg near` injection, we set it here,
-        // so example contracts get the host-function path instead of the pure-Rust fallback.
-        env: vec![("RUSTFLAGS".into(), "-C link-arg=-s --cfg near".into())],
         ..Default::default()
     })
     .expect(&format!("building `{}` contract for tests", contract_name));

--- a/examples/mission-control/.cargo/config.toml
+++ b/examples/mission-control/.cargo/config.toml
@@ -1,5 +1,0 @@
-[build]
-rustflags = ["--cfg", "near"]
-
-[target.wasm32-unknown-unknown]
-rustflags = ["-C", "link-arg=-s", "--cfg", "near"]

--- a/examples/mpc-contract/.cargo/config.toml
+++ b/examples/mpc-contract/.cargo/config.toml
@@ -1,5 +1,0 @@
-[build]
-rustflags = ["--cfg", "near"]
-
-[target.wasm32-unknown-unknown]
-rustflags = ["-C", "link-arg=-s", "--cfg", "near"]

--- a/examples/non-fungible-token/.cargo/config.toml
+++ b/examples/non-fungible-token/.cargo/config.toml
@@ -1,5 +1,0 @@
-[build]
-rustflags = ["--cfg", "near"]
-
-[target.wasm32-unknown-unknown]
-rustflags = ["-C", "link-arg=-s", "--cfg", "near"]

--- a/examples/non-fungible-token/tests/workspaces/utils.rs
+++ b/examples/non-fungible-token/tests/workspaces/utils.rs
@@ -46,10 +46,6 @@ fn build_contract(path: &str, contract_name: &str) -> Vec<u8> {
         manifest_path: Some(
             cargo_near_build::camino::Utf8PathBuf::from_str(path).expect("camino PathBuf from str"),
         ),
-        // `cargo near build` hardcodes RUSTFLAGS="-C link-arg=-s", overriding any per-package
-        // .cargo/config.toml. Until cargo-near ships `--cfg near` injection, we set it here,
-        // so example contracts get the host-function path instead of the pure-Rust fallback.
-        env: vec![("RUSTFLAGS".into(), "-C link-arg=-s --cfg near".into())],
         ..Default::default()
     })
     .expect(&format!("building `{}` contract for tests", contract_name));

--- a/examples/status-message/.cargo/config.toml
+++ b/examples/status-message/.cargo/config.toml
@@ -1,5 +1,0 @@
-[build]
-rustflags = ["--cfg", "near"]
-
-[target.wasm32-unknown-unknown]
-rustflags = ["-C", "link-arg=-s", "--cfg", "near"]

--- a/examples/test-contract/.cargo/config.toml
+++ b/examples/test-contract/.cargo/config.toml
@@ -1,5 +1,0 @@
-[build]
-rustflags = ["--cfg", "near"]
-
-[target.wasm32-unknown-unknown]
-rustflags = ["-C", "link-arg=-s", "--cfg", "near"]

--- a/examples/test-contract/src/lib.rs
+++ b/examples/test-contract/src/lib.rs
@@ -50,13 +50,7 @@ mod tests {
     use near_abi::AbiRoot;
     use near_sdk::serde_json;
 
-    /// Build the current crate as a wasm contract with `--cfg near` set.
-    ///
-    /// `near_workspaces::compile_project` goes through `cargo_near_build::build_with_cli`,
-    /// which hardcodes `RUSTFLAGS="-C link-arg=-s"` (overriding any per-package
-    /// `.cargo/config.toml`). Until `cargo-near` ships `--cfg near` injection, we inject it
-    /// here so example contracts get the host-function path instead of the pure-Rust fallback.
-    async fn build_with_cfg_near(path: &str) -> anyhow::Result<Vec<u8>> {
+    async fn build_contract(path: &str) -> anyhow::Result<Vec<u8>> {
         use near_workspaces::cargo_near_build;
         use std::str::FromStr;
         let path = path.to_string();
@@ -67,7 +61,6 @@ mod tests {
             let artifact = cargo_near_build::build_with_cli(cargo_near_build::BuildOpts {
                 no_locked: true,
                 manifest_path: Some(manifest),
-                env: vec![("RUSTFLAGS".into(), "-C link-arg=-s --cfg near".into())],
                 ..Default::default()
             })
             .map_err(|e| anyhow::anyhow!("cargo near build: {e:?}"))?;
@@ -87,7 +80,7 @@ mod tests {
     // view call
     #[tokio::test]
     async fn embedded_abi_test() -> anyhow::Result<()> {
-        let wasm = build_with_cfg_near("./").await?;
+        let wasm = build_contract("./").await?;
         let worker = near_workspaces::sandbox().await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
@@ -105,7 +98,7 @@ mod tests {
     /// The method should fail with "Method new_private is private".
     #[tokio::test]
     async fn private_init_cannot_be_called_by_external_account() -> anyhow::Result<()> {
-        let wasm = build_with_cfg_near("./").await?;
+        let wasm = build_contract("./").await?;
         let worker = near_workspaces::sandbox().await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
@@ -135,7 +128,7 @@ mod tests {
     /// This simulates the contract calling its own init method (e.g., via a callback).
     #[tokio::test]
     async fn private_init_can_be_called_by_current_account() -> anyhow::Result<()> {
-        let wasm = build_with_cfg_near("./").await?;
+        let wasm = build_contract("./").await?;
         let worker = near_workspaces::sandbox().await?;
         let contract = worker.dev_deploy(&wasm).await?;
 

--- a/examples/versioned/.cargo/config.toml
+++ b/examples/versioned/.cargo/config.toml
@@ -1,5 +1,0 @@
-[build]
-rustflags = ["--cfg", "near"]
-
-[target.wasm32-unknown-unknown]
-rustflags = ["-C", "link-arg=-s", "--cfg", "near"]

--- a/near-global-contracts/Cargo.toml
+++ b/near-global-contracts/Cargo.toml
@@ -7,9 +7,16 @@ categories.workspace = true
 repository.workspace = true
 homepage.workspace = true
 rust-version.workspace = true
+readme = "./README.md"
 description = """
-Global contract identifiers and deterministic account derivation (NEP-616) for the NEAR SDK. 
+Global contract identifiers and deterministic account derivation (NEP-616) for the NEAR SDK.
 """
+
+# Make `derive_account_id` visible on docs.rs (it requires `borsh`; the off-chain sha3
+# backend is pulled in unconditionally on the `cfg(not(near))` path). Including all of
+# serde/borsh/abi here surfaces the full type surface.
+[package.metadata.docs.rs]
+features = ["serde", "borsh", "abi", "near-primitives-interop"]
 
 [dependencies]
 near-account-id = { version = "2.3.0", features = ["internal_unstable"] }

--- a/near-global-contracts/README.md
+++ b/near-global-contracts/README.md
@@ -1,0 +1,64 @@
+# near-global-contracts
+
+[NEP-616](https://github.com/near/NEPs/pull/616) global contract identifiers and
+deterministic account derivation, packaged as a standalone crate so off-chain code
+(indexers, CLIs, services, non-NEAR wasm runtimes) can use the same types and produce
+the same account IDs that on-chain contracts do.
+
+Contract authors using `near-sdk` get these types re-exported under
+`near_sdk::state_init` and do not need to depend on this crate directly.
+
+## Quick start
+
+### Off-chain (indexers, CLIs, etc.)
+
+```toml
+[dependencies]
+near-global-contracts = { version = "0.1", features = ["serde", "borsh"] }
+```
+
+```rust
+use near_global_contracts::{StateInit, StateInitV1, GlobalContractId};
+
+let state_init = StateInit::from(StateInitV1::code(
+    GlobalContractId::AccountId("example.near".parse().unwrap()),
+));
+let account_id = state_init.derive_account_id();
+println!("{account_id}"); // 0s<40 hex chars>
+```
+
+### Inside an on-chain contract (via `cargo-near`)
+
+You don't need to add this crate directly — use `near-sdk` and `cargo-near build`.
+`cargo-near` sets `--cfg near`, which routes hashing through the NEAR host functions.
+
+### Non-NEAR wasm runtimes (e.g. TEE-hosted code)
+
+Same `Cargo.toml` as the off-chain case. Building with `cargo build --target
+wasm32-unknown-unknown` (without `--cfg near`) produces a wasm binary that uses
+pure-Rust hashing and does not import any NEAR host functions. You can verify with
+`cargo tree --target wasm32-unknown-unknown`.
+
+## Features
+
+| Feature                    | Effect                                                                  |
+| -------------------------- | ----------------------------------------------------------------------- |
+| `serde`                    | `Serialize`/`Deserialize` impls                                         |
+| `borsh`                    | `BorshSerialize`/`BorshDeserialize` impls (also enables `derive_account_id`) |
+| `abi`                      | `schemars::JsonSchema` and `borsh::BorshSchema` for ABI tooling         |
+| `arbitrary`                | `arbitrary::Arbitrary` impls for fuzzing                                |
+| `near-primitives-interop`  | `From`/`Into` between these types and the `near-primitives-core` ones   |
+
+`StateInit::derive_account_id` requires the `borsh` feature. Hashing backend is selected
+automatically: on `--cfg near` (set by `cargo-near`) it routes through NEAR host functions
+via `near-env`; otherwise it uses pure-Rust `sha3`, which is pulled in unconditionally on
+the `cfg(not(near))` path.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../LICENSE-APACHE))
+- MIT license ([LICENSE-MIT](../LICENSE-MIT))
+
+at your option.

--- a/near-global-contracts/src/lib.rs
+++ b/near-global-contracts/src/lib.rs
@@ -1,3 +1,50 @@
+//! Global contract identifiers and deterministic account derivation as defined by
+//! [NEP-616](https://github.com/near/NEPs/pull/616).
+//!
+//! ## When to use this crate directly
+//!
+//! - **Off-chain code** (indexers, CLIs, services) that needs to compute the deterministic
+//!   account ID for a given [`StateInit`] without pulling in all of `near-sdk`.
+//! - **Non-NEAR wasm runtimes** (e.g. TEE-hosted code) that want NEP-616 types and derivation
+//!   without any contract-runtime dependencies.
+//!
+//! Contract authors using `near-sdk` get the same types re-exported under
+//! [`near_sdk::state_init`](https://docs.rs/near-sdk/) and do not need to depend on this crate
+//! directly.
+//!
+//! ## Feature flags
+//!
+//! By default this crate exposes only the type definitions. To use
+//! [`StateInit::derive_account_id`] you must enable the `borsh` feature. The hashing
+//! backend is then selected automatically:
+//!
+//! - On-chain contract builds: set `--cfg near` (the `cargo-near` toolchain does this
+//!   automatically). Hashing routes through the `keccak256` host function via `near-env`.
+//! - Off-chain / non-NEAR wasm builds: hashing is performed in pure Rust via [`sha3`],
+//!   pulled in unconditionally on the `cfg(not(near))` path.
+//!
+//! Both paths produce identical output, so you can verify on-chain derivations off-chain.
+//!
+//! Other features:
+//! - `serde`, `borsh` — derive the matching (de)serialization traits.
+//! - `abi` — schema generation for ABI tooling.
+//! - `arbitrary` — `arbitrary::Arbitrary` impls for fuzzing.
+//! - `near-primitives-interop` — `From`/`Into` between this crate's types and the equivalents
+//!   in `near-primitives-core`, for code that bridges to nearcore.
+//!
+//! ## Example: off-chain account ID derivation
+//!
+//! ```ignore
+//! # // Requires the `borsh` feature.
+//! use near_global_contracts::{StateInit, StateInitV1, GlobalContractId};
+//!
+//! let state_init = StateInit::from(StateInitV1::code(
+//!     GlobalContractId::AccountId("example.near".parse().unwrap()),
+//! ));
+//! let account_id = state_init.derive_account_id();
+//! println!("{account_id}"); // 0s<40 hex chars>
+//! ```
+
 #[cfg(all(test, feature = "__near-sdk-unit-testing"))]
 // XXX: `near-sdk` was added in order to enable doctests and tests that require mockchain
 use near_sdk as _;
@@ -6,4 +53,8 @@ mod global_contract_identifier;
 pub use global_contract_identifier::*;
 
 mod state_init;
-pub use state_init::{StateInit, StateInitV1};
+pub use state_init::*;
+
+// Re-export the underlying AccountId so consumers don't have to add `near-account-id` to their
+// Cargo.toml just to spell out the return type of `derive_account_id`.
+pub use near_account_id::AccountId;

--- a/near-global-contracts/src/state_init.rs
+++ b/near-global-contracts/src/state_init.rs
@@ -24,6 +24,19 @@ pub enum StateInit {
 
 impl StateInit {
     /// Derives [`AccountId`](near_account_id::AccountId) deterministically, according to NEP-616.
+    ///
+    /// # Availability
+    ///
+    /// This method is only compiled when:
+    /// - the `borsh` feature is enabled (needed to serialize the input for hashing), AND
+    /// - one of the following is true:
+    ///   - `--cfg near` is set (on-chain contract build; `cargo-near` sets this automatically) —
+    ///     routes through the `keccak256` host function via the `near-env` crate.
+    ///   - the `digest` feature is enabled (off-chain or non-NEAR wasm build) — uses pure-Rust
+    ///     `sha3::Keccak256`.
+    ///
+    /// If you see "no method named `derive_account_id`" on a `StateInit`, add the `digest`
+    /// feature to your `near-global-contracts` dependency.
     #[inline]
     #[cfg(feature = "borsh")]
     pub fn derive_account_id(&self) -> near_account_id::AccountId {

--- a/near-sdk/src/state_init.rs
+++ b/near-sdk/src/state_init.rs
@@ -1,5 +1,13 @@
-//! Deterministic account state initialization types (NEP-616)
+//! Deterministic account state initialization types ([NEP-616](https://github.com/near/NEPs/pull/616)).
 //!
-//! Types are defined in [`near_global_contracts`] and re-exported here for the ease of use.
+//! This module is available when the `deterministic-account-ids` feature is enabled on
+//! `near-sdk`. The underlying types live in the
+//! [`near_global_contracts`](https://docs.rs/near-global-contracts) crate and are re-exported
+//! here for convenience.
+//!
+//! When invoked from inside an on-chain contract (i.e. a build that sets `--cfg near` via
+//! `cargo-near`), `StateInit::derive_account_id` routes through the `keccak256` host
+//! function. Off-chain consumers should depend on `near-global-contracts` directly with the
+//! `digest` feature.
 
 pub use near_global_contracts::{StateInit, StateInitV1};

--- a/near-sdk/tests/store_performance_tests.rs
+++ b/near-sdk/tests/store_performance_tests.rs
@@ -59,13 +59,7 @@ async fn dev_generate(
     Ok((account.into_result()?, collection))
 }
 
-/// Build the current crate as a wasm contract with `--cfg near` set.
-///
-/// `near_workspaces::compile_project` goes through `cargo_near_build::build_with_cli`,
-/// which hardcodes `RUSTFLAGS="-C link-arg=-s"` (overriding any per-package
-/// `.cargo/config.toml`). Until `cargo-near` ships `--cfg near` injection, we inject it
-/// here so example contracts get the host-function path instead of the pure-Rust fallback.
-async fn build_with_cfg_near(path: &str) -> anyhow::Result<Vec<u8>> {
+async fn build_contract(path: &str) -> anyhow::Result<Vec<u8>> {
     use near_workspaces::cargo_near_build;
     use std::str::FromStr;
     let path = path.to_string();
@@ -76,7 +70,6 @@ async fn build_with_cfg_near(path: &str) -> anyhow::Result<Vec<u8>> {
         let artifact = cargo_near_build::build_with_cli(cargo_near_build::BuildOpts {
             no_locked: true,
             manifest_path: Some(manifest),
-            env: vec![("RUSTFLAGS".into(), "-C link-arg=-s --cfg near".into())],
             ..Default::default()
         })
         .map_err(|e| anyhow::anyhow!("cargo near build: {e:?}"))?;
@@ -93,7 +86,7 @@ async fn setup_worker(
         Contract::LazyContract => "./tests/test-contracts/lazy",
     };
     let worker = Arc::new(near_workspaces::sandbox().await?);
-    let wasm = build_with_cfg_near(contract_path).await?;
+    let wasm = build_contract(contract_path).await?;
     let contract = worker.dev_deploy(&wasm).await?;
     let res = contract.call("new").max_gas().transact().await?;
     assert!(res.is_success());

--- a/near-sdk/tests/test-contracts/deny_unknown_arguments/.cargo/config.toml
+++ b/near-sdk/tests/test-contracts/deny_unknown_arguments/.cargo/config.toml
@@ -1,5 +1,0 @@
-[build]
-rustflags = ["--cfg", "near"]
-
-[target.wasm32-unknown-unknown]
-rustflags = ["-C", "link-arg=-s", "--cfg", "near"]

--- a/near-sdk/tests/test-contracts/lazy/.cargo/config.toml
+++ b/near-sdk/tests/test-contracts/lazy/.cargo/config.toml
@@ -1,5 +1,0 @@
-[build]
-rustflags = ["--cfg", "near"]
-
-[target.wasm32-unknown-unknown]
-rustflags = ["-C", "link-arg=-s", "--cfg", "near"]

--- a/near-sdk/tests/test-contracts/store/.cargo/config.toml
+++ b/near-sdk/tests/test-contracts/store/.cargo/config.toml
@@ -1,5 +1,0 @@
-[build]
-rustflags = ["--cfg", "near"]
-
-[target.wasm32-unknown-unknown]
-rustflags = ["-C", "link-arg=-s", "--cfg", "near"]


### PR DESCRIPTION
Switches from a transitive `near-contracts` feature to a `--cfg near` rustc flag. Targeting #1524 as a stacked PR.