### PR TITLE
chore: release v5.28.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.28.2](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.28.1...near-sdk-v5.28.2) - 2026-06-17
+
+### Other
+
+- remove RUSTSEC-2026-0009 audit ignore and update README MSRV to 1.93 ([#1547](https://github.com/near/near-sdk-rs/pull/1547))
+
 ## [5.28.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.28.0...near-sdk-v5.28.1) - 2026-06-09
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.28.1"
+version = "5.28.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 categories = ["wasm"]

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -14,7 +14,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.28.1", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.28.2", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -23,7 +23,7 @@ required-features = ["abi", "unstable"]
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_with = { version = "3", features = ["base64", "hex", "json"] }
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.28.1" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.28.2" }
 near-sys = { path = "../near-sys", version = "0.2.10" }
 near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.1" }
 near-sdk-core = { path = "../near-sdk-core/", version = "~4.1.2", features = [


### PR DESCRIPTION



## 🤖 New release

* `near-sdk-macros`: 5.28.1 -> 5.28.2
* `near-sdk`: 5.28.1 -> 5.28.2 (✓ API compatible changes)
* `near-contract-standards`: 5.28.1 -> 5.28.2

<details><summary><i><b>Changelog</b></i></summary><p>


## `near-sdk`

<blockquote>

## [5.28.2](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.28.1...near-sdk-v5.28.2) - 2026-06-17

### Other

- remove RUSTSEC-2026-0009 audit ignore and update README MSRV to 1.93 ([#1547](https://github.com/near/near-sdk-rs/pull/1547))
</blockquote>

## `near-contract-standards`

<blockquote>

## [5.25.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.24.1...near-contract-standards-v5.25.0) - 2026-03-26

### Added

- add `ext_self()` and document cross-contract call patterns ([#1504](https://github.com/near/near-sdk-rs/pull/1504))

### Other

- update to Rust edition 2024 ([#1480](https://github.com/near/near-sdk-rs/pull/1480))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).