### PR TITLE
ci: also test near-sdk on latest stable Rust

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,7 @@ jobs:
           - os: warp-macos-latest-arm64-6x
             rs: "1.93.0"
             name: macos
-          # Floating `stable` (linux only): blocking, moving-target coverage so the
-          # feature-powerset checks also surface breakage on current Rust. See the
-          # matching note in the `test` job for why we accept the surprise-red cost.
+          # Floating `stable` (linux): blocking coverage against current Rust. See the `test` job note.
           - os: warp-ubuntu-latest-x64-4x
             rs: "stable"
             name: linux
@@ -89,10 +87,9 @@ jobs:
           - os: warp-macos-latest-arm64-6x
             rs: "1.93.0"
             name: macos
-          # Floating `stable`: a moving target on purpose. This is a blocking gate,
-          # so a new Rust release can turn CI red on an unrelated PR — that's the
-          # cost we accept to *guarantee* near-sdk builds on whatever Rust users
-          # actually have installed, rather than only the version we pinned.
+          # Floating `stable` (linux): a blocking gate, so a new Rust release can turn CI
+          # red on an unrelated PR. Deliberate — guarantees near-sdk builds on whatever
+          # Rust users have, not just the pinned version.
           - os: warp-ubuntu-latest-x64-4x
             rs: "stable"
             name: linux
@@ -131,12 +128,9 @@ jobs:
       - name: Print rustc && rustdoc version
         run: rustc --version && rustdoc --version
 
-      # The gas-budget assertions in `store_performance_tests` are toolchain-specific:
-      # they guard the gas a contract burns when built with the *production-pinned*
-      # toolchain (1.93, what cargo-near uses). On the floating `stable` job the gas
-      # number drifts with each rustc codegen change, so we skip that one binary there
-      # rather than weaken the shared threshold. Stable still verifies the suite
-      # compiles, links, and passes functionally.
+      # `store_performance_tests` asserts gas budgets tied to the pinned 1.93 toolchain;
+      # the numbers drift with rustc codegen, so skip it on stable rather than loosen
+      # the shared threshold. Stable still checks the suite compiles, links, and passes.
       - name: Run tests with nextest
         run: |
           if [ "${{ matrix.platform.rs }}" = "stable" ]; then
@@ -149,10 +143,9 @@ jobs:
       - name: Run doctests
         run: cargo test --all ${{ matrix.features }} --doc
 
-  # Regression guard: the rest of CI only `cargo check`s for wasm32, which never
-  # invokes the linker. A toolchain change can therefore break contract *linking*
-  # (e.g. rustc 1.96 dropping wasm-ld `--allow-undefined`) without any CI signal.
-  # This job link-builds a real example contract on stable so such breakage surfaces.
+  # Regression guard: the rest of CI only `cargo check`s wasm32, never linking. A
+  # toolchain change can break contract linking (e.g. 1.96 dropping wasm-ld
+  # `--allow-undefined`) unnoticed, so link-build a real contract on stable.
   wasm-link:
     name: Example contract links on stable
     runs-on: warp-ubuntu-latest-x64-4x
@@ -176,12 +169,9 @@ jobs:
       - name: Install latest cargo-near CLI
         run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/latest/download/cargo-near-installer.sh | sh
 
-      # `examples/` is excluded from the workspace, so build from within the example.
-      # Build through cargo-near (the canonical user path: build + ABI generation +
-      # metadata-driven toolchain gating) so this job guards both raw-toolchain linker
-      # breakage and the cargo-near pipeline on current stable. Use `rustup run stable`
-      # so a future rust-toolchain.toml pin can't silently downgrade this job off stable
-      # and defeat the regression guard.
+      # `examples/` is outside the workspace, so build from within it. Go through
+      # cargo-near (the canonical user path) via `rustup run stable` so a future
+      # rust-toolchain.toml pin can't silently downgrade this job off stable.
       - name: Build adder example with cargo-near on stable
         working-directory: examples/adder
         run: rustup run stable cargo near build non-reproducible-wasm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,8 +131,19 @@ jobs:
       - name: Print rustc && rustdoc version
         run: rustc --version && rustdoc --version
 
+      # The gas-budget assertions in `store_performance_tests` are toolchain-specific:
+      # they guard the gas a contract burns when built with the *production-pinned*
+      # toolchain (1.93, what cargo-near uses). On the floating `stable` job the gas
+      # number drifts with each rustc codegen change, so we skip that one binary there
+      # rather than weaken the shared threshold. Stable still verifies the suite
+      # compiles, links, and passes functionally.
       - name: Run tests with nextest
-        run: cargo nextest run --all ${{ matrix.features }} --profile ci
+        run: |
+          if [ "${{ matrix.platform.rs }}" = "stable" ]; then
+            cargo nextest run --all ${{ matrix.features }} --profile ci -E 'not binary(store_performance_tests)'
+          else
+            cargo nextest run --all ${{ matrix.features }} --profile ci
+          fi
 
       # Run doctests separately (nextest doesn't support doctests yet)
       - name: Run doctests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,12 @@ jobs:
           - os: warp-macos-latest-arm64-6x
             rs: "1.93.0"
             name: macos
+          # Floating `stable` (linux only): blocking, moving-target coverage so the
+          # feature-powerset checks also surface breakage on current Rust. See the
+          # matching note in the `test` job for why we accept the surprise-red cost.
+          - os: warp-ubuntu-latest-x64-4x
+            rs: "stable"
+            name: linux
     steps:
       - uses: actions/checkout@v4
 
@@ -83,6 +89,13 @@ jobs:
           - os: warp-macos-latest-arm64-6x
             rs: "1.93.0"
             name: macos
+          # Floating `stable`: a moving target on purpose. This is a blocking gate,
+          # so a new Rust release can turn CI red on an unrelated PR — that's the
+          # cost we accept to *guarantee* near-sdk builds on whatever Rust users
+          # actually have installed, rather than only the version we pinned.
+          - os: warp-ubuntu-latest-x64-4x
+            rs: "stable"
+            name: linux
         features:
           - ""
           - "--features unstable,legacy,__abi-generate,deterministic-account-ids"


### PR DESCRIPTION
## What

Adds a floating `stable` Linux entry to the `test` and `cargo-hack` matrices, so near-sdk runs against the latest stable Rust alongside the pinned 1.93.

## Why

Every job pins 1.93, so new Rust releases have repeatedly broken downstream consumers (near-plugins, near-sys, near-workspaces) before near-sdk's CI noticed — e.g. 1.96 dropping wasm-ld's `--allow-undefined`. A latest-stable job catches this proactively instead of waiting for downstream to get blocked.

## Tradeoff

`stable` is a moving target and these gates are blocking, so a new Rust release can turn CI red on an unrelated PR. That's deliberate: pinning only guarantees the version we remembered to pin, while floating `stable` guarantees near-sdk builds on whatever Rust users actually have.

## Notes

- Linux only; other jobs (clippy, `compilation`, `windows`, `audit`) still pin 1.93.
- `store_performance_tests` is skipped on `stable` — its gas-budget assertions are tied to the production-pinned toolchain and drift with codegen. Stable still verifies the suite compiles, links, and passes functionally.
