### PR TITLE
feat: add gas-key host functions (nearcore 2.13)

### DIFF
--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -36,21 +36,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use nearcore 2.13 RC sandbox (protocol v85)
-        run: |
-          set -euo pipefail
-          case "${{ matrix.platform.name }}" in
-            linux) url="https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/Linux-x86_64/2.13.0-rc.1/near-sandbox.tar.gz" ;;
-            macos) url="https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/Darwin-arm64/2.13.0-rc.1/near-sandbox.tar.gz" ;;
-            *) echo "unknown platform: ${{ matrix.platform.name }}" >&2; exit 1 ;;
-          esac
-          dest="$RUNNER_TEMP/near-sandbox-2.13.0-rc.1"
-          mkdir -p "$dest"
-          curl --proto '=https' --tlsv1.2 -fLsS "$url" | tar xz -C "$dest" --strip-components=1
-          chmod +x "$dest/near-sandbox"
-          "$dest/near-sandbox" --version
-          echo "NEAR_SANDBOX_BIN_PATH=$dest/near-sandbox" >> "$GITHUB_ENV"
-
       - name: Set CC for wasm32 target (MacOS only)
         if: matrix.platform.name == 'macos'
         run: |

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -36,6 +36,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Use nearcore 2.13 RC sandbox (protocol v85)
+        run: |
+          set -euo pipefail
+          case "${{ matrix.platform.name }}" in
+            linux) url="https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/Linux-x86_64/2.13.0-rc.1/near-sandbox.tar.gz" ;;
+            macos) url="https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/Darwin-arm64/2.13.0-rc.1/near-sandbox.tar.gz" ;;
+            *) echo "unknown platform: ${{ matrix.platform.name }}" >&2; exit 1 ;;
+          esac
+          dest="$RUNNER_TEMP/near-sandbox-2.13.0-rc.1"
+          mkdir -p "$dest"
+          curl --proto '=https' --tlsv1.2 -fLsS "$url" | tar xz -C "$dest" --strip-components=1
+          chmod +x "$dest/near-sandbox"
+          "$dest/near-sandbox" --version
+          echo "NEAR_SANDBOX_BIN_PATH=$dest/near-sandbox" >> "$GITHUB_ENV"
+
       - name: Set CC for wasm32 target (MacOS only)
         if: matrix.platform.name == 'macos'
         run: |

--- a/.github/workflows/test_examples_small.yml
+++ b/.github/workflows/test_examples_small.yml
@@ -31,6 +31,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Use nearcore 2.13 RC sandbox (protocol v85)
+        run: |
+          set -euo pipefail
+          case "${{ matrix.platform.name }}" in
+            linux) url="https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/Linux-x86_64/2.13.0-rc.1/near-sandbox.tar.gz" ;;
+            macos) url="https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/Darwin-arm64/2.13.0-rc.1/near-sandbox.tar.gz" ;;
+            *) echo "unknown platform: ${{ matrix.platform.name }}" >&2; exit 1 ;;
+          esac
+          dest="$RUNNER_TEMP/near-sandbox-2.13.0-rc.1"
+          mkdir -p "$dest"
+          curl --proto '=https' --tlsv1.2 -fLsS "$url" | tar xz -C "$dest" --strip-components=1
+          chmod +x "$dest/near-sandbox"
+          "$dest/near-sandbox" --version
+          echo "NEAR_SANDBOX_BIN_PATH=$dest/near-sandbox" >> "$GITHUB_ENV"
+
       - name: Set CC for wasm32 target (MacOS only)
         if: matrix.platform.name == 'macos'
         run: |

--- a/.github/workflows/test_examples_small.yml
+++ b/.github/workflows/test_examples_small.yml
@@ -31,21 +31,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use nearcore 2.13 RC sandbox (protocol v85)
-        run: |
-          set -euo pipefail
-          case "${{ matrix.platform.name }}" in
-            linux) url="https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/Linux-x86_64/2.13.0-rc.1/near-sandbox.tar.gz" ;;
-            macos) url="https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/Darwin-arm64/2.13.0-rc.1/near-sandbox.tar.gz" ;;
-            *) echo "unknown platform: ${{ matrix.platform.name }}" >&2; exit 1 ;;
-          esac
-          dest="$RUNNER_TEMP/near-sandbox-2.13.0-rc.1"
-          mkdir -p "$dest"
-          curl --proto '=https' --tlsv1.2 -fLsS "$url" | tar xz -C "$dest" --strip-components=1
-          chmod +x "$dest/near-sandbox"
-          "$dest/near-sandbox" --version
-          echo "NEAR_SANDBOX_BIN_PATH=$dest/near-sandbox" >> "$GITHUB_ENV"
-
       - name: Set CC for wasm32 target (MacOS only)
         if: matrix.platform.name == 'macos'
         run: |

--- a/examples/adder/src/lib.rs
+++ b/examples/adder/src/lib.rs
@@ -54,7 +54,7 @@ mod tests {
     #[tokio::test]
     async fn test_add_callback_vec() -> anyhow::Result<()> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let worker = near_workspaces::sandbox().await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         let res = contract

--- a/examples/adder/src/lib.rs
+++ b/examples/adder/src/lib.rs
@@ -54,7 +54,8 @@ mod tests {
     #[tokio::test]
     async fn test_add_callback_vec() -> anyhow::Result<()> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
+        // TODO: drop explicit version once near-sandbox-rs ships a v85 DEFAULT_NEAR_SANDBOX_VERSION
+        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         let res = contract

--- a/examples/callback-results/src/lib.rs
+++ b/examples/callback-results/src/lib.rs
@@ -93,7 +93,7 @@ mod tests {
     #[tokio::test]
     async fn workspaces_test() -> anyhow::Result<()> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         // Call function a only to ensure it has correct behaviour
@@ -151,7 +151,7 @@ mod tests {
     #[tokio::test]
     async fn workspaces_test_reverse() -> anyhow::Result<()> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         // No failures

--- a/examples/callback-results/src/lib.rs
+++ b/examples/callback-results/src/lib.rs
@@ -93,7 +93,7 @@ mod tests {
     #[tokio::test]
     async fn workspaces_test() -> anyhow::Result<()> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let worker = near_workspaces::sandbox().await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         // Call function a only to ensure it has correct behaviour
@@ -151,7 +151,7 @@ mod tests {
     #[tokio::test]
     async fn workspaces_test_reverse() -> anyhow::Result<()> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let worker = near_workspaces::sandbox().await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         // No failures

--- a/examples/cross-contract-calls/tests/workspaces.rs
+++ b/examples/cross-contract-calls/tests/workspaces.rs
@@ -5,7 +5,7 @@ use test_case::test_case;
 #[tokio::test]
 async fn test_factorial(contract_path: &str) -> anyhow::Result<()> {
     let wasm = near_workspaces::compile_project(contract_path).await?;
-    let worker = near_workspaces::sandbox().await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
     let contract = worker.dev_deploy(&wasm).await?;
 
     let res = contract.call("factorial").args_json((1,)).max_gas().transact().await?;

--- a/examples/cross-contract-calls/tests/workspaces.rs
+++ b/examples/cross-contract-calls/tests/workspaces.rs
@@ -5,7 +5,7 @@ use test_case::test_case;
 #[tokio::test]
 async fn test_factorial(contract_path: &str) -> anyhow::Result<()> {
     let wasm = near_workspaces::compile_project(contract_path).await?;
-    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
     let contract = worker.dev_deploy(&wasm).await?;
 
     let res = contract.call("factorial").args_json((1,)).max_gas().transact().await?;

--- a/examples/factory-contract-global/tests/workspaces.rs
+++ b/examples/factory-contract-global/tests/workspaces.rs
@@ -9,7 +9,7 @@ const GLOBAL_STORAGE_COST_PER_BYTE: NearToken = STORAGE_DEPOSIT_PER_BYTE.saturat
 async fn test_deploy_global_contract() -> anyhow::Result<()> {
     // Initialize the sandbox environment with specific commit that includes global contract support
     println!("Initializing worker");
-    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
 
     println!("Deploying global contract");
 
@@ -57,7 +57,7 @@ async fn test_deploy_global_contract() -> anyhow::Result<()> {
 /// Test using a global contract by hash
 #[tokio::test]
 async fn test_use_global_contract_by_hash() -> anyhow::Result<()> {
-    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
     let factory_wasm = near_workspaces::compile_project(".").await?;
     let factory_contract = worker.dev_deploy(&factory_wasm).await?;
 
@@ -102,7 +102,7 @@ async fn test_use_global_contract_by_hash() -> anyhow::Result<()> {
 /// Test using a global contract by account ID
 #[tokio::test]
 async fn test_use_global_contract_by_account() -> anyhow::Result<()> {
-    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
     let factory_wasm = near_workspaces::compile_project(".").await?;
     let factory_contract = worker.dev_deploy(&factory_wasm).await?;
 
@@ -139,7 +139,7 @@ async fn test_use_global_contract_by_account() -> anyhow::Result<()> {
 /// Test error cases and edge conditions
 #[tokio::test]
 async fn test_global_contract_edge_cases() -> anyhow::Result<()> {
-    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
     let factory_wasm = near_workspaces::compile_project(".").await?;
     let factory_contract = worker.dev_deploy(&factory_wasm).await?;
 

--- a/examples/factory-contract-global/tests/workspaces.rs
+++ b/examples/factory-contract-global/tests/workspaces.rs
@@ -9,7 +9,7 @@ const GLOBAL_STORAGE_COST_PER_BYTE: NearToken = STORAGE_DEPOSIT_PER_BYTE.saturat
 async fn test_deploy_global_contract() -> anyhow::Result<()> {
     // Initialize the sandbox environment with specific commit that includes global contract support
     println!("Initializing worker");
-    let worker = near_workspaces::sandbox().await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
 
     println!("Deploying global contract");
 
@@ -57,7 +57,7 @@ async fn test_deploy_global_contract() -> anyhow::Result<()> {
 /// Test using a global contract by hash
 #[tokio::test]
 async fn test_use_global_contract_by_hash() -> anyhow::Result<()> {
-    let worker = near_workspaces::sandbox().await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
     let factory_wasm = near_workspaces::compile_project(".").await?;
     let factory_contract = worker.dev_deploy(&factory_wasm).await?;
 
@@ -102,7 +102,7 @@ async fn test_use_global_contract_by_hash() -> anyhow::Result<()> {
 /// Test using a global contract by account ID
 #[tokio::test]
 async fn test_use_global_contract_by_account() -> anyhow::Result<()> {
-    let worker = near_workspaces::sandbox().await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
     let factory_wasm = near_workspaces::compile_project(".").await?;
     let factory_contract = worker.dev_deploy(&factory_wasm).await?;
 
@@ -139,7 +139,7 @@ async fn test_use_global_contract_by_account() -> anyhow::Result<()> {
 /// Test error cases and edge conditions
 #[tokio::test]
 async fn test_global_contract_edge_cases() -> anyhow::Result<()> {
-    let worker = near_workspaces::sandbox().await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
     let factory_wasm = near_workspaces::compile_project(".").await?;
     let factory_contract = worker.dev_deploy(&factory_wasm).await?;
 

--- a/examples/factory-contract/tests/workspaces.rs
+++ b/examples/factory-contract/tests/workspaces.rs
@@ -26,7 +26,7 @@ async fn build_contract(path: &str) -> anyhow::Result<Vec<u8>> {
 #[tokio::test]
 async fn test_deploy_status_message(contract_path: &str) -> anyhow::Result<()> {
     let wasm = build_contract(contract_path).await?;
-    let worker = near_workspaces::sandbox().await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
     let contract = worker.dev_deploy(&wasm).await?;
 
     let status_id: AccountId = format!("status.{}", contract.id()).parse()?;

--- a/examples/factory-contract/tests/workspaces.rs
+++ b/examples/factory-contract/tests/workspaces.rs
@@ -26,7 +26,7 @@ async fn build_contract(path: &str) -> anyhow::Result<Vec<u8>> {
 #[tokio::test]
 async fn test_deploy_status_message(contract_path: &str) -> anyhow::Result<()> {
     let wasm = build_contract(contract_path).await?;
-    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
     let contract = worker.dev_deploy(&wasm).await?;
 
     let status_id: AccountId = format!("status.{}", contract.id()).parse()?;

--- a/examples/fungible-token/tests/workspaces.rs
+++ b/examples/fungible-token/tests/workspaces.rs
@@ -60,7 +60,7 @@ async fn initialized_contracts(
     fungible_contract_wasm: &Vec<u8>,
     defi_contract_wasm: &Vec<u8>,
 ) -> anyhow::Result<(Contract, Account, Contract)> {
-    let worker = near_workspaces::sandbox().await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
 
     let ft_contract = worker.dev_deploy(fungible_contract_wasm).await?;
 
@@ -150,7 +150,9 @@ async fn test_storage_deposit_not_enough_deposit(
         contract.view_account().await?.balance.saturating_sub(contract_balance_before_deposit);
     // contract receives a gas rewards for the function call, so it should gain some NEAR
     assert!(contract_balance_diff > NearToken::from_near(0));
-    assert!(contract_balance_diff < NearToken::from_yoctonear(30_000_000_000_000_000_000));
+    // raised for protocol v85 (nearcore 2.13): function-call gas reward increased vs v84
+    // (measured ~502e18 yocto under 2.13.0-rc.1; bound kept well under 1 milliNEAR)
+    assert!(contract_balance_diff < NearToken::from_yoctonear(800_000_000_000_000_000_000));
 
     Ok(())
 }
@@ -283,9 +285,11 @@ async fn test_storage_deposit_refunds_excessive_deposit(
         contract.view_account().await?.balance.saturating_sub(contract_balance_before_deposit);
     // contract receives a gas rewards for the function call, so the difference should be slightly more than minimal_deposit
     assert!(contract_balance_diff > minimal_deposit);
+    // raised for protocol v85 (nearcore 2.13): function-call gas reward increased vs v84
+    // (measured ~517e18 yocto over minimal_deposit under 2.13.0-rc.1)
     assert!(
         contract_balance_diff
-            < minimal_deposit.saturating_add(NearToken::from_yoctonear(50_000_000_000_000_000_000))
+            < minimal_deposit.saturating_add(NearToken::from_yoctonear(800_000_000_000_000_000_000))
     );
 
     Ok(())
@@ -430,13 +434,20 @@ async fn simulate_transfer_call_with_burned_amount(
     assert!(logs.contains(&"The account of the sender was deleted"));
     assert!(logs.contains(&(expected.as_str())));
 
-    match res.receipt_outcomes()[4].clone().into_result()? {
-        ValueOrReceiptId::Value(val) => {
-            let used_amount = val.json::<U128>()?;
-            assert_eq!(used_amount, transfer_amount);
-        }
-        _ => panic!("Unexpected receipt id"),
-    }
+    // The `ft_resolve_transfer` callback returns the used amount as a U128. Its position in
+    // `receipt_outcomes()` shifted between protocol versions (v85 / nearcore 2.13 added receipts),
+    // so locate it by content instead of a hardcoded index: it is the last outcome whose value
+    // parses as a U128. (The inner `value_please` outcome also parses as U128, hence "last".)
+    let used_amount = res
+        .receipt_outcomes()
+        .iter()
+        .filter_map(|outcome| match outcome.clone().into_result() {
+            Ok(ValueOrReceiptId::Value(val)) => val.json::<U128>().ok(),
+            _ => None,
+        })
+        .next_back()
+        .expect("no receipt outcome returned a U128 (ft_resolve_transfer used-amount)");
+    assert_eq!(used_amount, transfer_amount);
     assert!(res.json::<bool>()?);
 
     let res = contract.call("ft_total_supply").view().await?;

--- a/examples/fungible-token/tests/workspaces.rs
+++ b/examples/fungible-token/tests/workspaces.rs
@@ -60,7 +60,7 @@ async fn initialized_contracts(
     fungible_contract_wasm: &Vec<u8>,
     defi_contract_wasm: &Vec<u8>,
 ) -> anyhow::Result<(Contract, Account, Contract)> {
-    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
 
     let ft_contract = worker.dev_deploy(fungible_contract_wasm).await?;
 
@@ -151,7 +151,7 @@ async fn test_storage_deposit_not_enough_deposit(
     // contract receives a gas rewards for the function call, so it should gain some NEAR
     assert!(contract_balance_diff > NearToken::from_near(0));
     // raised for protocol v85 (nearcore 2.13): function-call gas reward increased vs v84
-    // (measured ~502e18 yocto under 2.13.0-rc.1; bound kept well under 1 milliNEAR)
+    // (measured ~502e18 yocto under 2.13.0-rc.2; bound kept well under 1 milliNEAR)
     assert!(contract_balance_diff < NearToken::from_yoctonear(800_000_000_000_000_000_000));
 
     Ok(())
@@ -286,7 +286,7 @@ async fn test_storage_deposit_refunds_excessive_deposit(
     // contract receives a gas rewards for the function call, so the difference should be slightly more than minimal_deposit
     assert!(contract_balance_diff > minimal_deposit);
     // raised for protocol v85 (nearcore 2.13): function-call gas reward increased vs v84
-    // (measured ~517e18 yocto over minimal_deposit under 2.13.0-rc.1)
+    // (measured ~517e18 yocto over minimal_deposit under 2.13.0-rc.2)
     assert!(
         contract_balance_diff
             < minimal_deposit.saturating_add(NearToken::from_yoctonear(800_000_000_000_000_000_000))

--- a/examples/lockable-fungible-token/tests/workspaces.rs
+++ b/examples/lockable-fungible-token/tests/workspaces.rs
@@ -36,7 +36,7 @@ async fn initialized_contract(
     initial_balance: U128,
     lockable_fungible_contract_wasm: &Vec<u8>,
 ) -> anyhow::Result<(Contract, Account)> {
-    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
 
     let contract = worker.dev_deploy(lockable_fungible_contract_wasm).await?;
 

--- a/examples/lockable-fungible-token/tests/workspaces.rs
+++ b/examples/lockable-fungible-token/tests/workspaces.rs
@@ -36,7 +36,7 @@ async fn initialized_contract(
     initial_balance: U128,
     lockable_fungible_contract_wasm: &Vec<u8>,
 ) -> anyhow::Result<(Contract, Account)> {
-    let worker = near_workspaces::sandbox().await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
 
     let contract = worker.dev_deploy(lockable_fungible_contract_wasm).await?;
 

--- a/examples/mission-control/src/mission_control.rs
+++ b/examples/mission-control/src/mission_control.rs
@@ -103,7 +103,7 @@ mod tests {
     #[tokio::test]
     async fn embedded_abi_test() -> anyhow::Result<()> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         let res = contract.view("__contract_abi").await?;

--- a/examples/mission-control/src/mission_control.rs
+++ b/examples/mission-control/src/mission_control.rs
@@ -103,7 +103,7 @@ mod tests {
     #[tokio::test]
     async fn embedded_abi_test() -> anyhow::Result<()> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let worker = near_workspaces::sandbox().await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         let res = contract.view("__contract_abi").await?;

--- a/examples/mpc-contract/src/lib.rs
+++ b/examples/mpc-contract/src/lib.rs
@@ -12,6 +12,15 @@ const SIGN_ON_FINISH_CALL_GAS: Gas = Gas::from_tgas(5);
 // Prepaid gas for a `do_something` call
 const CHAINED_CALL_GAS: Gas = Gas::from_tgas(5);
 
+/// Deterministically derive a 32-byte yield id from a request index. Both `sign_with_id` and
+/// `sign_respond_with_id` derive it the same way, so the responder can recompute the id from the
+/// public request index instead of needing a runtime-generated token handed back to it. A
+/// production contract would typically fold in more context (e.g. the signer and message) to keep
+/// ids unique across unrelated requests.
+fn derive_yield_id(index: u64) -> CryptoHash {
+    env::sha256_array(&index.to_le_bytes())
+}
+
 #[near(serializers = [borsh, json])]
 #[derive(Clone, Debug)]
 pub struct SignatureRequest {
@@ -82,6 +91,68 @@ impl MpcContract {
 
         log!("submitting response {} for data id {:?}", &signature, &data_id);
         env::promise_yield_resume(&data_id, &serde_json::to_vec(&signature).unwrap());
+    }
+
+    /// Variant of [`Self::sign`] using nearcore 2.13's `promise_yield_create_with_id`. Instead of
+    /// letting the runtime generate the resumption token, the contract derives the yield id itself
+    /// (here, from the request index). Because the id is deterministic, the responder can recompute
+    /// it from the public request index alone (see `sign_respond_with_id`), so the contract never
+    /// has to read a `data_id` out of a register and surface it.
+    ///
+    /// The high-level equivalents are `near_sdk::Promise::new_yield_with_id` and
+    /// `near_sdk::UserYieldId`.
+    pub fn sign_with_id(&mut self, message: String) {
+        let index = self.next_available_request_index;
+        self.next_available_request_index += 1;
+
+        let yield_id = derive_yield_id(index);
+
+        // `promise_yield_create_with_id` returns `None` if a yield with this id is already pending
+        // for this account. Deriving from the unique request index means that can't happen here,
+        // but a real contract can branch on `None` to recover from duplicates instead of aborting.
+        let yield_promise = env::promise_yield_create_with_id(
+            "sign_on_finish",
+            &serde_json::to_vec(&(index,)).unwrap(),
+            NearToken::from_near(0),
+            SIGN_ON_FINISH_CALL_GAS,
+            GasWeight(0),
+            &yield_id,
+        )
+        .unwrap_or_else(|| env::panic_str("a request with this yield id is already pending"));
+
+        // We can still store the id for `log_pending_requests`/`get_requests`, but note the
+        // responder does not depend on it — it recomputes the id from `index`.
+        self.requests.insert(
+            index,
+            SignatureRequest { data_id: yield_id, account_id: env::signer_account_id(), message },
+        );
+
+        // Composable with the rest of the promise API, exactly like `sign`.
+        env::promise_then(
+            yield_promise,
+            env::current_account_id(),
+            "do_something",
+            &[],
+            NearToken::from_near(0),
+            CHAINED_CALL_GAS,
+        );
+
+        env::promise_return(yield_promise);
+    }
+
+    /// Called by MPC participants to submit a signature for a request created with
+    /// [`Self::sign_with_id`]. The responder only needs the public `request_index`: it recomputes
+    /// the same yield id and resumes by id, without the contract surfacing a runtime `data_id`.
+    pub fn sign_respond_with_id(&mut self, request_index: u64, signature: String) {
+        // check that caller is allowed to respond, signature is valid, etc.
+        // ...
+
+        let yield_id = derive_yield_id(request_index);
+        log!("submitting response {} for request {}", &signature, request_index);
+        env::promise_yield_resume_with_yield_id(
+            &yield_id,
+            &serde_json::to_vec(&signature).unwrap(),
+        );
     }
 
     /// Callback receiving the externally submitted data (or a PromiseError)

--- a/examples/mpc-contract/src/lib.rs
+++ b/examples/mpc-contract/src/lib.rs
@@ -292,7 +292,7 @@ mod tests {
     #[tokio::test]
     async fn happy_path() -> Result<(), Box<dyn std::error::Error>> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let workspace = near_workspaces::sandbox().await?;
+        let workspace = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
 
         let contract_account = workspace.dev_create_account().await?;
         let contract = contract_account.deploy(wasm.as_slice()).await?.into_result()?;
@@ -323,7 +323,7 @@ mod tests {
     #[tokio::test]
     async fn negative_path() -> Result<(), Box<dyn std::error::Error>> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let workspace = near_workspaces::sandbox().await?;
+        let workspace = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
 
         let contract_account = workspace.dev_create_account().await?;
         let contract = contract_account.deploy(wasm.as_slice()).await?.into_result()?;

--- a/examples/mpc-contract/src/lib.rs
+++ b/examples/mpc-contract/src/lib.rs
@@ -292,7 +292,7 @@ mod tests {
     #[tokio::test]
     async fn happy_path() -> Result<(), Box<dyn std::error::Error>> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let workspace = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
+        let workspace = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
 
         let contract_account = workspace.dev_create_account().await?;
         let contract = contract_account.deploy(wasm.as_slice()).await?.into_result()?;
@@ -323,7 +323,7 @@ mod tests {
     #[tokio::test]
     async fn negative_path() -> Result<(), Box<dyn std::error::Error>> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let workspace = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
+        let workspace = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
 
         let contract_account = workspace.dev_create_account().await?;
         let contract = contract_account.deploy(wasm.as_slice()).await?.into_result()?;

--- a/examples/non-fungible-token/tests/workspaces/utils.rs
+++ b/examples/non-fungible-token/tests/workspaces/utils.rs
@@ -85,7 +85,7 @@ pub async fn initialized_contracts(
     token_receiver_contract_wasm: &Vec<u8>,
     approval_receiver_contract_wasm: &Vec<u8>,
 ) -> anyhow::Result<(Contract, Account, Contract, Contract)> {
-    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
     let nft_contract = worker.dev_deploy(non_fungible_contract_wasm).await?;
 
     let res = nft_contract

--- a/examples/non-fungible-token/tests/workspaces/utils.rs
+++ b/examples/non-fungible-token/tests/workspaces/utils.rs
@@ -85,7 +85,7 @@ pub async fn initialized_contracts(
     token_receiver_contract_wasm: &Vec<u8>,
     approval_receiver_contract_wasm: &Vec<u8>,
 ) -> anyhow::Result<(Contract, Account, Contract, Contract)> {
-    let worker = near_workspaces::sandbox().await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
     let nft_contract = worker.dev_deploy(non_fungible_contract_wasm).await?;
 
     let res = nft_contract

--- a/examples/status-message/src/lib.rs
+++ b/examples/status-message/src/lib.rs
@@ -78,7 +78,7 @@ mod tests {
     #[tokio::test]
     async fn embedded_abi_test() -> anyhow::Result<()> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let worker = near_workspaces::sandbox().await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         let res = contract.view("__contract_abi").await?;

--- a/examples/status-message/src/lib.rs
+++ b/examples/status-message/src/lib.rs
@@ -78,7 +78,7 @@ mod tests {
     #[tokio::test]
     async fn embedded_abi_test() -> anyhow::Result<()> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         let res = contract.view("__contract_abi").await?;

--- a/examples/test-contract/src/lib.rs
+++ b/examples/test-contract/src/lib.rs
@@ -81,7 +81,7 @@ mod tests {
     #[tokio::test]
     async fn embedded_abi_test() -> anyhow::Result<()> {
         let wasm = build_contract("./").await?;
-        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         let res = contract.view("__contract_abi").await?;
@@ -99,7 +99,7 @@ mod tests {
     #[tokio::test]
     async fn private_init_cannot_be_called_by_external_account() -> anyhow::Result<()> {
         let wasm = build_contract("./").await?;
-        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         // Create an external account (alice)
@@ -129,7 +129,7 @@ mod tests {
     #[tokio::test]
     async fn private_init_can_be_called_by_current_account() -> anyhow::Result<()> {
         let wasm = build_contract("./").await?;
-        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         // Contract calls its own private init method - should succeed

--- a/examples/test-contract/src/lib.rs
+++ b/examples/test-contract/src/lib.rs
@@ -81,7 +81,7 @@ mod tests {
     #[tokio::test]
     async fn embedded_abi_test() -> anyhow::Result<()> {
         let wasm = build_contract("./").await?;
-        let worker = near_workspaces::sandbox().await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         let res = contract.view("__contract_abi").await?;
@@ -99,7 +99,7 @@ mod tests {
     #[tokio::test]
     async fn private_init_cannot_be_called_by_external_account() -> anyhow::Result<()> {
         let wasm = build_contract("./").await?;
-        let worker = near_workspaces::sandbox().await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         // Create an external account (alice)
@@ -129,7 +129,7 @@ mod tests {
     #[tokio::test]
     async fn private_init_can_be_called_by_current_account() -> anyhow::Result<()> {
         let wasm = build_contract("./").await?;
-        let worker = near_workspaces::sandbox().await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         // Contract calls its own private init method - should succeed

--- a/examples/versioned/src/lib.rs
+++ b/examples/versioned/src/lib.rs
@@ -152,7 +152,7 @@ mod tests {
     #[tokio::test]
     async fn embedded_abi_test() -> anyhow::Result<()> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         let res = contract.view("__contract_abi").await?;

--- a/examples/versioned/src/lib.rs
+++ b/examples/versioned/src/lib.rs
@@ -152,7 +152,7 @@ mod tests {
     #[tokio::test]
     async fn embedded_abi_test() -> anyhow::Result<()> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let worker = near_workspaces::sandbox().await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         let res = contract.view("__contract_abi").await?;

--- a/near-global-contracts/Cargo.toml
+++ b/near-global-contracts/Cargo.toml
@@ -32,7 +32,8 @@ borsh = { version = "1.0.0", features = ["derive"], optional = true }
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 
 near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.2", optional = true }
-near-primitives-core = { version = "0.36.0", optional = true }
+# Pinned to the nearcore 2.13-release branch; see near-sdk/Cargo.toml for the rationale.
+near-primitives-core = { git = "https://github.com/near/nearcore", rev = "1aa50f765d15d1cd5a946daf3eff04646c5a1957", optional = true }
 
 schemars-v0_8 = { version = "0.8.22", optional = true, package = "schemars" }
 

--- a/near-global-contracts/Cargo.toml
+++ b/near-global-contracts/Cargo.toml
@@ -32,8 +32,8 @@ borsh = { version = "1.0.0", features = ["derive"], optional = true }
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 
 near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.2", optional = true }
-# Pinned to the nearcore 2.13-release branch; see near-sdk/Cargo.toml for the rationale.
-near-primitives-core = { git = "https://github.com/near/nearcore", rev = "1aa50f765d15d1cd5a946daf3eff04646c5a1957", optional = true }
+# Pinned to the published nearcore 2.13 release candidate `0.37.0-rc.1`; see near-sdk/Cargo.toml for the rationale.
+near-primitives-core = { version = "=0.37.0-rc.1", optional = true }
 
 schemars-v0_8 = { version = "0.8.22", optional = true, package = "schemars" }
 

--- a/near-global-contracts/Cargo.toml
+++ b/near-global-contracts/Cargo.toml
@@ -32,8 +32,8 @@ borsh = { version = "1.0.0", features = ["derive"], optional = true }
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 
 near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.2", optional = true }
-# Pinned to the published nearcore 2.13 release candidate `0.37.0-rc.1`; see near-sdk/Cargo.toml for the rationale.
-near-primitives-core = { version = "=0.37.0-rc.1", optional = true }
+# Pinned to the published nearcore 2.13 release candidate `0.37.0-rc.2`; see near-sdk/Cargo.toml for the rationale.
+near-primitives-core = { version = "=0.37.0-rc.2", optional = true }
 
 schemars-v0_8 = { version = "0.8.22", optional = true, package = "schemars" }
 

--- a/near-sdk-core/Cargo.toml
+++ b/near-sdk-core/Cargo.toml
@@ -36,19 +36,19 @@ near-crypto-hash = { path = "../near-crypto-hash/", version = "~0.2.0" }
 near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.2", optional = true }
 
 schemars-v0_8 = { version = "0.8.22", optional = true, package = "schemars" }
-# Pinned to the published nearcore 2.13 release candidate `0.37.0-rc.1`; see near-sdk/Cargo.toml for
+# Pinned to the published nearcore 2.13 release candidate `0.37.0-rc.2`; see near-sdk/Cargo.toml for
 # the rationale. All nearcore-versioned crates across the workspace must use the same version so their
 # types unify. Bump to `0.37.0` (drop the `=`) once 2.13 ships stable.
-near-primitives-core = { version = "=0.37.0-rc.1", optional = true }
+near-primitives-core = { version = "=0.37.0-rc.2", optional = true }
 unicode-segmentation = { version = "1", optional = true }
-near-parameters = { version = "=0.37.0-rc.1", optional = true }
+near-parameters = { version = "=0.37.0-rc.2", optional = true }
 
 # near-crypto is only used by the `near-crypto-interop` conversions, which are host-only (gated
 # `cfg(all(not(target_arch = "wasm32"), feature = "near-crypto-interop"))`). Keep it off wasm targets
 # so contracts that enable `unit-testing` still build for wasm — since nearcore 2.13, near-crypto
 # pulls a non-optional aws-lc-rs (C) dependency that cannot compile for wasm32. Mirrors near-sdk.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-near-crypto = { version = "=0.37.0-rc.1", default-features = false, optional = true }
+near-crypto = { version = "=0.37.0-rc.2", default-features = false, optional = true }
 
 [target.'cfg(near)'.dependencies]
 near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.2" }

--- a/near-sdk-core/Cargo.toml
+++ b/near-sdk-core/Cargo.toml
@@ -36,18 +36,19 @@ near-crypto-hash = { path = "../near-crypto-hash/", version = "~0.2.0" }
 near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.2", optional = true }
 
 schemars-v0_8 = { version = "0.8.22", optional = true, package = "schemars" }
-# Pinned to the nearcore 2.13-release branch; see near-sdk/Cargo.toml for the rationale. All
-# nearcore-versioned crates across the workspace must use the same source/rev so their types unify.
-near-primitives-core = { git = "https://github.com/near/nearcore", rev = "1aa50f765d15d1cd5a946daf3eff04646c5a1957", optional = true }
+# Pinned to the published nearcore 2.13 release candidate `0.37.0-rc.1`; see near-sdk/Cargo.toml for
+# the rationale. All nearcore-versioned crates across the workspace must use the same version so their
+# types unify. Bump to `0.37.0` (drop the `=`) once 2.13 ships stable.
+near-primitives-core = { version = "=0.37.0-rc.1", optional = true }
 unicode-segmentation = { version = "1", optional = true }
-near-parameters = { git = "https://github.com/near/nearcore", rev = "1aa50f765d15d1cd5a946daf3eff04646c5a1957", optional = true }
+near-parameters = { version = "=0.37.0-rc.1", optional = true }
 
 # near-crypto is only used by the `near-crypto-interop` conversions, which are host-only (gated
 # `cfg(all(not(target_arch = "wasm32"), feature = "near-crypto-interop"))`). Keep it off wasm targets
 # so contracts that enable `unit-testing` still build for wasm — since nearcore 2.13, near-crypto
 # pulls a non-optional aws-lc-rs (C) dependency that cannot compile for wasm32. Mirrors near-sdk.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-near-crypto = { git = "https://github.com/near/nearcore", rev = "1aa50f765d15d1cd5a946daf3eff04646c5a1957", default-features = false, optional = true }
+near-crypto = { version = "=0.37.0-rc.1", default-features = false, optional = true }
 
 [target.'cfg(near)'.dependencies]
 near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.2" }

--- a/near-sdk-core/Cargo.toml
+++ b/near-sdk-core/Cargo.toml
@@ -39,9 +39,15 @@ schemars-v0_8 = { version = "0.8.22", optional = true, package = "schemars" }
 # Pinned to the nearcore 2.13-release branch; see near-sdk/Cargo.toml for the rationale. All
 # nearcore-versioned crates across the workspace must use the same source/rev so their types unify.
 near-primitives-core = { git = "https://github.com/near/nearcore", rev = "1aa50f765d15d1cd5a946daf3eff04646c5a1957", optional = true }
-near-crypto = { git = "https://github.com/near/nearcore", rev = "1aa50f765d15d1cd5a946daf3eff04646c5a1957", default-features = false, optional = true }
 unicode-segmentation = { version = "1", optional = true }
 near-parameters = { git = "https://github.com/near/nearcore", rev = "1aa50f765d15d1cd5a946daf3eff04646c5a1957", optional = true }
+
+# near-crypto is only used by the `near-crypto-interop` conversions, which are host-only (gated
+# `cfg(all(not(target_arch = "wasm32"), feature = "near-crypto-interop"))`). Keep it off wasm targets
+# so contracts that enable `unit-testing` still build for wasm — since nearcore 2.13, near-crypto
+# pulls a non-optional aws-lc-rs (C) dependency that cannot compile for wasm32. Mirrors near-sdk.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+near-crypto = { git = "https://github.com/near/nearcore", rev = "1aa50f765d15d1cd5a946daf3eff04646c5a1957", default-features = false, optional = true }
 
 [target.'cfg(near)'.dependencies]
 near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.2" }

--- a/near-sdk-core/Cargo.toml
+++ b/near-sdk-core/Cargo.toml
@@ -36,10 +36,12 @@ near-crypto-hash = { path = "../near-crypto-hash/", version = "~0.2.0" }
 near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.2", optional = true }
 
 schemars-v0_8 = { version = "0.8.22", optional = true, package = "schemars" }
-near-primitives-core = { version = "0.36.0", optional = true }
-near-crypto = { version = "0.36.0", default-features = false, optional = true }
+# Pinned to the nearcore 2.13-release branch; see near-sdk/Cargo.toml for the rationale. All
+# nearcore-versioned crates across the workspace must use the same source/rev so their types unify.
+near-primitives-core = { git = "https://github.com/near/nearcore", rev = "1aa50f765d15d1cd5a946daf3eff04646c5a1957", optional = true }
+near-crypto = { git = "https://github.com/near/nearcore", rev = "1aa50f765d15d1cd5a946daf3eff04646c5a1957", default-features = false, optional = true }
 unicode-segmentation = { version = "1", optional = true }
-near-parameters = { version = "0.36.0", optional = true }
+near-parameters = { git = "https://github.com/near/nearcore", rev = "1aa50f765d15d1cd5a946daf3eff04646c5a1957", optional = true }
 
 [target.'cfg(near)'.dependencies]
 near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.2" }

--- a/near-sdk-core/src/types/public_key.rs
+++ b/near-sdk-core/src/types/public_key.rs
@@ -95,6 +95,14 @@ const _: () = {
             let curve_type = match value {
                 near_crypto::PublicKey::ED25519(_) => CurveType::ED25519,
                 near_crypto::PublicKey::SECP256K1(_) => CurveType::SECP256K1,
+                // near_sdk's PublicKey/CurveType only models ed25519 and secp256k1. ML-DSA-65
+                // (post-quantum, added in nearcore 2.13) has no representation here. Matched
+                // explicitly so a future near_crypto variant re-triggers this exhaustiveness error.
+                near_crypto::PublicKey::MLDSA65(_) => {
+                    panic!(
+                        "near_sdk::PublicKey does not support ML-DSA-65 (post-quantum) near_crypto::PublicKey keys"
+                    )
+                }
             };
             Self { data: [[curve_type as u8].as_slice(), value.key_data()].concat() }
         }

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -59,13 +59,13 @@ near-abi = { version = "0.4.0", features = [
 ], optional = true }
 # nearcore 2.13 adds the promise_yield_create_with_id / promise_yield_resume_with_yield_id host
 # functions (protocol v85), so the unit-testing mock can delegate to VMLogic for them. Pinned to the
-# published 2.13 release candidate `0.37.0-rc.1`. Bump to `0.37.0` (drop the `=`) once 2.13 ships stable.
-near-vm-runner = { version = "=0.37.0-rc.1", optional = true }
-near-primitives-core = { version = "=0.37.0-rc.1", optional = true }
-near-primitives = { version = "=0.37.0-rc.1", optional = true }
-near-crypto = { version = "=0.37.0-rc.1", default-features = false, optional = true }
+# published 2.13 release candidate `0.37.0-rc.2`. Bump to `0.37.0` (drop the `=`) once 2.13 ships stable.
+near-vm-runner = { version = "=0.37.0-rc.2", optional = true }
+near-primitives-core = { version = "=0.37.0-rc.2", optional = true }
+near-primitives = { version = "=0.37.0-rc.2", optional = true }
+near-crypto = { version = "=0.37.0-rc.2", default-features = false, optional = true }
 unicode-segmentation = { version = "1", optional = true }
-near-parameters = { version = "=0.37.0-rc.1", optional = true }
+near-parameters = { version = "=0.37.0-rc.2", optional = true }
 
 [dev-dependencies]
 openssl = { version = "0.10", features = ["vendored"] }

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -58,15 +58,14 @@ near-abi = { version = "0.4.0", features = [
     "__chunked-entries",
 ], optional = true }
 # nearcore 2.13 adds the promise_yield_create_with_id / promise_yield_resume_with_yield_id host
-# functions (protocol v85), which are not in any published near-vm-runner release yet (latest is
-# 0.36.0). Pin the nearcore-versioned crates to the 2.13-release branch HEAD so the unit-testing
-# mock can delegate to VMLogic for them. Revert to crates.io versions once a 2.13 release is published.
-near-vm-runner = { git = "https://github.com/near/nearcore", rev = "1aa50f765d15d1cd5a946daf3eff04646c5a1957", optional = true }
-near-primitives-core = { git = "https://github.com/near/nearcore", rev = "1aa50f765d15d1cd5a946daf3eff04646c5a1957", optional = true }
-near-primitives = { git = "https://github.com/near/nearcore", rev = "1aa50f765d15d1cd5a946daf3eff04646c5a1957", optional = true }
-near-crypto = { git = "https://github.com/near/nearcore", rev = "1aa50f765d15d1cd5a946daf3eff04646c5a1957", default-features = false, optional = true }
+# functions (protocol v85), so the unit-testing mock can delegate to VMLogic for them. Pinned to the
+# published 2.13 release candidate `0.37.0-rc.1`. Bump to `0.37.0` (drop the `=`) once 2.13 ships stable.
+near-vm-runner = { version = "=0.37.0-rc.1", optional = true }
+near-primitives-core = { version = "=0.37.0-rc.1", optional = true }
+near-primitives = { version = "=0.37.0-rc.1", optional = true }
+near-crypto = { version = "=0.37.0-rc.1", default-features = false, optional = true }
 unicode-segmentation = { version = "1", optional = true }
-near-parameters = { git = "https://github.com/near/nearcore", rev = "1aa50f765d15d1cd5a946daf3eff04646c5a1957", optional = true }
+near-parameters = { version = "=0.37.0-rc.1", optional = true }
 
 [dev-dependencies]
 openssl = { version = "0.10", features = ["vendored"] }

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -57,12 +57,16 @@ ed25519-dalek = { version = "2.2.0", optional = true }
 near-abi = { version = "0.4.0", features = [
     "__chunked-entries",
 ], optional = true }
-near-vm-runner = { version = "0.36.0", optional = true }
-near-primitives-core = { version = "0.36.0", optional = true }
-near-primitives = { version = "0.36.0", optional = true }
-near-crypto = { version = "0.36.0", default-features = false, optional = true }
+# nearcore 2.13 adds the promise_yield_create_with_id / promise_yield_resume_with_yield_id host
+# functions (protocol v85), which are not in any published near-vm-runner release yet (latest is
+# 0.36.0). Pin the nearcore-versioned crates to the 2.13-release branch HEAD so the unit-testing
+# mock can delegate to VMLogic for them. Revert to crates.io versions once a 2.13 release is published.
+near-vm-runner = { git = "https://github.com/near/nearcore", rev = "1aa50f765d15d1cd5a946daf3eff04646c5a1957", optional = true }
+near-primitives-core = { git = "https://github.com/near/nearcore", rev = "1aa50f765d15d1cd5a946daf3eff04646c5a1957", optional = true }
+near-primitives = { git = "https://github.com/near/nearcore", rev = "1aa50f765d15d1cd5a946daf3eff04646c5a1957", optional = true }
+near-crypto = { git = "https://github.com/near/nearcore", rev = "1aa50f765d15d1cd5a946daf3eff04646c5a1957", default-features = false, optional = true }
 unicode-segmentation = { version = "1", optional = true }
-near-parameters = { version = "0.36.0", optional = true }
+near-parameters = { git = "https://github.com/near/nearcore", rev = "1aa50f765d15d1cd5a946daf3eff04646c5a1957", optional = true }
 
 [dev-dependencies]
 openssl = { version = "0.10", features = ["vendored"] }

--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -1574,6 +1574,145 @@ pub fn promise_batch_action_add_key_allowance_with_function_call(
     }
 }
 
+/// Attach a transfer-to-gas-key promise action to the NEAR promise index with the provided promise index.
+///
+/// More info about batching [here](crate::env::promise_batch_create)
+///
+/// # Requirements
+///
+/// Requires the host to support gas-key host functions (nearcore protocol version 85+, shipped in nearcore 2.13).
+/// # Examples
+/// ```no_run
+/// use near_sdk::env::{promise_batch_action_transfer_to_gas_key, promise_batch_create};
+/// use near_sdk::{NearToken, PublicKey, AccountId};
+/// use std::str::FromStr;
+///
+/// let promise = promise_batch_create(
+///     &AccountId::from_str("receiver.near").unwrap()
+/// );
+///
+/// let pk: PublicKey = "secp256k1:qMoRgcoXai4mBPsdbHi1wfyxF9TdbPCF4qSDQTRP3TfescSRoUdSx6nmeQoN3aiwGzwMyGXAb1gUjBTv5AY8DXj".parse().unwrap();
+/// promise_batch_action_transfer_to_gas_key(
+///     promise,
+///     &pk,
+///     NearToken::from_near(1)
+/// );
+/// ```
+/// More low-level info here: [`near_vm_runner::logic::VMLogic::promise_batch_action_transfer_to_gas_key`]
+pub fn promise_batch_action_transfer_to_gas_key(
+    promise_index: PromiseIndex,
+    public_key: &PublicKey,
+    amount: NearToken,
+) {
+    unsafe {
+        sys::promise_batch_action_transfer_to_gas_key(
+            promise_index.0,
+            public_key.as_bytes().len() as _,
+            public_key.as_bytes().as_ptr() as _,
+            &amount.as_yoctonear() as *const u128 as _,
+        )
+    }
+}
+
+/// Attach promise action that adds a gas key with full access to the NEAR promise index with the provided promise index.
+///
+/// More info about batching [here](crate::env::promise_batch_create)
+///
+/// # Requirements
+///
+/// Requires the host to support gas-key host functions (nearcore protocol version 85+, shipped in nearcore 2.13).
+/// # Examples
+/// ```no_run
+/// use near_sdk::env::{promise_batch_action_add_gas_key_with_full_access, promise_batch_create};
+/// use near_sdk::{PublicKey, AccountId};
+/// use std::str::FromStr;
+///
+/// let promise = promise_batch_create(
+///     &AccountId::from_str("receiver.near").unwrap()
+/// );
+///
+/// let pk: PublicKey = "secp256k1:qMoRgcoXai4mBPsdbHi1wfyxF9TdbPCF4qSDQTRP3TfescSRoUdSx6nmeQoN3aiwGzwMyGXAb1gUjBTv5AY8DXj".parse().unwrap();
+/// let num_nonces = 3;
+/// promise_batch_action_add_gas_key_with_full_access(
+///     promise,
+///     &pk,
+///     num_nonces
+/// );
+/// ```
+/// More low-level info here: [`near_vm_runner::logic::VMLogic::promise_batch_action_add_gas_key_with_full_access`]
+pub fn promise_batch_action_add_gas_key_with_full_access(
+    promise_index: PromiseIndex,
+    public_key: &PublicKey,
+    num_nonces: u32,
+) {
+    unsafe {
+        sys::promise_batch_action_add_gas_key_with_full_access(
+            promise_index.0,
+            public_key.as_bytes().len() as _,
+            public_key.as_bytes().as_ptr() as _,
+            num_nonces as u64,
+        )
+    }
+}
+
+/// Attach promise action that adds a gas key restricted to function calls with a specific allowance
+/// to the NEAR promise index with the provided promise index.
+///
+/// More info about batching [here](crate::env::promise_batch_create)
+///
+/// # Requirements
+///
+/// Requires the host to support gas-key host functions (nearcore protocol version 85+, shipped in nearcore 2.13).
+/// # Examples
+/// ```no_run
+/// use near_sdk::env::{promise_batch_action_add_gas_key_with_function_call, promise_batch_create};
+/// use near_sdk::{PublicKey, AccountId, Allowance, NearToken};
+/// use std::str::FromStr;
+///
+/// let promise = promise_batch_create(
+///     &AccountId::from_str("receiver.near").unwrap()
+/// );
+///
+/// let pk: PublicKey = "secp256k1:qMoRgcoXai4mBPsdbHi1wfyxF9TdbPCF4qSDQTRP3TfescSRoUdSx6nmeQoN3aiwGzwMyGXAb1gUjBTv5AY8DXj".parse().unwrap();
+/// let num_nonces = 3;
+/// promise_batch_action_add_gas_key_with_function_call(
+///     promise,
+///     &pk,
+///     num_nonces,
+///     Allowance::limited(NearToken::from_near(1)).unwrap(),
+///     &AccountId::from_str("counter.near").unwrap(),
+///     "increase,decrease"
+/// );
+/// ```
+/// More low-level info here: [`near_vm_runner::logic::VMLogic::promise_batch_action_add_gas_key_with_function_call`]
+pub fn promise_batch_action_add_gas_key_with_function_call(
+    promise_index: PromiseIndex,
+    public_key: &PublicKey,
+    num_nonces: u32,
+    allowance: Allowance,
+    receiver_id: &AccountId,
+    function_names: &str,
+) {
+    let receiver_id: &str = receiver_id.as_ref();
+    let allowance = match allowance {
+        Allowance::Limited(x) => x.get(),
+        Allowance::Unlimited => 0,
+    };
+    unsafe {
+        sys::promise_batch_action_add_gas_key_with_function_call(
+            promise_index.0,
+            public_key.as_bytes().len() as _,
+            public_key.as_bytes().as_ptr() as _,
+            num_nonces as u64,
+            &allowance as *const u128 as _,
+            receiver_id.len() as _,
+            receiver_id.as_ptr() as _,
+            function_names.len() as _,
+            function_names.as_ptr() as _,
+        )
+    }
+}
+
 /// Attach promise action that deletes the key to the NEAR promise index with the provided promise index.
 ///
 /// More info about batching [here](crate::env::promise_batch_create)

--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -2017,6 +2017,77 @@ pub fn promise_yield_resume(data_id: &CryptoHash, data: impl AsRef<[u8]>) -> boo
     }
 }
 
+/// Like [`promise_yield_create`], but the caller supplies a custom 32-byte `yield_id` and may
+/// attach a `deposit`. The yield is later resumed with the same `yield_id` via
+/// [`promise_yield_resume_with_yield_id`], so both the creator and the resumer can derive the id
+/// deterministically (e.g. from a request id) without first reading a runtime-generated `data_id`
+/// out of a register.
+///
+/// Returns `None` if a yield with the same `yield_id` is already pending for the current account.
+/// The host reports this duplicate with the `u64::MAX` sentinel and does not charge for receipt
+/// creation, so callers can branch on `None` to recover instead of aborting.
+///
+/// # Requirements
+/// Requires the host to support the yield-with-id functions (nearcore protocol version 85+,
+/// shipped in nearcore 2.13). `yield_id` must be exactly 32 bytes or the host aborts execution
+/// with `YieldIdMalformed`.
+///
+/// More low-level info here: [`near_vm_runner::logic::VMLogic::promise_yield_create_with_id`]
+pub fn promise_yield_create_with_id(
+    function_name: &str,
+    arguments: impl AsRef<[u8]>,
+    deposit: NearToken,
+    gas: Gas,
+    weight: GasWeight,
+    yield_id: &[u8],
+) -> Option<PromiseIndex> {
+    let arguments = arguments.as_ref();
+    let promise_index = unsafe {
+        sys::promise_yield_create_with_id(
+            function_name.len() as _,
+            function_name.as_ptr() as _,
+            arguments.len() as _,
+            arguments.as_ptr() as _,
+            &deposit.as_yoctonear() as *const u128 as _,
+            gas.as_gas(),
+            weight.0,
+            yield_id.len() as _,
+            yield_id.as_ptr() as _,
+        )
+    };
+    // `u64::MAX` is the host's "already pending" sentinel, not a valid promise index.
+    if promise_index == u64::MAX {
+        None
+    } else {
+        Some(PromiseIndex(promise_index))
+    }
+}
+
+/// Resumes a yield previously created with [`promise_yield_create_with_id`], using the same
+/// caller-provided `yield_id`. `data` is the payload passed to the yield callback as a promise
+/// result.
+///
+/// Returns `false` if no pending yield with the given `yield_id` exists for the current account
+/// (already resumed, timed out, or never created); `true` otherwise, guaranteeing the callback
+/// will run with the payload.
+///
+/// # Requirements
+/// Requires the host to support the yield-with-id functions (nearcore protocol version 85+,
+/// shipped in nearcore 2.13).
+///
+/// More low-level info here: [`near_vm_runner::logic::VMLogic::promise_yield_resume_with_yield_id`]
+pub fn promise_yield_resume_with_yield_id(yield_id: &[u8], data: impl AsRef<[u8]>) -> bool {
+    let data = data.as_ref();
+    unsafe {
+        sys::promise_yield_resume_with_yield_id(
+            yield_id.len() as _,
+            yield_id.as_ptr() as _,
+            data.len() as _,
+            data.as_ptr() as _,
+        ) != 0
+    }
+}
+
 // ###############
 // # Validator API #
 // ###############

--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -2056,11 +2056,7 @@ pub fn promise_yield_create_with_id(
         )
     };
     // `u64::MAX` is the host's "already pending" sentinel, not a valid promise index.
-    if promise_index == u64::MAX {
-        None
-    } else {
-        Some(PromiseIndex(promise_index))
-    }
+    if promise_index == u64::MAX { None } else { Some(PromiseIndex(promise_index)) }
 }
 
 /// Resumes a yield previously created with [`promise_yield_create_with_id`], using the same

--- a/near-sdk/src/environment/mock/mocked_blockchain.rs
+++ b/near-sdk/src/environment/mock/mocked_blockchain.rs
@@ -656,6 +656,64 @@ mod mock_chain {
         })
     }
     #[unsafe(no_mangle)]
+    extern "C-unwind" fn promise_batch_action_transfer_to_gas_key(
+        promise_index: u64,
+        public_key_len: u64,
+        public_key_ptr: u64,
+        amount_ptr: u64,
+    ) {
+        with_mock_interface(|b| {
+            b.promise_batch_action_transfer_to_gas_key(
+                promise_index,
+                public_key_len,
+                public_key_ptr,
+                amount_ptr,
+            )
+        })
+    }
+    #[unsafe(no_mangle)]
+    extern "C-unwind" fn promise_batch_action_add_gas_key_with_full_access(
+        promise_index: u64,
+        public_key_len: u64,
+        public_key_ptr: u64,
+        num_nonces: u64,
+    ) {
+        with_mock_interface(|b| {
+            b.promise_batch_action_add_gas_key_with_full_access(
+                promise_index,
+                public_key_len,
+                public_key_ptr,
+                num_nonces,
+            )
+        })
+    }
+    #[unsafe(no_mangle)]
+    extern "C-unwind" fn promise_batch_action_add_gas_key_with_function_call(
+        promise_index: u64,
+        public_key_len: u64,
+        public_key_ptr: u64,
+        num_nonces: u64,
+        allowance_ptr: u64,
+        receiver_id_len: u64,
+        receiver_id_ptr: u64,
+        method_names_len: u64,
+        method_names_ptr: u64,
+    ) {
+        with_mock_interface(|b| {
+            b.promise_batch_action_add_gas_key_with_function_call(
+                promise_index,
+                public_key_len,
+                public_key_ptr,
+                num_nonces,
+                allowance_ptr,
+                receiver_id_len,
+                receiver_id_ptr,
+                method_names_len,
+                method_names_ptr,
+            )
+        })
+    }
+    #[unsafe(no_mangle)]
     extern "C-unwind" fn promise_batch_action_delete_key(
         promise_index: u64,
         public_key_len: u64,

--- a/near-sdk/src/environment/mock/mocked_blockchain.rs
+++ b/near-sdk/src/environment/mock/mocked_blockchain.rs
@@ -746,7 +746,12 @@ mod mock_chain {
         payload_ptr: u64,
     ) -> u32 {
         with_mock_interface(|b| {
-            b.promise_yield_resume_with_yield_id(yield_id_len, yield_id_ptr, payload_len, payload_ptr)
+            b.promise_yield_resume_with_yield_id(
+                yield_id_len,
+                yield_id_ptr,
+                payload_len,
+                payload_ptr,
+            )
         })
     }
     #[unsafe(no_mangle)]

--- a/near-sdk/src/environment/mock/mocked_blockchain.rs
+++ b/near-sdk/src/environment/mock/mocked_blockchain.rs
@@ -713,6 +713,43 @@ mod mock_chain {
         })
     }
     #[unsafe(no_mangle)]
+    extern "C-unwind" fn promise_yield_create_with_id(
+        function_name_len: u64,
+        function_name_ptr: u64,
+        arguments_len: u64,
+        arguments_ptr: u64,
+        amount_ptr: u64,
+        gas: u64,
+        gas_weight: u64,
+        yield_id_len: u64,
+        yield_id_ptr: u64,
+    ) -> u64 {
+        with_mock_interface(|b| {
+            b.promise_yield_create_with_id(
+                function_name_len,
+                function_name_ptr,
+                arguments_len,
+                arguments_ptr,
+                amount_ptr,
+                gas,
+                gas_weight,
+                yield_id_len,
+                yield_id_ptr,
+            )
+        })
+    }
+    #[unsafe(no_mangle)]
+    extern "C-unwind" fn promise_yield_resume_with_yield_id(
+        yield_id_len: u64,
+        yield_id_ptr: u64,
+        payload_len: u64,
+        payload_ptr: u64,
+    ) -> u32 {
+        with_mock_interface(|b| {
+            b.promise_yield_resume_with_yield_id(yield_id_len, yield_id_ptr, payload_len, payload_ptr)
+        })
+    }
+    #[unsafe(no_mangle)]
     extern "C-unwind" fn promise_results_count() -> u64 {
         with_mock_interface(|b| b.promise_results_count())
     }

--- a/near-sdk/src/environment/mock/receipt.rs
+++ b/near-sdk/src/environment/mock/receipt.rs
@@ -81,6 +81,10 @@ pub enum MockAction {
     YieldCreate {
         data_id: near_primitives::hash::CryptoHash,
         receiver_id: AccountId,
+        /// The caller-provided yield id when the yield was created via
+        /// `promise_yield_create_with_id`, or `None` for a runtime-generated yield from
+        /// `promise_yield_create`.
+        yield_id: Option<near_primitives::hash::YieldId>,
     },
     YieldResume {
         data: Vec<u8>,
@@ -236,8 +240,8 @@ impl From<LogicMockAction> for MockAction {
             LogicMockAction::AddKeyWithFullAccess { receipt_index, public_key, nonce } => {
                 Self::AddKeyWithFullAccess { receipt_index, public_key, nonce }
             }
-            LogicMockAction::YieldCreate { data_id, receiver_id } => {
-                Self::YieldCreate { data_id, receiver_id }
+            LogicMockAction::YieldCreate { data_id, receiver_id, yield_id } => {
+                Self::YieldCreate { data_id, receiver_id, yield_id }
             }
             LogicMockAction::YieldResume { data, data_id } => Self::YieldResume { data, data_id },
             #[cfg(feature = "deterministic-account-ids")]

--- a/near-sdk/src/lib.rs
+++ b/near-sdk/src/lib.rs
@@ -1606,7 +1606,9 @@ pub use environment::env;
 pub use near_sys as sys;
 
 mod promise;
-pub use promise::{Allowance, ConcurrentPromises, Promise, PromiseOrValue, ResumeError, YieldId};
+pub use promise::{
+    Allowance, ConcurrentPromises, Promise, PromiseOrValue, ResumeError, UserYieldId, YieldId,
+};
 
 // Private types just used within macro generation, not stable to be used.
 #[doc(hidden)]

--- a/near-sdk/src/promise.rs
+++ b/near-sdk/src/promise.rs
@@ -61,6 +61,21 @@ enum PromiseAction {
     DeleteAccount {
         beneficiary_id: AccountId,
     },
+    TransferToGasKey {
+        public_key: PublicKey,
+        amount: NearToken,
+    },
+    AddGasKeyFullAccess {
+        public_key: PublicKey,
+        num_nonces: u32,
+    },
+    AddGasKeyFunctionCall {
+        public_key: PublicKey,
+        num_nonces: u32,
+        allowance: Allowance,
+        receiver_id: AccountId,
+        function_names: String,
+    },
     DeployGlobalContract {
         code: Vec<u8>,
     },
@@ -134,6 +149,34 @@ impl PromiseAction {
             DeleteAccount { beneficiary_id } => {
                 crate::env::promise_batch_action_delete_account(promise_index, &beneficiary_id)
             }
+            TransferToGasKey { public_key, amount } => {
+                crate::env::promise_batch_action_transfer_to_gas_key(
+                    promise_index,
+                    &public_key,
+                    amount,
+                )
+            }
+            AddGasKeyFullAccess { public_key, num_nonces } => {
+                crate::env::promise_batch_action_add_gas_key_with_full_access(
+                    promise_index,
+                    &public_key,
+                    num_nonces,
+                )
+            }
+            AddGasKeyFunctionCall {
+                public_key,
+                num_nonces,
+                allowance,
+                receiver_id,
+                function_names,
+            } => crate::env::promise_batch_action_add_gas_key_with_function_call(
+                promise_index,
+                &public_key,
+                num_nonces,
+                allowance,
+                &receiver_id,
+                &function_names,
+            ),
             DeployGlobalContract { code } => {
                 crate::env::promise_batch_action_deploy_global_contract(promise_index, &code)
             }
@@ -687,6 +730,54 @@ impl Promise {
     /// Uses low-level [`crate::env::promise_batch_action_delete_account`]
     pub fn delete_account(self, beneficiary_id: AccountId) -> Self {
         self.add_action(PromiseAction::DeleteAccount { beneficiary_id })
+    }
+
+    /// Transfer tokens to a gas key on the account that this promise acts on.
+    /// Uses low-level [`crate::env::promise_batch_action_transfer_to_gas_key`]
+    ///
+    /// # Requirements
+    ///
+    /// Requires the host to support gas-key host functions (nearcore protocol version 85+,
+    /// shipped in nearcore 2.13).
+    pub fn transfer_to_gas_key(self, public_key: PublicKey, amount: NearToken) -> Self {
+        self.add_action(PromiseAction::TransferToGasKey { public_key, amount })
+    }
+
+    /// Add a full access gas key to the given account, reserving `num_nonces` parallel nonces.
+    /// Uses low-level [`crate::env::promise_batch_action_add_gas_key_with_full_access`]
+    ///
+    /// # Requirements
+    ///
+    /// Requires the host to support gas-key host functions (nearcore protocol version 85+,
+    /// shipped in nearcore 2.13).
+    pub fn add_gas_key_full_access(self, public_key: PublicKey, num_nonces: u32) -> Self {
+        self.add_action(PromiseAction::AddGasKeyFullAccess { public_key, num_nonces })
+    }
+
+    /// Add a gas key restricted to only calling a smart contract on some account using only a
+    /// restricted set of methods, reserving `num_nonces` parallel nonces. Here `function_names`
+    /// is a comma separated list of methods, e.g. `"method_a,method_b"`.
+    /// Uses low-level [`crate::env::promise_batch_action_add_gas_key_with_function_call`]
+    ///
+    /// # Requirements
+    ///
+    /// Requires the host to support gas-key host functions (nearcore protocol version 85+,
+    /// shipped in nearcore 2.13).
+    pub fn add_gas_key_allowance_function_call(
+        self,
+        public_key: PublicKey,
+        num_nonces: u32,
+        allowance: Allowance,
+        receiver_id: AccountId,
+        function_names: String,
+    ) -> Self {
+        self.add_action(PromiseAction::AddGasKeyFunctionCall {
+            public_key,
+            num_nonces,
+            allowance,
+            receiver_id,
+            function_names,
+        })
     }
 
     /// Merge this promise with another promise, so that we can schedule execution of another
@@ -1357,6 +1448,101 @@ mod tests {
             function_names,
             Some(nonce)
         ));
+    }
+
+    #[test]
+    fn test_transfer_to_gas_key() {
+        testing_env!(VMContextBuilder::new().signer_account_id(alice()).build());
+
+        let public_key: PublicKey = pk();
+        let amount = NearToken::from_yoctonear(1000);
+
+        {
+            Promise::new(alice())
+                .create_account()
+                .transfer_to_gas_key(public_key.clone(), amount)
+                .detach();
+        }
+
+        let public_key = near_crypto::PublicKey::try_from(public_key).unwrap();
+        let has_action = get_actions().any(|el| {
+            matches!(
+                el,
+                MockAction::TransferToGasKey { public_key: p, deposit, receipt_index: _ }
+                if p == public_key && deposit == amount
+            )
+        });
+        assert!(has_action);
+    }
+
+    #[test]
+    fn test_add_gas_key_full_access() {
+        testing_env!(VMContextBuilder::new().signer_account_id(alice()).build());
+
+        let public_key: PublicKey = pk();
+
+        {
+            Promise::new(alice())
+                .create_account()
+                .add_gas_key_full_access(public_key.clone(), 3)
+                .detach();
+        }
+
+        let public_key = near_crypto::PublicKey::try_from(public_key).unwrap();
+        let has_action = get_actions().any(|el| {
+            matches!(
+                el,
+                MockAction::AddGasKeyWithFullAccess { public_key: p, num_nonces: 3, receipt_index: _ }
+                if p == public_key
+            )
+        });
+        assert!(has_action);
+    }
+
+    #[test]
+    fn test_add_gas_key_allowance_function_call() {
+        testing_env!(VMContextBuilder::new().signer_account_id(alice()).build());
+
+        let public_key: PublicKey = pk();
+        let allowance = 100;
+        let receiver_id = bob();
+        let function_names = "method_a,method_b".to_string();
+
+        {
+            Promise::new(alice())
+                .create_account()
+                .add_gas_key_allowance_function_call(
+                    public_key.clone(),
+                    5,
+                    Allowance::Limited(allowance.try_into().unwrap()),
+                    receiver_id.clone(),
+                    function_names.clone(),
+                )
+                .detach();
+        }
+
+        let public_key = near_crypto::PublicKey::try_from(public_key).unwrap();
+        let has_action = get_actions().any(|el| {
+            matches!(
+                el,
+                MockAction::AddGasKeyWithFunctionCall {
+                    public_key: p,
+                    num_nonces: 5,
+                    allowance: a,
+                    receiver_id: r,
+                    method_names,
+                    receipt_index: _,
+                }
+                if p == public_key
+                    && a == Some(NearToken::from_yoctonear(allowance))
+                    && r == receiver_id
+                    && method_names == function_names
+                        .split(',')
+                        .map(|s| s.as_bytes().to_vec())
+                        .collect::<Vec<_>>()
+            )
+        });
+        assert!(has_action);
     }
 
     #[test]

--- a/near-sdk/src/promise.rs
+++ b/near-sdk/src/promise.rs
@@ -388,6 +388,55 @@ impl Promise {
         (promise, yield_id)
     }
 
+    /// Create a yielded promise with a caller-provided [`UserYieldId`] and an optional `deposit`.
+    ///
+    /// Like [`Promise::new_yield`], but the caller supplies the resumption identifier instead of
+    /// the runtime generating one. The promise is later resumed with the same id via
+    /// [`UserYieldId::resume`], so the creator and the resumer can derive the id independently
+    /// (e.g. from a request id) without round-tripping a runtime-generated `data_id`.
+    ///
+    /// Returns `None` if a yield with the same `yield_id` is already pending for the current
+    /// account, letting the caller detect and recover from duplicates instead of aborting.
+    ///
+    /// # Arguments
+    /// * `function_name` - The callback function to invoke when the promise is resumed
+    /// * `arguments` - Arguments to pass to the callback function
+    /// * `deposit` - Amount of NEAR to attach to the callback (use `NearToken::from_yoctonear(0)` for none)
+    /// * `gas` - Base gas to allocate for the callback
+    /// * `weight` - Gas weight for distributing remaining gas
+    /// * `yield_id` - The caller-provided 32-byte resumption identifier
+    ///
+    /// # Requirements
+    /// Requires the host to support the yield-with-id functions (nearcore protocol version 85+,
+    /// shipped in nearcore 2.13).
+    ///
+    /// # Important
+    /// Like [`Promise::new_yield`], the resulting promise cannot be used as a continuation
+    /// (`other.then(yielded)` panics); it must come first in a chain.
+    ///
+    /// Uses low-level [`crate::env::promise_yield_create_with_id`]
+    pub fn new_yield_with_id(
+        function_name: &str,
+        arguments: impl AsRef<[u8]>,
+        deposit: NearToken,
+        gas: Gas,
+        weight: GasWeight,
+        yield_id: UserYieldId,
+    ) -> Option<Self> {
+        let promise_index = crate::env::promise_yield_create_with_id(
+            function_name,
+            arguments,
+            deposit,
+            gas,
+            weight,
+            yield_id.as_bytes(),
+        )?;
+        let promise = Self::new_with_subtype(PromiseSubtype::Single(PromiseSingle::new(
+            PromiseSingleSubtype::Yielded(promise_index),
+        )));
+        Some(promise)
+    }
+
     /// Set a different [`AccountId`] instead of current one to which refunds
     /// should go for all failed (e.g. [function_call](Promise::function_call_weight))
     /// or unused (e.g. [state_init](Promise::state_init)) deposits in
@@ -903,6 +952,72 @@ impl YieldId {
     /// Uses low-level [`crate::env::promise_yield_resume`]
     pub fn resume(self, data: impl AsRef<[u8]>) -> Result<(), ResumeError> {
         if crate::env::promise_yield_resume(&self.0, data) { Ok(()) } else { Err(ResumeError) }
+    }
+}
+
+/// A caller-provided identifier for a yielded promise created with [`Promise::new_yield_with_id`].
+///
+/// Unlike [`YieldId`] — which wraps the runtime-generated `data_id` returned by
+/// [`Promise::new_yield`] — a `UserYieldId` is chosen by the contract itself (any 32 bytes, e.g.
+/// derived from a request id). Because both the creator and the resumer can compute it
+/// independently, the resumer doesn't need the creator to hand back a runtime-generated token.
+///
+/// # Example
+/// ```ignore
+/// use near_sdk::{Promise, NearToken, Gas, GasWeight, UserYieldId};
+///
+/// let yield_id = UserYieldId::new([7u8; 32]);
+/// let promise = Promise::new_yield_with_id(
+///     "on_resume",
+///     vec![],
+///     NearToken::from_yoctonear(0),
+///     Gas::from_tgas(5),
+///     GasWeight(1),
+///     yield_id,
+/// )
+/// .expect("a yield with this id is already pending");
+///
+/// // Later, from another transaction, resume with the same id:
+/// yield_id.resume(b"result data").unwrap();
+/// ```
+#[near(inside_nearsdk, serializers = [json, borsh])]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
+pub struct UserYieldId(
+    #[serde_as(as = "::serde_with::base64::Base64")]
+    #[cfg_attr(feature = "abi", schemars(with = "String"))]
+    pub CryptoHash,
+);
+
+impl UserYieldId {
+    /// Construct a `UserYieldId` from 32 raw bytes.
+    pub const fn new(bytes: CryptoHash) -> Self {
+        Self(bytes)
+    }
+
+    /// The 32-byte identifier.
+    pub const fn as_bytes(&self) -> &CryptoHash {
+        &self.0
+    }
+
+    /// Resume the yielded promise created with this id, passing `data` to the callback as a
+    /// promise result.
+    ///
+    /// Returns `Ok(())` if a pending yield with this id was found and resume was submitted, or
+    /// `Err(ResumeError)` if none exists (already resumed, timed out, or never created).
+    ///
+    /// Uses low-level [`crate::env::promise_yield_resume_with_yield_id`]
+    pub fn resume(&self, data: impl AsRef<[u8]>) -> Result<(), ResumeError> {
+        if crate::env::promise_yield_resume_with_yield_id(&self.0, data) {
+            Ok(())
+        } else {
+            Err(ResumeError)
+        }
+    }
+}
+
+impl From<CryptoHash> for UserYieldId {
+    fn from(bytes: CryptoHash) -> Self {
+        Self(bytes)
     }
 }
 
@@ -1676,6 +1791,87 @@ mod tests {
         assert_eq!(
             bob_receipt.actions[0],
             MockAction::Transfer { receipt_index, deposit: NearToken::from_yoctonear(1000) }
+        );
+    }
+
+    #[test]
+    fn test_new_yield_with_id_returns_promise() {
+        use crate::{Gas, GasWeight, UserYieldId};
+
+        testing_env!(VMContextBuilder::new().signer_account_id(alice()).build());
+
+        let yield_id = UserYieldId::new([7u8; 32]);
+        let promise = Promise::new_yield_with_id(
+            "on_callback",
+            b"args",
+            NearToken::from_yoctonear(0),
+            Gas::from_tgas(10),
+            GasWeight(1),
+            yield_id,
+        );
+
+        assert!(promise.is_some(), "new_yield_with_id should return Some for a fresh yield id");
+    }
+
+    #[test]
+    fn test_new_yield_with_id_duplicate_returns_none() {
+        use crate::{Gas, GasWeight, UserYieldId};
+
+        testing_env!(VMContextBuilder::new().signer_account_id(alice()).build());
+
+        let yield_id = UserYieldId::new([3u8; 32]);
+        let make = || {
+            Promise::new_yield_with_id(
+                "on_callback",
+                vec![],
+                NearToken::from_yoctonear(0),
+                Gas::from_tgas(5),
+                GasWeight(1),
+                yield_id,
+            )
+        };
+
+        let _first = make().expect("first create with a fresh id should succeed");
+        assert!(
+            make().is_none(),
+            "second create with the same yield id should return None (duplicate detected)"
+        );
+    }
+
+    #[test]
+    fn test_user_yield_id_resume() {
+        use crate::{Gas, GasWeight, UserYieldId};
+
+        testing_env!(VMContextBuilder::new().signer_account_id(alice()).build());
+
+        let yield_id = UserYieldId::new([9u8; 32]);
+        let _promise = Promise::new_yield_with_id(
+            "on_resume",
+            vec![],
+            NearToken::from_yoctonear(0),
+            Gas::from_tgas(5),
+            GasWeight(1),
+            yield_id,
+        )
+        .expect("create with a fresh id should succeed");
+
+        assert!(
+            yield_id.resume(b"payload").is_ok(),
+            "resuming a pending yield by its id should succeed"
+        );
+    }
+
+    #[test]
+    fn test_user_yield_id_resume_unknown_returns_err() {
+        use crate::UserYieldId;
+
+        testing_env!(VMContextBuilder::new().signer_account_id(alice()).build());
+
+        // No yield was ever created for this id.
+        let unknown = UserYieldId::new([1u8; 32]);
+        assert!(
+            unknown.resume(b"payload").is_err(),
+            "resuming an unknown yield id should return Err(ResumeError)"
         );
     }
 }

--- a/near-sys/src/lib.rs
+++ b/near-sys/src/lib.rs
@@ -166,6 +166,29 @@ unsafe extern "C" {
         function_names_len: u64,
         function_names_ptr: u64,
     );
+    pub fn promise_batch_action_transfer_to_gas_key(
+        promise_index: u64,
+        public_key_len: u64,
+        public_key_ptr: u64,
+        amount_ptr: u64,
+    );
+    pub fn promise_batch_action_add_gas_key_with_full_access(
+        promise_index: u64,
+        public_key_len: u64,
+        public_key_ptr: u64,
+        num_nonces: u64,
+    );
+    pub fn promise_batch_action_add_gas_key_with_function_call(
+        promise_index: u64,
+        public_key_len: u64,
+        public_key_ptr: u64,
+        num_nonces: u64,
+        allowance_ptr: u64,
+        receiver_id_len: u64,
+        receiver_id_ptr: u64,
+        method_names_len: u64,
+        method_names_ptr: u64,
+    );
     pub fn promise_batch_action_delete_key(
         promise_index: u64,
         public_key_len: u64,

--- a/near-sys/src/lib.rs
+++ b/near-sys/src/lib.rs
@@ -214,6 +214,23 @@ unsafe extern "C" {
         payload_len: u64,
         payload_ptr: u64,
     ) -> u32;
+    pub fn promise_yield_create_with_id(
+        function_name_len: u64,
+        function_name_ptr: u64,
+        arguments_len: u64,
+        arguments_ptr: u64,
+        amount_ptr: u64,
+        gas: u64,
+        gas_weight: u64,
+        yield_id_len: u64,
+        yield_id_ptr: u64,
+    ) -> u64;
+    pub fn promise_yield_resume_with_yield_id(
+        yield_id_len: u64,
+        yield_id_ptr: u64,
+        payload_len: u64,
+        payload_ptr: u64,
+    ) -> u32;
     // #######################
     // # Promise API results #
     // #######################


### PR DESCRIPTION
**Cause:** nearcore 2.13 (protocol v85) adds three gas-key promise-batch host functions — `promise_batch_action_transfer_to_gas_key`, `promise_batch_action_add_gas_key_with_full_access`, and `promise_batch_action_add_gas_key_with_function_call` — but near-sdk has no bindings for them.

**Fix:** Added the `near-sys` extern declarations, the safe `env` wrappers, the `mocked_blockchain` shims, and the `Promise` builder methods (`transfer_to_gas_key`, `add_gas_key_full_access`, `add_gas_key_allowance_function_call`), plus unit tests covering all three builders. The mock receipt-conversion layer (`MockAction::{TransferToGasKey, AddGasKeyWithFullAccess, AddGasKeyWithFunctionCall}`) already landed on master.

**Notes:**
- Stacked on #1563 for the 2.13 crate pin and compat changes; git-pinned to nearcore rev `1aa50f765d` — revert to crates.io once nearcore 2.13 publishes.
- **CI:** the compile / wasm-build / clippy / fmt / doctest / unit-test jobs are green. The `<example> - linux/macos` sandbox integration jobs fail with `Link Error: unknown or invalid import` — they run against the latest published sandbox (protocol v84 / 2.12), which has no gas-key host functions yet. Unlike yield-with-id (#1563, opt-in constructor, only `mpc-contract` affected), gas-key actions live in the core `PromiseAction::add` dispatch, so every action-using contract imports the new host functions and fails to link. This clears automatically once a protocol-v85 sandbox binary is available.