### PR TITLE
chore: remove RUSTSEC-2026-0009 audit ignore and update README MSRV to 1.93

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -5,7 +5,4 @@ ignore = [
     "RUSTSEC-2024-0344", # security audit error in ed25519-dalek which is not relevant for near-sdk-rs
     "RUSTSEC-2021-0145", # this needs to be investigated, `atty` has not been updated for 4 years
     "RUSTSEC-2022-0054", # unmaintained, perhaps needs to be replaced
-    # time has a DoS vulnerability (stack exhaustion), fixed in 0.3.47+ which requires Rust 1.88
-    # TODO(#1492): Remove this when rust-toolchain.toml is updated to >= 1.88
-    "RUSTSEC-2026-0009",
 ]

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@
     Previously known as <code>near-bindgen</code>.
   </p>
   <p>
-      Maximum supported Rust version is <strong>1.86.0</strong>
+      Maximum supported Rust version is <strong>1.93.0</strong>
   </p>
 
 
   <p>
     <a href="https://docs.rs/near-sdk"><img src="https://docs.rs/near-sdk/badge.svg?style=flat-square" alt="Reference Documentation" /></a>
-    <a href="https://blog.rust-lang.org/2025/04/03/Rust-1.86.0/"><img src="https://img.shields.io/badge/rustc-1.86-lightgray.svg?style=flat-square" alt="MSRV" /></a>
+    <a href="https://blog.rust-lang.org/2026/01/22/Rust-1.93.0/"><img src="https://img.shields.io/badge/rustc-1.93-lightgray.svg?style=flat-square" alt="MSRV" /></a>
     <a href="https://crates.io/crates/near-sdk"><img src="https://img.shields.io/crates/v/near-sdk.svg?style=flat-square" alt="Crates.io version" /></a>
     <a href="https://crates.io/crates/near-sdk"><img src="https://img.shields.io/crates/d/near-sdk.svg?style=flat-square" alt="Download" /></a>
     <a href="http://near.chat"><img src="https://img.shields.io/discord/490367152054992913?style=flat-square&label=discord&color=lightgreen" alt="Join the community on Discord" /></a>
@@ -329,7 +329,7 @@ State breaking changes (low-level serialization format of any data type) will be
 
 ### MSRV
 
-The minimum supported Rust version is currently `1.86`. There are no guarantees that this will be upheld if a security patch release needs to come in that requires a Rust toolchain increase.
+The minimum supported Rust version is currently `1.93`. There are no guarantees that this will be upheld if a security patch release needs to come in that requires a Rust toolchain increase.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     Previously known as <code>near-bindgen</code>.
   </p>
   <p>
-      Maximum supported Rust version is <strong>1.93.0</strong>
+      Minimum supported Rust version (MSRV) is <strong>1.93.0</strong>
   </p>
 
 


### PR DESCRIPTION
## Context

The workspace MSRV was bumped from 1.86 to 1.93 in #1536. The RUSTSEC-2026-0009 advisory (DoS / stack exhaustion in `time`) was fixed in `time` 0.3.47, which required Rust 1.88. Now that the toolchain is 1.93 and `time` resolves to `0.3.47` in `Cargo.lock`, the advisory fix is in and the audit ignore is no longer needed.

## Changes

- `.cargo/audit.toml`: drop the `RUSTSEC-2026-0009` ignore entry and its two explanatory comment lines. Other ignore entries are untouched.
- `README.md`: update stale MSRV references from 1.86 to 1.93 (header text, rustc badge + Rust 1.93.0 release blog link, and the MSRV section).

Closes #1492