### PR TITLE
fix: select near-sdk-env host path on cfg(near), not cfg(near) + wasm32

### DIFF
--- a/near-sdk-env/src/hash.rs
+++ b/near-sdk-env/src/hash.rs
@@ -1,15 +1,9 @@
 use crate::CryptoHash;
 
-#[cfg(any(
-    all(near, target_arch = "wasm32"),
-    all(feature = "__near-sdk-unit-testing", not(doctest))
-))]
+#[cfg(any(near, all(feature = "__near-sdk-unit-testing", not(doctest))))]
 use near_sys as sys;
 
-#[cfg(any(
-    all(near, target_arch = "wasm32"),
-    all(feature = "__near-sdk-unit-testing", not(doctest))
-))]
+#[cfg(any(near, all(feature = "__near-sdk-unit-testing", not(doctest))))]
 use crate::{ATOMIC_OP_REGISTER, read_register_fixed};
 
 /// Hashes the random sequence of bytes using sha256.

--- a/near-sdk-env/src/lib.rs
+++ b/near-sdk-env/src/lib.rs
@@ -11,25 +11,16 @@ pub use hash::*;
 
 pub type CryptoHash = [u8; 32];
 
-#[cfg(any(
-    all(near, target_arch = "wasm32"),
-    all(feature = "__near-sdk-unit-testing", not(doctest))
-))]
+#[cfg(any(near, all(feature = "__near-sdk-unit-testing", not(doctest))))]
 use near_sys as sys;
 
-#[cfg(any(
-    all(near, target_arch = "wasm32"),
-    all(feature = "__near-sdk-unit-testing", not(doctest))
-))]
+#[cfg(any(near, all(feature = "__near-sdk-unit-testing", not(doctest))))]
 /// Register used internally for atomic operations. This register is safe to use by the user,
 /// since it only needs to be untouched while methods of `Environment` execute, which is guaranteed
 /// guest code is not parallel.
 pub(crate) const ATOMIC_OP_REGISTER: u64 = u64::MAX - 2;
 
-#[cfg(any(
-    all(near, target_arch = "wasm32"),
-    all(feature = "__near-sdk-unit-testing", not(doctest))
-))]
+#[cfg(any(near, all(feature = "__near-sdk-unit-testing", not(doctest))))]
 #[inline]
 pub(crate) unsafe fn read_register_fixed<const N: usize>(register_id: u64) -> [u8; N] {
     let mut buf = [0; N];

--- a/near-sdk-env/src/macros.rs
+++ b/near-sdk-env/src/macros.rs
@@ -11,13 +11,13 @@ macro_rules! execute_target_specific {
         local: $local_block:block $(,)?
      ) => {
         #[cfg(any(
-            all(near, target_arch = "wasm32"),
+            near,
             all(feature = "__near-sdk-unit-testing", not(doctest))
         ))]
         $host_block
 
         #[cfg(not(any(
-            all(near, target_arch = "wasm32"),
+            near,
             all(feature = "__near-sdk-unit-testing", not(doctest))
         )))]
         $local_block


### PR DESCRIPTION
## Problem

Native builds that set `--cfg near` don't compile:

```
$ RUSTFLAGS='--cfg=near' cargo check -p near-sdk-env
error[E0432]: unresolved import `sha2` / `sha3` / `ripemd`
```

## Cause

The dependency table gates the host path on `cfg(near)` (host impls whenever `cfg(near)`, regardless of target), but the code gated it on `all(near, target_arch = "wasm32")`. So a native `--cfg near` build compiled the pure-Rust path while `cfg(not(near))` excluded the crates backing it.

## Fix

Drop the `target_arch = "wasm32"` qualifier so the host path keys on `cfg(near)` alone — matching the dependency table and the sibling `near-global-contracts` crate. On-chain (`near` + `wasm32`) behavior is unchanged. 7-line diff, no `Cargo.toml` change.

## Deferred

Doesn't fix the downstream `cargo test --cfg near` linker error (`undefined reference to sha256`): `near-sdk`'s mock host functions only link when `near-sdk` is referenced. Reliable fix = move the mock into `near-sdk-env`; interim bypass (precedent: `near-sdk-core`, `near-global-contracts`):

```rust
#[cfg(all(near, test))]
use near_sdk as _;
```
