### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.28.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.27.0...near-sdk-v5.28.0) - 2026-06-03
+
+### Other
+
+- bump nearcore to 0.36 + declare min_protocol_version=84 (2.12 / protocol 84) ([#1536](https://github.com/near/near-sdk-rs/pull/1536))
+
 ## [5.27.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.26.1...near-sdk-v5.27.0) - 2026-05-26
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.27.0"
+version = "5.28.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 categories = ["wasm"]

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -14,7 +14,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.27.0", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.28.0", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-global-contracts/Cargo.toml
+++ b/near-global-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-global-contracts"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 license.workspace = true
 categories.workspace = true

--- a/near-sdk-core/Cargo.toml
+++ b/near-sdk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sdk-core"
-version = "4.1.0"
+version = "4.1.1"
 authors = ["Near Inc <hello@near.org>"]
 edition.workspace = true
 license.workspace = true

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -23,14 +23,14 @@ required-features = ["abi", "unstable"]
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_with = { version = "3", features = ["base64", "hex", "json"] }
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.27.0" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.28.0" }
 near-sys = { path = "../near-sys", version = "0.2.9" }
 near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.0" }
-near-sdk-core = { path = "../near-sdk-core/", version = "~4.1.0", features = [
+near-sdk-core = { path = "../near-sdk-core/", version = "~4.1.1", features = [
     "serde",
     "borsh",
 ] }
-near-global-contracts = { path = "../near-global-contracts/", version = "~0.1.0", features = [
+near-global-contracts = { path = "../near-global-contracts/", version = "~0.1.1", features = [
     "serde",
     "borsh",
 ] }


### PR DESCRIPTION



## 🤖 New release

* `near-global-contracts`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `near-sdk-core`: 4.1.0 -> 4.1.1 (✓ API compatible changes)
* `near-sdk-macros`: 5.27.0 -> 5.27.1
* `near-sdk`: 5.27.0 -> 5.27.1 (✓ API compatible changes)
* `near-contract-standards`: 5.27.0 -> 5.27.1

<details><summary><i><b>Changelog</b></i></summary><p>




## `near-sdk`

<blockquote>

## [5.27.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.27.0...near-sdk-v5.27.1) - 2026-06-03

### Other

- bump nearcore to 0.36 + declare min_protocol_version=84 (2.12 / protocol 84) ([#1536](https://github.com/near/near-sdk-rs/pull/1536))
</blockquote>

## `near-contract-standards`

<blockquote>

## [5.25.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.24.1...near-contract-standards-v5.25.0) - 2026-03-26

### Added

- add `ext_self()` and document cross-contract call patterns ([#1504](https://github.com/near/near-sdk-rs/pull/1504))

### Other

- update to Rust edition 2024 ([#1480](https://github.com/near/near-sdk-rs/pull/1480))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).