### PR TITLE
chore: drop skip_rust_version_check workarounds now that MSRV is 1.93 / PV 84

### DIFF
--- a/.github/workflows/compare_sizes.yml
+++ b/.github/workflows/compare_sizes.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install cargo-near CLI
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.20.2/cargo-near-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.21.0/cargo-near-installer.sh | sh
 
       - name: Build example
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,7 +39,7 @@ jobs:
           cache-all-crates: true
 
       - name: Install cargo-near CLI
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.20.2/cargo-near-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.21.0/cargo-near-installer.sh | sh
 
       - name: Llvm version
         run: llvm-config --version

--- a/.github/workflows/sizes_baseline.yml
+++ b/.github/workflows/sizes_baseline.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install cargo-near CLI
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.20.2/cargo-near-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.21.0/cargo-near-installer.sh | sh
 
       - name: Build example
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
           rustup override set ${{ matrix.platform.rs }}
 
       - name: Install cargo-near CLI
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.20.2/cargo-near-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.21.0/cargo-near-installer.sh | sh
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -48,7 +48,7 @@ jobs:
           rustup override set ${{ matrix.toolchain }}
 
       - name: Install cargo-near CLI
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.20.2/cargo-near-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.21.0/cargo-near-installer.sh | sh
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2

--- a/.github/workflows/test_examples_small.yml
+++ b/.github/workflows/test_examples_small.yml
@@ -43,7 +43,7 @@ jobs:
           rustup override set ${{ matrix.toolchain }}
 
       - name: Install cargo-near CLI
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.20.2/cargo-near-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.21.0/cargo-near-installer.sh | sh
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2

--- a/examples/factory-contract/high-level/build.rs
+++ b/examples/factory-contract/high-level/build.rs
@@ -14,7 +14,11 @@ fn main() {
     // =================================
     let mut build_opts =
         cargo_near_build::BuildOpts::builder().manifest_path(manifest_path).build();
-    // 2.12 RC: contracts build on rustc 1.93 > the 1.86 declared in Cargo.toml.
+    // cargo-near caps the building rustc based on near-sdk's declared
+    // `package.metadata.near.min_protocol_version`: < 84 (or unset) caps at 1.86
+    // and rejects the bulk-memory opcodes rustc >= 1.87 emits. near-sdk now
+    // declares PV 84, which lifts that cap, so this is no longer required; left
+    // only to keep older near-sdk pins building.
     // The OptsBuilder doesn't expose this, so set the public field directly.
     build_opts.skip_rust_version_check = true;
 

--- a/examples/factory-contract/high-level/build.rs
+++ b/examples/factory-contract/high-level/build.rs
@@ -12,15 +12,8 @@ fn main() {
         .run()
         .expect("no `cargo update` err");
     // =================================
-    let mut build_opts =
+    let build_opts =
         cargo_near_build::BuildOpts::builder().manifest_path(manifest_path).build();
-    // cargo-near caps the building rustc based on near-sdk's declared
-    // `package.metadata.near.min_protocol_version`: < 84 (or unset) caps at 1.86
-    // and rejects the bulk-memory opcodes rustc >= 1.87 emits. near-sdk now
-    // declares PV 84, which lifts that cap, so this is no longer required; left
-    // only to keep older near-sdk pins building.
-    // The OptsBuilder doesn't expose this, so set the public field directly.
-    build_opts.skip_rust_version_check = true;
 
     let extended_build_opts = cargo_near_build::extended::BuildOptsExtended::builder()
         .build_opts(build_opts)

--- a/examples/factory-contract/low-level/build.rs
+++ b/examples/factory-contract/low-level/build.rs
@@ -14,7 +14,11 @@ fn main() {
     // =================================
     let mut build_opts =
         cargo_near_build::BuildOpts::builder().manifest_path(manifest_path).build();
-    // 2.12 RC: contracts build on rustc 1.93 > the 1.86 declared in Cargo.toml.
+    // cargo-near caps the building rustc based on near-sdk's declared
+    // `package.metadata.near.min_protocol_version`: < 84 (or unset) caps at 1.86
+    // and rejects the bulk-memory opcodes rustc >= 1.87 emits. near-sdk now
+    // declares PV 84, which lifts that cap, so this is no longer required; left
+    // only to keep older near-sdk pins building.
     // The OptsBuilder doesn't expose this, so set the public field directly.
     build_opts.skip_rust_version_check = true;
 

--- a/examples/factory-contract/low-level/build.rs
+++ b/examples/factory-contract/low-level/build.rs
@@ -12,15 +12,8 @@ fn main() {
         .run()
         .expect("no `cargo update` err");
     // =================================
-    let mut build_opts =
+    let build_opts =
         cargo_near_build::BuildOpts::builder().manifest_path(manifest_path).build();
-    // cargo-near caps the building rustc based on near-sdk's declared
-    // `package.metadata.near.min_protocol_version`: < 84 (or unset) caps at 1.86
-    // and rejects the bulk-memory opcodes rustc >= 1.87 emits. near-sdk now
-    // declares PV 84, which lifts that cap, so this is no longer required; left
-    // only to keep older near-sdk pins building.
-    // The OptsBuilder doesn't expose this, so set the public field directly.
-    build_opts.skip_rust_version_check = true;
 
     let extended_build_opts = cargo_near_build::extended::BuildOptsExtended::builder()
         .build_opts(build_opts)

--- a/examples/factory-contract/tests/workspaces.rs
+++ b/examples/factory-contract/tests/workspaces.rs
@@ -13,12 +13,6 @@ async fn build_contract(path: &str) -> anyhow::Result<Vec<u8>> {
         let artifact = cargo_near_build::build_with_cli(cargo_near_build::BuildOpts {
             no_locked: true,
             manifest_path: Some(manifest),
-            // cargo-near caps the building rustc based on near-sdk's declared
-            // `package.metadata.near.min_protocol_version`: < 84 (or unset) caps
-            // at 1.86 and rejects the bulk-memory opcodes rustc >= 1.87 emits.
-            // near-sdk now declares PV 84, which lifts that cap, so this is no
-            // longer required; left only to keep older near-sdk pins building.
-            skip_rust_version_check: true,
             ..Default::default()
         })
         .map_err(|e| anyhow::anyhow!("cargo near build: {e:?}"))?;

--- a/examples/factory-contract/tests/workspaces.rs
+++ b/examples/factory-contract/tests/workspaces.rs
@@ -13,8 +13,11 @@ async fn build_contract(path: &str) -> anyhow::Result<Vec<u8>> {
         let artifact = cargo_near_build::build_with_cli(cargo_near_build::BuildOpts {
             no_locked: true,
             manifest_path: Some(manifest),
-            // 2.12 RC: contracts build on rustc 1.93 > the 1.86 declared in
-            // Cargo.toml; cargo-near otherwise refuses wasm built with >= 1.87.
+            // cargo-near caps the building rustc based on near-sdk's declared
+            // `package.metadata.near.min_protocol_version`: < 84 (or unset) caps
+            // at 1.86 and rejects the bulk-memory opcodes rustc >= 1.87 emits.
+            // near-sdk now declares PV 84, which lifts that cap, so this is no
+            // longer required; left only to keep older near-sdk pins building.
             skip_rust_version_check: true,
             ..Default::default()
         })

--- a/examples/fungible-token/tests/workspaces.rs
+++ b/examples/fungible-token/tests/workspaces.rs
@@ -27,7 +27,11 @@ fn build_contract(path: &str, contract_name: &str) -> Vec<u8> {
         manifest_path: Some(
             cargo_near_build::camino::Utf8PathBuf::from_str(path).expect("camino PathBuf from str"),
         ),
-        // 2.12 RC: contracts build on rustc 1.93 > the 1.86 declared in Cargo.toml.
+        // cargo-near caps the building rustc based on near-sdk's declared
+        // `package.metadata.near.min_protocol_version`: < 84 (or unset) caps at
+        // 1.86 and rejects the bulk-memory opcodes rustc >= 1.87 emits. near-sdk
+        // now declares PV 84, which lifts that cap, so this is no longer required;
+        // left only to keep older near-sdk pins building.
         skip_rust_version_check: true,
         ..Default::default()
     })

--- a/examples/fungible-token/tests/workspaces.rs
+++ b/examples/fungible-token/tests/workspaces.rs
@@ -27,12 +27,6 @@ fn build_contract(path: &str, contract_name: &str) -> Vec<u8> {
         manifest_path: Some(
             cargo_near_build::camino::Utf8PathBuf::from_str(path).expect("camino PathBuf from str"),
         ),
-        // cargo-near caps the building rustc based on near-sdk's declared
-        // `package.metadata.near.min_protocol_version`: < 84 (or unset) caps at
-        // 1.86 and rejects the bulk-memory opcodes rustc >= 1.87 emits. near-sdk
-        // now declares PV 84, which lifts that cap, so this is no longer required;
-        // left only to keep older near-sdk pins building.
-        skip_rust_version_check: true,
         ..Default::default()
     })
     .expect(&format!("building `{}` contract for tests", contract_name));

--- a/examples/lockable-fungible-token/tests/workspaces.rs
+++ b/examples/lockable-fungible-token/tests/workspaces.rs
@@ -15,12 +15,6 @@ fn build_contract(path: &str, contract_name: &str) -> Vec<u8> {
         manifest_path: Some(
             cargo_near_build::camino::Utf8PathBuf::from_str(path).expect("camino PathBuf from str"),
         ),
-        // cargo-near caps the building rustc based on near-sdk's declared
-        // `package.metadata.near.min_protocol_version`: < 84 (or unset) caps at
-        // 1.86 and rejects the bulk-memory opcodes rustc >= 1.87 emits. near-sdk
-        // now declares PV 84, which lifts that cap, so this is no longer required;
-        // left only to keep older near-sdk pins building.
-        skip_rust_version_check: true,
         ..Default::default()
     })
     .expect(&format!("building `{}` contract for tests", contract_name));

--- a/examples/lockable-fungible-token/tests/workspaces.rs
+++ b/examples/lockable-fungible-token/tests/workspaces.rs
@@ -15,7 +15,11 @@ fn build_contract(path: &str, contract_name: &str) -> Vec<u8> {
         manifest_path: Some(
             cargo_near_build::camino::Utf8PathBuf::from_str(path).expect("camino PathBuf from str"),
         ),
-        // 2.12 RC: contracts build on rustc 1.93 > the 1.86 declared in Cargo.toml.
+        // cargo-near caps the building rustc based on near-sdk's declared
+        // `package.metadata.near.min_protocol_version`: < 84 (or unset) caps at
+        // 1.86 and rejects the bulk-memory opcodes rustc >= 1.87 emits. near-sdk
+        // now declares PV 84, which lifts that cap, so this is no longer required;
+        // left only to keep older near-sdk pins building.
         skip_rust_version_check: true,
         ..Default::default()
     })

--- a/examples/non-fungible-token/tests/workspaces/utils.rs
+++ b/examples/non-fungible-token/tests/workspaces/utils.rs
@@ -46,7 +46,11 @@ fn build_contract(path: &str, contract_name: &str) -> Vec<u8> {
         manifest_path: Some(
             cargo_near_build::camino::Utf8PathBuf::from_str(path).expect("camino PathBuf from str"),
         ),
-        // 2.12 RC: contracts build on rustc 1.93 > the 1.86 declared in Cargo.toml.
+        // cargo-near caps the building rustc based on near-sdk's declared
+        // `package.metadata.near.min_protocol_version`: < 84 (or unset) caps at
+        // 1.86 and rejects the bulk-memory opcodes rustc >= 1.87 emits. near-sdk
+        // now declares PV 84, which lifts that cap, so this is no longer required;
+        // left only to keep older near-sdk pins building.
         skip_rust_version_check: true,
         ..Default::default()
     })

--- a/examples/non-fungible-token/tests/workspaces/utils.rs
+++ b/examples/non-fungible-token/tests/workspaces/utils.rs
@@ -46,12 +46,6 @@ fn build_contract(path: &str, contract_name: &str) -> Vec<u8> {
         manifest_path: Some(
             cargo_near_build::camino::Utf8PathBuf::from_str(path).expect("camino PathBuf from str"),
         ),
-        // cargo-near caps the building rustc based on near-sdk's declared
-        // `package.metadata.near.min_protocol_version`: < 84 (or unset) caps at
-        // 1.86 and rejects the bulk-memory opcodes rustc >= 1.87 emits. near-sdk
-        // now declares PV 84, which lifts that cap, so this is no longer required;
-        // left only to keep older near-sdk pins building.
-        skip_rust_version_check: true,
         ..Default::default()
     })
     .expect(&format!("building `{}` contract for tests", contract_name));

--- a/examples/test-contract/src/lib.rs
+++ b/examples/test-contract/src/lib.rs
@@ -61,8 +61,11 @@ mod tests {
             let artifact = cargo_near_build::build_with_cli(cargo_near_build::BuildOpts {
                 no_locked: true,
                 manifest_path: Some(manifest),
-                // 2.12 RC: contracts build on rustc 1.93 > the 1.86 declared in
-                // Cargo.toml; cargo-near otherwise refuses wasm built with >= 1.87.
+                // cargo-near caps the building rustc based on near-sdk's declared
+                // `package.metadata.near.min_protocol_version`: < 84 (or unset) caps
+                // at 1.86 and rejects the bulk-memory opcodes rustc >= 1.87 emits.
+                // near-sdk now declares PV 84, which lifts that cap, so this is no
+                // longer required; left only to keep older near-sdk pins building.
                 skip_rust_version_check: true,
                 ..Default::default()
             })

--- a/examples/test-contract/src/lib.rs
+++ b/examples/test-contract/src/lib.rs
@@ -61,12 +61,6 @@ mod tests {
             let artifact = cargo_near_build::build_with_cli(cargo_near_build::BuildOpts {
                 no_locked: true,
                 manifest_path: Some(manifest),
-                // cargo-near caps the building rustc based on near-sdk's declared
-                // `package.metadata.near.min_protocol_version`: < 84 (or unset) caps
-                // at 1.86 and rejects the bulk-memory opcodes rustc >= 1.87 emits.
-                // near-sdk now declares PV 84, which lifts that cap, so this is no
-                // longer required; left only to keep older near-sdk pins building.
-                skip_rust_version_check: true,
                 ..Default::default()
             })
             .map_err(|e| anyhow::anyhow!("cargo near build: {e:?}"))?;

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -80,7 +80,7 @@ rand_chacha = "0.3.1"
 near-rng = "0.1.1"
 near-abi = { version = "0.4.0", features = ["__chunked-entries"] }
 symbolic-debuginfo = "12"
-near-workspaces = { version = "0.22", features = ["unstable"] }
+near-workspaces = { version = "0.22.2", features = ["unstable"] }
 anyhow = "1.0"
 tokio = { version = "1", features = ["full"] }
 strum = "0.25.0"

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -81,6 +81,14 @@ near-rng = "0.1.1"
 near-abi = { version = "0.4.0", features = ["__chunked-entries"] }
 symbolic-debuginfo = "12"
 near-workspaces = { version = "0.22.2", features = ["unstable"] }
+# near-workspaces 0.22.2 requires near-primitives ^0.36, but its transitive
+# near-jsonrpc-client ^0.21 only moves to near-primitives ^0.36 in 0.21.1 (which
+# needs rustc 1.93). The MSRV-aware resolver targets the workspace floor (1.88,
+# declared by near-crypto-hash/near-global-contracts) and would otherwise pick
+# near-jsonrpc-client 0.21.0 (^0.35), splitting near-primitives across 0.35/0.36
+# and failing to compile near-workspaces. Pin >= 0.21.1 to keep the whole graph
+# on near-primitives 0.36.
+near-jsonrpc-client = "0.21.1"
 anyhow = "1.0"
 tokio = { version = "1", features = ["full"] }
 strum = "0.25.0"

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -80,15 +80,7 @@ rand_chacha = "0.3.1"
 near-rng = "0.1.1"
 near-abi = { version = "0.4.0", features = ["__chunked-entries"] }
 symbolic-debuginfo = "12"
-near-workspaces = { version = "0.22.2", features = ["unstable"] }
-# near-workspaces 0.22.2 requires near-primitives ^0.36, but its transitive
-# near-jsonrpc-client ^0.21 only moves to near-primitives ^0.36 in 0.21.1 (which
-# needs rustc 1.93). The MSRV-aware resolver targets the workspace floor (1.88,
-# declared by near-crypto-hash/near-global-contracts) and would otherwise pick
-# near-jsonrpc-client 0.21.0 (^0.35), splitting near-primitives across 0.35/0.36
-# and failing to compile near-workspaces. Pin >= 0.21.1 to keep the whole graph
-# on near-primitives 0.36.
-near-jsonrpc-client = "0.21.1"
+near-workspaces = { version = "0.22.4", features = ["unstable"] }
 anyhow = "1.0"
 tokio = { version = "1", features = ["full"] }
 strum = "0.25.0"

--- a/near-sdk/tests/common/mod.rs
+++ b/near-sdk/tests/common/mod.rs
@@ -2,7 +2,7 @@
 //! artifact for `tests/test-contracts/*`.
 //!
 //! Builds the wasm through `near_workspaces::compile_project`, which shells out
-//! to `cargo near build`. near-workspaces >= 0.22.2 (the dev-dependency floor)
+//! to `cargo near build`. near-workspaces >= 0.22.4 (the dev-dependency floor)
 //! makes `compile_project` pass `skip_rust_version_check` internally, and near-sdk
 //! declares `package.metadata.near.min_protocol_version = 84` (which lifts
 //! cargo-near's rustc cap), so building these contracts with current toolchains

--- a/near-sdk/tests/common/mod.rs
+++ b/near-sdk/tests/common/mod.rs
@@ -1,53 +1,20 @@
 //! Shared helpers for integration tests that need a sandbox-deployable wasm
 //! artifact for `tests/test-contracts/*`.
 //!
-//! Builds the wasm directly with `cargo build` instead of going through
-//! `near-workspaces::compile_project` / `cargo near build`.
-//!
-//! Historical context: this bypass was added during the 2.12-RC bump because
-//! `cargo near build` (the path `compile_project` takes) capped the building
-//! rustc based on near-sdk's declared `package.metadata.near.min_protocol_version`
-//! — when that was < 84 (or unset) it rejected the bulk-memory opcodes rustc
-//! >= 1.87 emits, and `compile_project` did not expose `skip_rust_version_check`.
-//! A plain `cargo build --target wasm32-unknown-unknown --release` produces the
-//! same `.wasm` we ultimately deploy — we just lose the ABI embedding step,
-//! which none of the sandbox tests in this directory care about.
-//!
-//! Both halves of that are now resolved: near-sdk declares PV 84 (no rustc cap),
-//! and near-workspaces 0.22.2 `compile_project` passes `skip_rust_version_check`
-//! internally anyway — so this helper can be replaced with
-//! `near_workspaces::compile_project(...)`.
+//! Builds the wasm through `near_workspaces::compile_project`, which shells out
+//! to `cargo near build`. near-workspaces 0.22.2's `compile_project` passes
+//! `skip_rust_version_check` internally, and near-sdk declares
+//! `package.metadata.near.min_protocol_version = 84` (which lifts cargo-near's
+//! rustc cap), so building these contracts with current toolchains works without
+//! any bypass.
 
 #![allow(dead_code)]
 
-use std::path::PathBuf;
-
 /// Builds the wasm artifact for `tests/test-contracts/<name>/` and returns its bytes.
-pub fn build_test_contract(name: &str) -> anyhow::Result<Vec<u8>> {
+pub async fn build_test_contract(name: &str) -> anyhow::Result<Vec<u8>> {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    let project_dir: PathBuf = [manifest_dir, "tests", "test-contracts", name].iter().collect();
-    let manifest_path = project_dir.join("Cargo.toml");
-
-    let status = std::process::Command::new(env!("CARGO"))
-        .args(["build", "--release", "--target", "wasm32-unknown-unknown", "--manifest-path"])
-        .arg(&manifest_path)
-        // Wipe inherited cargo flags that would otherwise be propagated from the
-        // parent invocation (in particular `--target` and any flags that imply
-        // host artifacts) — `cargo build` in a wasm context needs a clean slate.
-        .env_remove("CARGO_BUILD_TARGET")
-        .env_remove("CARGO_ENCODED_RUSTFLAGS")
-        .env_remove("RUSTFLAGS")
-        .status()?;
-    if !status.success() {
-        anyhow::bail!("cargo build for test-contract `{name}` failed with {status}");
-    }
-
-    let wasm_path = project_dir
-        .join("target")
-        .join("wasm32-unknown-unknown")
-        .join("release")
-        .join(format!("{}.wasm", name.replace('-', "_")));
-    let wasm = std::fs::read(&wasm_path)
-        .map_err(|e| anyhow::anyhow!("failed to read wasm at {}: {e}", wasm_path.display()))?;
-    Ok(wasm)
+    let project_dir = format!("{manifest_dir}/tests/test-contracts/{name}");
+    near_workspaces::compile_project(&project_dir)
+        .await
+        .map_err(|e| anyhow::anyhow!("compiling test-contract `{name}`: {e}"))
 }

--- a/near-sdk/tests/common/mod.rs
+++ b/near-sdk/tests/common/mod.rs
@@ -2,19 +2,21 @@
 //! artifact for `tests/test-contracts/*`.
 //!
 //! Builds the wasm directly with `cargo build` instead of going through
-//! `near-workspaces::compile_project` / `cargo near build`. This bypasses two
-//! problems that block sandbox-backed integration tests after the 2.12-RC bump:
+//! `near-workspaces::compile_project` / `cargo near build`.
 //!
-//! 1. `cargo near build` (the path `compile_project` takes) hard-refuses to
-//!    build contracts with rustc >= 1.87 unless `--skip-rust-version-check` is
-//!    passed, and the `compile_project` API does not expose that knob.
-//! 2. A plain `cargo build --target wasm32-unknown-unknown --release` produces
-//!    the same `.wasm` we ultimately deploy — we just lose the ABI embedding
-//!    step, which none of the sandbox tests in this directory care about.
+//! Historical context: this bypass was added during the 2.12-RC bump because
+//! `cargo near build` (the path `compile_project` takes) capped the building
+//! rustc based on near-sdk's declared `package.metadata.near.min_protocol_version`
+//! — when that was < 84 (or unset) it rejected the bulk-memory opcodes rustc
+//! >= 1.87 emits, and `compile_project` did not expose `skip_rust_version_check`.
+//! A plain `cargo build --target wasm32-unknown-unknown --release` produces the
+//! same `.wasm` we ultimately deploy — we just lose the ABI embedding step,
+//! which none of the sandbox tests in this directory care about.
 //!
-//! Once `near-workspaces` exposes a `skip_rust_version_check` option (or
-//! `cargo-near` itself relaxes the check for >=1.93), this helper can be
-//! replaced with `near_workspaces::compile_project(...)` again.
+//! Both halves of that are now resolved: near-sdk declares PV 84 (no rustc cap),
+//! and near-workspaces 0.22.2 `compile_project` passes `skip_rust_version_check`
+//! internally anyway — so this helper can be replaced with
+//! `near_workspaces::compile_project(...)`.
 
 #![allow(dead_code)]
 

--- a/near-sdk/tests/common/mod.rs
+++ b/near-sdk/tests/common/mod.rs
@@ -2,11 +2,11 @@
 //! artifact for `tests/test-contracts/*`.
 //!
 //! Builds the wasm through `near_workspaces::compile_project`, which shells out
-//! to `cargo near build`. near-workspaces 0.22.2's `compile_project` passes
-//! `skip_rust_version_check` internally, and near-sdk declares
-//! `package.metadata.near.min_protocol_version = 84` (which lifts cargo-near's
-//! rustc cap), so building these contracts with current toolchains works without
-//! any bypass.
+//! to `cargo near build`. near-workspaces >= 0.22.2 (the dev-dependency floor)
+//! makes `compile_project` pass `skip_rust_version_check` internally, and near-sdk
+//! declares `package.metadata.near.min_protocol_version = 84` (which lifts
+//! cargo-near's rustc cap), so building these contracts with current toolchains
+//! works without any bypass.
 
 #![allow(dead_code)]
 

--- a/near-sdk/tests/deny_unknown_arguments_tests.rs
+++ b/near-sdk/tests/deny_unknown_arguments_tests.rs
@@ -6,7 +6,7 @@ mod common;
 
 #[tokio::test]
 async fn test_contract_is_operational() -> Result<(), Box<dyn std::error::Error>> {
-    let contract_wasm = common::build_test_contract("deny_unknown_arguments")?;
+    let contract_wasm = common::build_test_contract("deny_unknown_arguments").await?;
     let sandbox = near_workspaces::sandbox().await?;
 
     // Create basic accounts and deploy main contract

--- a/near-sdk/tests/store_performance_tests.rs
+++ b/near-sdk/tests/store_performance_tests.rs
@@ -70,7 +70,7 @@ async fn setup_worker(
         Contract::LazyContract => "lazy",
     };
     let worker = Arc::new(near_workspaces::sandbox().await?);
-    let wasm = common::build_test_contract(contract_name)?;
+    let wasm = common::build_test_contract(contract_name).await?;
     let contract = worker.dev_deploy(&wasm).await?;
     let res = contract.call("new").max_gas().transact().await?;
     assert!(res.is_success());


### PR DESCRIPTION
## Summary

Removes the `skip_rust_version_check` workarounds added during the nearcore 2.12 / MSRV-bump transition (#1536). Both reasons they existed are now gone:

- **cargo-near's rustc ceiling** only applies when near-sdk declares `min_protocol_version < 84`. This repo now declares `min_protocol_version = 84` (#1536), so there's no ceiling and the flags are redundant.
- **old sandbox rejecting rustc 1.87+ wasm** was resolved by #1546 (sandbox defaults to 2.12).

## Changes

1. **Fix stale comments** — they claimed cargo-near compares against the contract's own `rust-version`; it actually caps rustc via near-sdk's `min_protocol_version`. Comment-only.
2. **Drop the workarounds** — removes `skip_rust_version_check` from all 7 example sites, and replaces the `cargo build` bypass in `near-sdk/tests/common/mod.rs` with `near_workspaces::compile_project` (passes the skip internally). The dev-dependency floor is raised to `near-workspaces 0.22.4` so that behavior is guaranteed. `build_test_contract` becomes async.
3. **Bump cargo-near CLI 0.20.2 → 0.21.0** across every workflow that installs it — 0.20.2 bundles cargo-near-build 0.11.2 (still has the unconditional 1.86 ceiling); the PV-84-aware check ships in 0.11.3 (bundled by 0.21.0). `test.yml` is bumped too: its core job already passes via near-workspaces' internal skip, so the bump there is purely to keep every workflow on a single cargo-near version.
4. **Bump `near-workspaces` dev-dependency `0.22.2 → 0.22.4`** — unrelated to the workaround removal, but required to keep CI green. `near-workspaces 0.22.2`/`0.22.3` need `near-primitives ^0.36` but left `near-jsonrpc-client` at the loose `^0.21`; on this repo's 1.88 MSRV floor (declared by `near-crypto-hash` / `near-global-contracts`), resolver-v3 downgrades to `near-jsonrpc-client 0.21.0` (`^0.35`), splitting `near-primitives` across 0.35/0.36 and failing to compile `near-workspaces`. Fixed upstream in [near-workspaces 0.22.4](https://github.com/near/near-workspaces-rs/pull/450), which requires `near-jsonrpc-client ^0.21.1` — so a fresh resolve now stays on a single `near-primitives 0.36` with no downstream pin needed.
