### PR TITLE
ci: drop NEAR_SANDBOX_BIN_PATH workaround now that near-sandbox defaults to 2.12

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,16 +41,6 @@ jobs:
       - name: Install cargo-near CLI
         run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.20.2/cargo-near-installer.sh | sh
 
-      # 2.12 RC: point `near-workspaces` at a PV-84 sandbox so wasm produced by
-      # rustc 1.93 is accepted. See the same step in `test.yml` for the rationale.
-      - name: Download near-sandbox 2.12.0
-        run: |
-          mkdir -p "$HOME/.near-sandbox-2.12.0"
-          curl -sL "https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/Linux-x86_64/2.12.0/near-sandbox.tar.gz" \
-            | tar -xz -C "$HOME/.near-sandbox-2.12.0" --strip-components=1
-          chmod +x "$HOME/.near-sandbox-2.12.0/near-sandbox"
-          echo "NEAR_SANDBOX_BIN_PATH=$HOME/.near-sandbox-2.12.0/near-sandbox" >> "$GITHUB_ENV"
-
       - name: Llvm version
         run: llvm-config --version
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,25 +109,6 @@ jobs:
         with:
           tool: nextest
 
-      # 2.12 RC: nearcore v2.12.0 ships a sandbox built on protocol version 84,
-      # which is what we need to run wasm produced by rustc >= 1.93. The version
-      # baked into `near-sandbox` 0.3.9 is v2.11.0 (PV-83), so we download the RC
-      # binary explicitly and point `near-workspaces` at it via the
-      # `NEAR_SANDBOX_BIN_PATH` env var (honoured by both the build.rs install
-      # step and the runtime binary lookup).
-      - name: Download near-sandbox 2.12.0
-        run: |
-          case "${{ matrix.platform.name }}" in
-            linux) plat=Linux-x86_64 ;;
-            macos) plat=Darwin-arm64 ;;
-            *) echo "unsupported platform"; exit 1 ;;
-          esac
-          mkdir -p "$HOME/.near-sandbox-2.12.0"
-          curl -sL "https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${plat}/2.12.0/near-sandbox.tar.gz" \
-            | tar -xz -C "$HOME/.near-sandbox-2.12.0" --strip-components=1
-          chmod +x "$HOME/.near-sandbox-2.12.0/near-sandbox"
-          echo "NEAR_SANDBOX_BIN_PATH=$HOME/.near-sandbox-2.12.0/near-sandbox" >> "$GITHUB_ENV"
-
       - uses: Swatinem/rust-cache@v2
         with:
           cache-provider: warpbuild

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -55,23 +55,6 @@ jobs:
         with:
           tool: nextest
 
-      # 2.12 RC: contracts built with rustc 1.93 emit bulk-memory/reftypes wasm
-      # that only the PV-84 runtime can deserialize. near-sandbox 0.3.9 still ships
-      # the v2.11.0 (PV-83) binary, so download the 2.12.0 sandbox and point
-      # near-workspaces at it via NEAR_SANDBOX_BIN_PATH.
-      - name: Download near-sandbox 2.12.0
-        run: |
-          case "${{ matrix.platform.name }}" in
-            linux) plat=Linux-x86_64 ;;
-            macos) plat=Darwin-arm64 ;;
-            *) echo "unsupported platform"; exit 1 ;;
-          esac
-          mkdir -p "$HOME/.near-sandbox-2.12.0"
-          curl -sL "https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${plat}/2.12.0/near-sandbox.tar.gz" \
-            | tar -xz -C "$HOME/.near-sandbox-2.12.0" --strip-components=1
-          chmod +x "$HOME/.near-sandbox-2.12.0/near-sandbox"
-          echo "NEAR_SANDBOX_BIN_PATH=$HOME/.near-sandbox-2.12.0/near-sandbox" >> "$GITHUB_ENV"
-
       - uses: Swatinem/rust-cache@v2
         with:
           cache-provider: warpbuild

--- a/.github/workflows/test_examples_small.yml
+++ b/.github/workflows/test_examples_small.yml
@@ -50,23 +50,6 @@ jobs:
         with:
           tool: nextest
 
-      # 2.12 RC: contracts built with rustc 1.93 emit bulk-memory/reftypes wasm
-      # that only the PV-84 runtime can deserialize. near-sandbox 0.3.9 still ships
-      # the v2.11.0 (PV-83) binary, so download the 2.12.0 sandbox and point
-      # near-workspaces at it via NEAR_SANDBOX_BIN_PATH.
-      - name: Download near-sandbox 2.12.0
-        run: |
-          case "${{ matrix.platform.name }}" in
-            linux) plat=Linux-x86_64 ;;
-            macos) plat=Darwin-arm64 ;;
-            *) echo "unsupported platform"; exit 1 ;;
-          esac
-          mkdir -p "$HOME/.near-sandbox-2.12.0"
-          curl -sL "https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${plat}/2.12.0/near-sandbox.tar.gz" \
-            | tar -xz -C "$HOME/.near-sandbox-2.12.0" --strip-components=1
-          chmod +x "$HOME/.near-sandbox-2.12.0/near-sandbox"
-          echo "NEAR_SANDBOX_BIN_PATH=$HOME/.near-sandbox-2.12.0/near-sandbox" >> "$GITHUB_ENV"
-
       - uses: Swatinem/rust-cache@v2
         with:
           cache-provider: warpbuild

--- a/examples/factory-contract-global/tests/workspaces.rs
+++ b/examples/factory-contract-global/tests/workspaces.rs
@@ -9,7 +9,7 @@ const GLOBAL_STORAGE_COST_PER_BYTE: NearToken = STORAGE_DEPOSIT_PER_BYTE.saturat
 async fn test_deploy_global_contract() -> anyhow::Result<()> {
     // Initialize the sandbox environment with specific commit that includes global contract support
     println!("Initializing worker");
-    let worker = near_workspaces::sandbox_with_version("2.7.0").await?;
+    let worker = near_workspaces::sandbox().await?;
 
     println!("Deploying global contract");
 
@@ -57,7 +57,7 @@ async fn test_deploy_global_contract() -> anyhow::Result<()> {
 /// Test using a global contract by hash
 #[tokio::test]
 async fn test_use_global_contract_by_hash() -> anyhow::Result<()> {
-    let worker = near_workspaces::sandbox_with_version("2.7.0").await?;
+    let worker = near_workspaces::sandbox().await?;
     let factory_wasm = near_workspaces::compile_project(".").await?;
     let factory_contract = worker.dev_deploy(&factory_wasm).await?;
 
@@ -102,7 +102,7 @@ async fn test_use_global_contract_by_hash() -> anyhow::Result<()> {
 /// Test using a global contract by account ID
 #[tokio::test]
 async fn test_use_global_contract_by_account() -> anyhow::Result<()> {
-    let worker = near_workspaces::sandbox_with_version("2.7.0").await?;
+    let worker = near_workspaces::sandbox().await?;
     let factory_wasm = near_workspaces::compile_project(".").await?;
     let factory_contract = worker.dev_deploy(&factory_wasm).await?;
 
@@ -139,7 +139,7 @@ async fn test_use_global_contract_by_account() -> anyhow::Result<()> {
 /// Test error cases and edge conditions
 #[tokio::test]
 async fn test_global_contract_edge_cases() -> anyhow::Result<()> {
-    let worker = near_workspaces::sandbox_with_version("2.7.0").await?;
+    let worker = near_workspaces::sandbox().await?;
     let factory_wasm = near_workspaces::compile_project(".").await?;
     let factory_contract = worker.dev_deploy(&factory_wasm).await?;
 


### PR DESCRIPTION
While 2.12 was still an RC, CI manually downloaded the `2.12.0` sandbox tarball and pointed `near-workspaces` at it via `NEAR_SANDBOX_BIN_PATH`, because the `near-sandbox` version we pulled in still defaulted to the 2.11 (PV-83) VM, which can't run wasm produced by rustc 1.93.

That's no longer necessary. `near-sandbox` 0.3.11 is published and its `DEFAULT_NEAR_SANDBOX_VERSION` is now `2.12.0` (protocol 84). `near-workspaces` 0.22.2 (used by our example/integration tests) depends on `near-sandbox ^0.3.9`, which resolves to 0.3.11, so the tests get the 2.12 VM by default — no manual download or env override needed.

This removes the download step and the `NEAR_SANDBOX_BIN_PATH` env from `test.yml`, `coverage.yml`, `test_examples.yml`, and `test_examples_small.yml`. CI-only change; no crate source touched.