### PR TITLE
fix(near-sys): declare host function imports from the "env" wasm module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,6 +125,37 @@ jobs:
       - name: Run doctests
         run: cargo test --all ${{ matrix.features }} --doc
 
+  # Regression guard: the rest of CI only `cargo check`s for wasm32, which never
+  # invokes the linker. A toolchain change can therefore break contract *linking*
+  # (e.g. rustc 1.96 dropping wasm-ld `--allow-undefined`) without any CI signal.
+  # This job link-builds a real example contract on stable so such breakage surfaces.
+  wasm-link:
+    name: Example contract links on stable
+    runs-on: warp-ubuntu-latest-x64-4x
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable with wasm32 target
+        run: |
+          rustup toolchain install stable --profile minimal --target wasm32-unknown-unknown
+          rustup override set stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-provider: warpbuild
+          shared-key: "linux-stable-wasm-link"
+          cache-all-crates: true
+
+      - name: Print rustc version
+        run: rustc --version
+
+      # `examples/` is excluded from the workspace, so build from within the example.
+      # Use `rustup run stable` so a future rust-toolchain.toml pin can't silently
+      # downgrade this job off stable and defeat the regression guard.
+      - name: Build adder example for wasm32 (release)
+        working-directory: examples/adder
+        run: rustup run stable cargo build --target wasm32-unknown-unknown --release
+
   lint:
     name: Clippy and fmt
     runs-on: warp-ubuntu-latest-x64-4x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,12 +149,18 @@ jobs:
       - name: Print rustc version
         run: rustc --version
 
+      - name: Install latest cargo-near CLI
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/latest/download/cargo-near-installer.sh | sh
+
       # `examples/` is excluded from the workspace, so build from within the example.
-      # Use `rustup run stable` so a future rust-toolchain.toml pin can't silently
-      # downgrade this job off stable and defeat the regression guard.
-      - name: Build adder example for wasm32 (release)
+      # Build through cargo-near (the canonical user path: build + ABI generation +
+      # metadata-driven toolchain gating) so this job guards both raw-toolchain linker
+      # breakage and the cargo-near pipeline on current stable. Use `rustup run stable`
+      # so a future rust-toolchain.toml pin can't silently downgrade this job off stable
+      # and defeat the regression guard.
+      - name: Build adder example with cargo-near on stable
         working-directory: examples/adder
-        run: rustup run stable cargo build --target wasm32-unknown-unknown --release
+        run: rustup run stable cargo near build non-reproducible-wasm
 
   lint:
     name: Clippy and fmt

--- a/near-sys/src/lib.rs
+++ b/near-sys/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 
+#[cfg_attr(target_arch = "wasm32", link(wasm_import_module = "env"))]
 unsafe extern "C" {
     // #############
     // # Registers #


### PR DESCRIPTION
Rust 1.96.0 removed wasm-ld's `--allow-undefined` for `wasm32-unknown-unknown` ([announcement](https://blog.rust-lang.org/2026/04/04/changes-to-webassembly-targets-and-handling-undefined-symbols/)), so bare `extern "C"` declarations no longer become implicit `env` imports — every near-sdk contract fails to link on 1.96 with `rust-lld: error: undefined symbol: storage_read` (and every other host function).

Fix: annotate near-sys's host-function block with `#[link(wasm_import_module = "env")]` (gated to wasm32). Verified on rustc 1.93–1.96; the resulting wasm imports all host functions from `env` as before.

Also adds a `wasm-link` CI job that builds `examples/adder` with cargo-near on current stable, since nothing in CI previously link-built a contract — this class of breakage was invisible.