### PR TITLE
fix: two lint failures on newer Rust / wasm32 builds

### DIFF
--- a/near-sdk-macros/src/core_impl/code_generator/impl_item_method_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/impl_item_method_info.rs
@@ -432,11 +432,21 @@ impl ImplItemMethodInfo {
     }
 
     fn non_bindgen_attrs_tokens(&self) -> TokenStream2 {
-        self.attr_signature_info.non_bindgen_attrs.iter().fold(TokenStream2::new(), |acc, value| {
-            quote! {
-                #acc
-                #value
-            }
-        })
+        self.attr_signature_info
+            .non_bindgen_attrs
+            .iter()
+            // `#[inline]` (and its `always`/`never` variants) is ignored by rustc on the
+            // generated `#[no_mangle] extern "C"` wrapper and triggers the
+            // `unused_attributes` lint ("`#[inline]` is ignored on externally exported
+            // functions") when the contract is built for wasm32. The attribute is still
+            // forwarded to the original method, where it has its intended effect, so it is
+            // safe to drop it here.
+            .filter(|attr| !attr.path().is_ident("inline"))
+            .fold(TokenStream2::new(), |acc, value| {
+                quote! {
+                    #acc
+                    #value
+                }
+            })
     }
 }

--- a/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
@@ -51,6 +51,41 @@ mod tests {
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
 
+    /// `#[inline]` is meaningless on the generated `#[no_mangle] extern "C"` wrapper and
+    /// triggers the `unused_attributes` lint on wasm32 builds, so it must not be forwarded.
+    #[test]
+    fn inline_not_forwarded_to_wrapper() {
+        let impl_type: Type = syn::parse_str("Hello").unwrap();
+        let mut method: ImplItemFn = parse_quote! {
+            #[inline]
+            pub fn method(&self) { }
+        };
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
+        let actual = method_info.method_wrapper();
+        let generated = pretty_print_syn_str(&actual).unwrap();
+        assert!(
+            !generated.contains("inline"),
+            "`#[inline]` must not be forwarded to the exported wrapper, got:\n{generated}"
+        );
+    }
+
+    /// `#[inline(always)]` / `#[inline(never)]` must be dropped from the wrapper too.
+    #[test]
+    fn inline_variants_not_forwarded_to_wrapper() {
+        let impl_type: Type = syn::parse_str("Hello").unwrap();
+        let mut method: ImplItemFn = parse_quote! {
+            #[inline(always)]
+            pub fn method(&self) { }
+        };
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
+        let actual = method_info.method_wrapper();
+        let generated = pretty_print_syn_str(&actual).unwrap();
+        assert!(
+            !generated.contains("inline"),
+            "`#[inline(always)]` must not be forwarded to the exported wrapper, got:\n{generated}"
+        );
+    }
+
     #[test]
     fn owned_no_args_no_return_no_mut() {
         let impl_type: Type = syn::parse_str("Hello").unwrap();

--- a/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs
@@ -28,7 +28,7 @@ impl ItemImplInfo {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use syn::{parse_quote, parse_str, ImplItemFn, Type};
+    use syn::{parse_quote, parse_str, Attribute, ImplItemFn, ItemFn, Type};
     use crate::core_impl::info_extractor::ImplItemMethodInfo;
     use crate::core_impl::utils::test_helpers::{local_insta_assert_snapshot, pretty_print_syn_str};
 
@@ -51,39 +51,41 @@ mod tests {
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
 
+    /// Builds the exported wrapper for `method` and returns the original method's
+    /// (post-processing) attributes alongside the parsed wrapper function.
+    fn wrapper_of(mut method: ImplItemFn) -> (Vec<Attribute>, ItemFn) {
+        let impl_type: Type = syn::parse_str("Hello").unwrap();
+        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
+        let wrapper: ItemFn = syn::parse2(method_info.method_wrapper()).unwrap();
+        (method.attrs, wrapper)
+    }
+
+    fn has_inline(attrs: &[Attribute]) -> bool {
+        attrs.iter().any(|attr| attr.path().is_ident("inline"))
+    }
+
     /// `#[inline]` is meaningless on the generated `#[no_mangle] extern "C"` wrapper and
-    /// triggers the `unused_attributes` lint on wasm32 builds, so it must not be forwarded.
+    /// triggers the `unused_attributes` lint on wasm32 builds, so it must not be forwarded
+    /// — but it must stay on the original method, where it has its intended effect.
     #[test]
     fn inline_not_forwarded_to_wrapper() {
-        let impl_type: Type = syn::parse_str("Hello").unwrap();
-        let mut method: ImplItemFn = parse_quote! {
+        let (original_attrs, wrapper) = wrapper_of(parse_quote! {
             #[inline]
             pub fn method(&self) { }
-        };
-        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
-        let actual = method_info.method_wrapper();
-        let generated = pretty_print_syn_str(&actual).unwrap();
-        assert!(
-            !generated.contains("inline"),
-            "`#[inline]` must not be forwarded to the exported wrapper, got:\n{generated}"
-        );
+        });
+        assert!(!has_inline(&wrapper.attrs), "`#[inline]` must not be forwarded to the wrapper");
+        assert!(has_inline(&original_attrs), "`#[inline]` must be kept on the original method");
     }
 
     /// `#[inline(always)]` / `#[inline(never)]` must be dropped from the wrapper too.
     #[test]
     fn inline_variants_not_forwarded_to_wrapper() {
-        let impl_type: Type = syn::parse_str("Hello").unwrap();
-        let mut method: ImplItemFn = parse_quote! {
+        let (original_attrs, wrapper) = wrapper_of(parse_quote! {
             #[inline(always)]
             pub fn method(&self) { }
-        };
-        let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
-        let actual = method_info.method_wrapper();
-        let generated = pretty_print_syn_str(&actual).unwrap();
-        assert!(
-            !generated.contains("inline"),
-            "`#[inline(always)]` must not be forwarded to the exported wrapper, got:\n{generated}"
-        );
+        });
+        assert!(!has_inline(&wrapper.attrs), "`#[inline(always)]` must not reach the wrapper");
+        assert!(has_inline(&original_attrs), "`#[inline(always)]` must be kept on the method");
     }
 
     #[test]

--- a/near-sdk/src/collections/tree_map.rs
+++ b/near-sdk/src/collections/tree_map.rs
@@ -396,7 +396,7 @@ where
                     parent = node;
                 }
                 None => {
-                    return node.and_then(|n| parent.map(|p| (n, p)));
+                    return node.zip(parent);
                 }
             }
         }
@@ -415,7 +415,7 @@ where
                     at = rgt;
                 }
                 None => {
-                    return node.and_then(|n| parent.map(|p| (n, p)));
+                    return node.zip(parent);
                 }
             }
         }


### PR DESCRIPTION
Two independent lint fixes that surface when building a contract for wasm32 under `-D warnings`.

**1. `near-sdk-macros`: stop forwarding `#[inline]` to the generated `extern "C"` wrapper.** A method's `#[inline]` was copied onto the `#[no_mangle]` wrapper, which trips `unused_attributes` ("`#[inline]` is ignored on externally exported functions") on wasm32 builds. The SDK's own CI misses it because the wrapper is `#[cfg(target_arch = "wasm32")]` and host-target clippy compiles it out. The attribute stays on the original method; only the exported shim drops it. +2 tests.

**2. `near-sdk`: use `Option::zip` in `TreeMap::min_at`/`max_at`.** Clippy ≥1.94 flags the manual `and_then`/`map` as `manual_option_zip`. No-op refactor; avoids a failure once the lint toolchain moves past 1.93 (cf. #1556).

Follow-up (separate): the `#[inline]` fix is a denylist; the cleaner fix is to point the wrapper at the same `cfg`/`allow` allowlist `_Ext` already uses (#959, #1508).