### PR TITLE
feat: `near-digest` crate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ env:
   RUSTFLAGS: -D warnings
 
 jobs:
-  # NOTE: we mainly only "check" if things can compile in extracted crates. 
+  # NOTE: we mainly only "check" if things can compile in extracted crates. Testing is done later by nextest.
   cargo-hack:
     runs-on: ${{ matrix.platform.os }}
     name: "cargo-hack ${{ matrix.crate }} ${{ matrix.platform.name }} ${{ matrix.platform.rs }}"
@@ -20,6 +20,7 @@ jobs:
           - "near-sdk-core"
           - "near-global-contracts"
           - "near-sdk-env"
+          - "near-digest"
         platform:
           - os: warp-ubuntu-latest-x64-4x
             rs: "1.93.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "near-sys",
     "near-global-contracts",
     "near-crypto-hash",
+    "near-digest",
 ]
 exclude = ["examples/"]
 

--- a/near-digest/Cargo.toml
+++ b/near-digest/Cargo.toml
@@ -7,6 +7,9 @@ categories.workspace = true
 repository.workspace = true
 homepage.workspace = true
 rust-version.workspace = true
+description = """
+`digest` trait implementations for hash functions in NEAR smart contracts: backed by NEAR host functions on-chain, pure Rust off-chain.
+"""
 
 [dependencies]
 digest = "0.11.3"

--- a/near-digest/Cargo.toml
+++ b/near-digest/Cargo.toml
@@ -21,6 +21,8 @@ sha3 = { version = "0.11.0", optional = true }
 [target.'cfg(near)'.dependencies]
 near-sdk-env = { path = "../near-sdk-env/" }
 impl-tools = "0.12.0"
+# for `unstable` Sha3-256/512
+sha3 = { version = "0.11.0", optional = true }
 
 [features]
 ripemd = ["dep:ripemd"]
@@ -53,3 +55,6 @@ near-sdk = { path = "../near-sdk/", features = ["unit-testing"] }
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/near-digest/Cargo.toml
+++ b/near-digest/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "near-digest"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+categories.workspace = true
+repository.workspace = true
+homepage.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+digest = "0.11.3"
+
+zeroize = { version = "1.9.0", features = ["derive"], optional = true }
+
+[target.'cfg(not(near))'.dependencies]
+ripemd = { version = "0.2.0", optional = true }
+sha2 = { version = "0.11.0", optional = true }
+sha3 = { version = "0.11.0", optional = true }
+
+[target.'cfg(near)'.dependencies]
+near-sdk-env = { path = "../near-sdk-env/" }
+impl-tools = "0.12.0"
+
+[features]
+ripemd = ["dep:ripemd"]
+sha2 = ["dep:sha2"]
+sha3 = ["dep:sha3"]
+
+zeroize = [
+    "dep:zeroize",
+    "digest/zeroize",
+    "ripemd?/zeroize",
+    "sha2?/zeroize",
+    "sha3?/zeroize",
+]
+
+[dev-dependencies]
+near-digest = { path = ".", features = ["ripemd", "sha2", "sha3", "zeroize"] }
+rstest = "0.26.1"
+hex = "0.4.3"
+
+[target.'cfg(near)'.dev-dependencies]
+near-sdk = { path = "../near-sdk/", features = ["unit-testing"] }
+
+[lints]
+workspace = true

--- a/near-digest/Cargo.toml
+++ b/near-digest/Cargo.toml
@@ -46,7 +46,7 @@ near-digest = { path = ".", features = [
     "unstable",
 ] }
 rstest = "0.26.1"
-hex = "0.4.3"
+hex-literal = "1.1.0"
 
 [target.'cfg(near)'.dev-dependencies]
 near-sdk = { path = "../near-sdk/", features = ["unit-testing"] }

--- a/near-digest/Cargo.toml
+++ b/near-digest/Cargo.toml
@@ -35,8 +35,16 @@ zeroize = [
     "sha3?/zeroize",
 ]
 
+unstable = []
+
 [dev-dependencies]
-near-digest = { path = ".", features = ["ripemd", "sha2", "sha3", "zeroize"] }
+near-digest = { path = ".", features = [
+    "ripemd",
+    "sha2",
+    "sha3",
+    "zeroize",
+    "unstable",
+] }
 rstest = "0.26.1"
 hex = "0.4.3"
 

--- a/near-digest/Cargo.toml
+++ b/near-digest/Cargo.toml
@@ -19,7 +19,7 @@ sha2 = { version = "0.11.0", optional = true }
 sha3 = { version = "0.11.0", optional = true }
 
 [target.'cfg(near)'.dependencies]
-near-sdk-env = { path = "../near-sdk-env/" }
+near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.1" }
 impl-tools = "0.12.0"
 # for `unstable` Sha3-256/512
 sha3 = { version = "0.11.0", optional = true }
@@ -40,6 +40,8 @@ zeroize = [
 unstable = []
 
 [dev-dependencies]
+# XXX: `near-sdk` was added in order to enable tests and doctests compiling with mockchain
+near-sdk = { path = "../near-sdk", features = ["unit-testing"] }
 near-digest = { path = ".", features = [
     "ripemd",
     "sha2",

--- a/near-digest/src/lib.rs
+++ b/near-digest/src/lib.rs
@@ -1,0 +1,65 @@
+//! Helper crate to automatically chose a backend for digest implementations.
+//! Currently supported backends are:
+//!
+//! * `cfg(near)`: via Near host-function
+//! * default: fallback to pure Rust implementation
+
+pub use digest::*;
+
+#[cfg(feature = "ripemd")]
+pub mod ripemd;
+#[cfg(feature = "sha2")]
+pub mod sha2;
+#[cfg(feature = "sha3")]
+pub mod sha3;
+#[cfg(near)]
+mod utils;
+
+// TODO: use `cfg_check!` macro to reduce duplicates once we reach rustc 1.95
+
+macro_rules! digest_cfg {
+    ($vis:vis struct $name:ident {
+        near => $near_path:path,
+        local => $local_path:path $(,)?
+    }) => {
+        #[cfg(near)]
+        #[derive(Debug, Clone, Default)]
+        #[repr(transparent)]
+        $vis struct $name($near_path);
+
+        #[cfg(not(near))]
+        #[derive(Debug, Clone, Default)]
+        #[repr(transparent)]
+        $vis struct $name($local_path);
+
+        #[cfg(near)]
+        impl ::digest::OutputSizeUser for $name {
+            type OutputSize = <$near_path as ::digest::OutputSizeUser>::OutputSize;
+        }
+
+        #[cfg(not(near))]
+        impl ::digest::OutputSizeUser for $name {
+            type OutputSize = <$local_path as ::digest::OutputSizeUser>::OutputSize;
+        }
+
+        impl ::digest::Update for $name {
+            #[inline]
+            fn update(&mut self, data: &[u8]) {
+                ::digest::Update::update(&mut self.0, data);
+            }
+        }
+
+        impl ::digest::FixedOutput for $name {
+            #[inline]
+            fn finalize_into(self, out: &mut ::digest::Output<Self>) {
+                ::digest::FixedOutput::finalize_into(self.0, out);
+            }
+        }
+
+        impl ::digest::HashMarker for $name {}
+
+        #[cfg(feature = "zeroize")]
+        impl ::zeroize::ZeroizeOnDrop for $name {}
+    };
+}
+pub(crate) use digest_cfg;

--- a/near-digest/src/lib.rs
+++ b/near-digest/src/lib.rs
@@ -131,6 +131,20 @@ macro_rules! digest_cfg {
             }
         }
 
+        impl ::digest::Reset for $name {
+            #[inline]
+            fn reset(&mut self) {
+                ::digest::Reset::reset(&mut self.0);
+            }
+        }
+
+        impl ::digest::FixedOutputReset for $name {
+            #[inline]
+            fn finalize_into_reset(&mut self, out: &mut ::digest::Output<Self>) {
+                ::digest::FixedOutputReset::finalize_into_reset(&mut self.0, out);
+            }
+        }
+
         impl ::digest::HashMarker for $name {}
 
         #[cfg(feature = "zeroize")]
@@ -163,6 +177,20 @@ macro_rules! digest_cfg {
             }
         }
 
+        impl ::digest::Reset for $name {
+            #[inline]
+            fn reset(&mut self) {
+                ::digest::Reset::reset(&mut self.0);
+            }
+        }
+
+        impl ::digest::FixedOutputReset for $name {
+            #[inline]
+            fn finalize_into_reset(&mut self, out: &mut ::digest::Output<Self>) {
+                ::digest::FixedOutputReset::finalize_into_reset(&mut self.0, out);
+            }
+        }
+
         impl ::digest::HashMarker for $name {}
 
         #[cfg(feature = "zeroize")]
@@ -171,3 +199,29 @@ macro_rules! digest_cfg {
 }
 #[cfg(any(feature = "ripemd", feature = "sha2", feature = "sha3"))]
 pub(crate) use digest_cfg;
+
+#[cfg(test)]
+pub(crate) mod test_utils {
+    use digest::{Digest, FixedOutputReset, Reset};
+
+    /// Asserts that `reset`/`finalize_reset` return a hasher to its initial state on
+    /// whichever backend was selected for the compilation target.
+    pub(crate) fn assert_reset_roundtrip<D: Digest + FixedOutputReset + Reset>() {
+        let expected_first = D::digest(b"example ");
+        let expected_second = D::digest(b"example2");
+
+        // `finalize_reset` produces the digest of the input so far and clears the state
+        let mut hasher = D::new();
+        Digest::update(&mut hasher, b"example ");
+        assert_eq!(Digest::finalize_reset(&mut hasher), expected_first);
+        Digest::update(&mut hasher, b"example2");
+        assert_eq!(Digest::finalize(hasher), expected_second);
+
+        // `reset` discards buffered input without producing a digest
+        let mut hasher = D::new();
+        Digest::update(&mut hasher, b"example ");
+        Digest::reset(&mut hasher);
+        Digest::update(&mut hasher, b"example2");
+        assert_eq!(Digest::finalize(hasher), expected_second);
+    }
+}

--- a/near-digest/src/lib.rs
+++ b/near-digest/src/lib.rs
@@ -61,5 +61,38 @@ macro_rules! digest_cfg {
         #[cfg(feature = "zeroize")]
         impl ::zeroize::ZeroizeOnDrop for $name {}
     };
+
+    ($vis:vis struct $name:ident {
+        local => $local_path:path $(,)?
+    }) => {
+        #[cfg(not(near))]
+        #[derive(Debug, Clone, Default)]
+        #[repr(transparent)]
+        $vis struct $name($local_path);
+
+        #[cfg(not(near))]
+        impl ::digest::OutputSizeUser for $name {
+            type OutputSize = <$local_path as ::digest::OutputSizeUser>::OutputSize;
+        }
+
+        impl ::digest::Update for $name {
+            #[inline]
+            fn update(&mut self, data: &[u8]) {
+                ::digest::Update::update(&mut self.0, data);
+            }
+        }
+
+        impl ::digest::FixedOutput for $name {
+            #[inline]
+            fn finalize_into(self, out: &mut ::digest::Output<Self>) {
+                ::digest::FixedOutput::finalize_into(self.0, out);
+            }
+        }
+
+        impl ::digest::HashMarker for $name {}
+
+        #[cfg(feature = "zeroize")]
+        impl ::zeroize::ZeroizeOnDrop for $name {}
+    }
 }
 pub(crate) use digest_cfg;

--- a/near-digest/src/lib.rs
+++ b/near-digest/src/lib.rs
@@ -23,6 +23,7 @@
 //! # Example
 //!
 //! ```
+//! # use near_sdk as _;
 //! use near_digest::digest::Digest;
 //! use near_digest::sha2::Sha256;
 //!

--- a/near-digest/src/lib.rs
+++ b/near-digest/src/lib.rs
@@ -20,7 +20,7 @@ mod utils;
 macro_rules! digest_cfg {
     ($vis:vis struct $name:ident {
         near => $near_path:path,
-        local => $local_path:path $(,)?
+        _ => $local_path:path $(,)?
     }) => {
         #[cfg(near)]
         #[derive(Debug, Clone, Default)]
@@ -63,14 +63,12 @@ macro_rules! digest_cfg {
     };
 
     ($vis:vis struct $name:ident {
-        local => $local_path:path $(,)?
+        _ => $local_path:path $(,)?
     }) => {
-        #[cfg(not(near))]
         #[derive(Debug, Clone, Default)]
         #[repr(transparent)]
         $vis struct $name($local_path);
 
-        #[cfg(not(near))]
         impl ::digest::OutputSizeUser for $name {
             type OutputSize = <$local_path as ::digest::OutputSizeUser>::OutputSize;
         }

--- a/near-digest/src/lib.rs
+++ b/near-digest/src/lib.rs
@@ -15,8 +15,8 @@
 //! Both backends produce identical output for identical input, so code using these
 //! types behaves the same on-chain and off-chain.
 //!
-//! All types implement the traits of the [`digest`] crate ([`Digest`](digest::Digest),
-//! [`Update`](digest::Update), [`FixedOutput`](digest::FixedOutput), ...), which makes
+//! All types implement the traits of the [`digest`] crate ([`Digest`],
+//! [`Update`], [`FixedOutput`], ...), which makes
 //! them drop-in replacements for the RustCrypto types in any generic API that accepts
 //! a `D: Digest` parameter.
 //!
@@ -60,13 +60,15 @@
 //! # On-chain buffering
 //!
 //! The NEAR host functions are one-shot: they take the whole message and return the
-//! hash. To still support the [`Update`](digest::Update) API, the `cfg(near)`
+//! hash. To still support the [`Update`] API, the `cfg(near)`
 //! backend buffers all input in memory and invokes the host function once at
 //! finalization.
 //!
 
 // re-export of the `digest` crate
 pub use digest;
+#[doc(no_inline)]
+pub use digest::{Digest, FixedOutput, HashMarker, OutputSizeUser, Update};
 
 #[cfg(any(doctest, test))]
 // XXX: `near-sdk` was added in order to enable tests and doctests compiling with mockchain (`--cfg

--- a/near-digest/src/lib.rs
+++ b/near-digest/src/lib.rs
@@ -67,6 +67,11 @@
 // re-export of the `digest` crate
 pub use digest;
 
+#[cfg(any(doctest, test))]
+// XXX: `near-sdk` was added in order to enable tests and doctests compiling with mockchain (`--cfg
+// near` path)
+use near_sdk as _;
+
 #[cfg(feature = "ripemd")]
 pub mod ripemd;
 #[cfg(feature = "sha2")]

--- a/near-digest/src/lib.rs
+++ b/near-digest/src/lib.rs
@@ -1,10 +1,71 @@
-//! Helper crate to automatically chose a backend for digest implementations.
-//! Currently supported backends are:
+//! Cryptographic hash functions that automatically choose the backend for the compilation
+//! target.
 //!
-//! * `cfg(near)`: via Near host-function
-//! * default: fallback to pure Rust implementation
+//! Every hash type in this crate is a thin `#[repr(transparent)]` wrapper that selects
+//! its implementation at compile time:
+//!
+//! * `cfg(near)` — the crate is compiled as a NEAR contract (the cfg is set by
+//!   `cargo near build`): hashing is delegated to the corresponding NEAR host function,
+//!   which is significantly cheaper in gas than computing the hash inside the Wasm
+//!   module.
+//! * everything else — native binaries, unit tests, tooling, non-contract Wasm:
+//!   falls back to the pure-Rust [RustCrypto](https://github.com/RustCrypto/hashes)
+//!   implementation of the same algorithm.
+//!
+//! Both backends produce identical output for identical input, so code using these
+//! types behaves the same on-chain and off-chain.
+//!
+//! All types implement the traits of the [`digest`] crate ([`Digest`](digest::Digest),
+//! [`Update`](digest::Update), [`FixedOutput`](digest::FixedOutput), ...), which makes
+//! them drop-in replacements for the RustCrypto types in any generic API that accepts
+//! a `D: Digest` parameter.
+//!
+//! # Example
+//!
+//! ```
+//! use near_digest::digest::Digest;
+//! use near_digest::sha2::Sha256;
+//!
+//! let hash = Sha256::digest(b"near is cool!");
+//!
+//! // or incrementally:
+//! let mut hasher = Sha256::new();
+//! hasher.update(b"near ");
+//! hasher.update(b"is cool!");
+//! assert_eq!(hasher.finalize(), hash);
+//! ```
+//!
+//! # Available hashes and feature flags
+//!
+//! No features are enabled by default; each hash family is gated behind its own
+//! feature:
+//!
+//! | Type | Feature | NEAR host function |
+//! |------|---------|--------------------|
+//! | `sha2::Sha256` | `sha2` | `sha256_array` |
+//! | `sha3::Keccak256` | `sha3` | `keccak256_array` |
+//! | `sha3::Keccak512` | `sha3` | `keccak512_array` |
+//! | `sha3::Sha3_256` | `sha3` + `unstable` | - (pure Rust on all targets for now) |
+//! | `sha3::Sha3_512` | `sha3` + `unstable` | - (pure Rust on all targets for now) |
+//! | `ripemd::Ripemd160` | `ripemd` | `ripemd160_array` |
+//!
+//! Additional features:
+//!
+//! * `zeroize` — implements `zeroize::ZeroizeOnDrop` for all hash types, clearing
+//!   buffered input from memory when a hasher is dropped.
+//! * `unstable` — enables items whose API or backend may change in a breaking way
+//!   between minor releases.
+//!
+//! # On-chain buffering
+//!
+//! The NEAR host functions are one-shot: they take the whole message and return the
+//! hash. To still support the [`Update`](digest::Update) API, the `cfg(near)`
+//! backend buffers all input in memory and invokes the host function once at
+//! finalization.
+//!
 
-pub use digest::*;
+// re-export of the `digest` crate
+pub use digest;
 
 #[cfg(feature = "ripemd")]
 pub mod ripemd;
@@ -12,22 +73,28 @@ pub mod ripemd;
 pub mod sha2;
 #[cfg(feature = "sha3")]
 pub mod sha3;
-#[cfg(near)]
+#[cfg(all(near, any(feature = "ripemd", feature = "sha2", feature = "sha3")))]
 mod utils;
 
 // TODO: use `cfg_check!` macro to reduce duplicates once we reach rustc 1.95
 
+/// Defines a hash type that wraps `$near_path` under `cfg(near)` and `$local_path` otherwise,
+/// forwarding the `digest` traits to whichever backend was selected. The `near =>` arm is optional
+/// for hashes that have no host-function counterpart.
+#[cfg(any(feature = "ripemd", feature = "sha2", feature = "sha3"))]
 macro_rules! digest_cfg {
-    ($vis:vis struct $name:ident {
+    ($(#[$attr:meta])* $vis:vis struct $name:ident {
         near => $near_path:path,
         _ => $local_path:path $(,)?
     }) => {
         #[cfg(near)]
+        $(#[$attr])*
         #[derive(Debug, Clone, Default)]
         #[repr(transparent)]
         $vis struct $name($near_path);
 
         #[cfg(not(near))]
+        $(#[$attr])*
         #[derive(Debug, Clone, Default)]
         #[repr(transparent)]
         $vis struct $name($local_path);
@@ -62,9 +129,10 @@ macro_rules! digest_cfg {
         impl ::zeroize::ZeroizeOnDrop for $name {}
     };
 
-    ($vis:vis struct $name:ident {
+    ($(#[$attr:meta])* $vis:vis struct $name:ident {
         _ => $local_path:path $(,)?
     }) => {
+        $(#[$attr])*
         #[derive(Debug, Clone, Default)]
         #[repr(transparent)]
         $vis struct $name($local_path);
@@ -93,4 +161,5 @@ macro_rules! digest_cfg {
         impl ::zeroize::ZeroizeOnDrop for $name {}
     }
 }
+#[cfg(any(feature = "ripemd", feature = "sha2", feature = "sha3"))]
 pub(crate) use digest_cfg;

--- a/near-digest/src/ripemd/mod.rs
+++ b/near-digest/src/ripemd/mod.rs
@@ -6,6 +6,6 @@ mod near;
 digest_cfg! {
     pub struct Ripemd160 {
         near => self::near::Ripemd160,
-        local => ::ripemd::Ripemd160,
+        _ => ::ripemd::Ripemd160,
     }
 }

--- a/near-digest/src/ripemd/mod.rs
+++ b/near-digest/src/ripemd/mod.rs
@@ -1,9 +1,16 @@
+//! RIPEMD hash family.
+
 use crate::digest_cfg;
 
 #[cfg(near)]
 mod near;
 
 digest_cfg! {
+    /// RIPEMD-160 hasher.
+    ///
+    /// Backed by the `ripemd160_array` host function when compiled as a NEAR contract
+    /// (`cfg(near)`), and by the pure-Rust implementation from the
+    /// [`ripemd`](https://docs.rs/ripemd) crate otherwise.
     pub struct Ripemd160 {
         near => self::near::Ripemd160,
         _ => ::ripemd::Ripemd160,

--- a/near-digest/src/ripemd/mod.rs
+++ b/near-digest/src/ripemd/mod.rs
@@ -36,4 +36,9 @@ mod test {
     fn ripemd160_has_not_changed(#[case] data: &[u8], #[case] output: [u8; 20]) {
         assert_eq!(Ripemd160::digest(data), output, "hash has changed")
     }
+
+    #[test]
+    fn ripemd160_resets_to_initial_state() {
+        crate::test_utils::assert_reset_roundtrip::<Ripemd160>();
+    }
 }

--- a/near-digest/src/ripemd/mod.rs
+++ b/near-digest/src/ripemd/mod.rs
@@ -9,3 +9,24 @@ digest_cfg! {
         _ => ::ripemd::Ripemd160,
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use digest::Digest;
+    use hex_literal::hex;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(
+        b"",
+        hex!("9c1185a5c5e9fc54612808977ee8f548b2258d31"),
+    )]
+    #[case(
+        b"near is cool!",
+        hex!("320214cbbb6821fb23d3cd96dc0731ff5644323b"),
+    )]
+    fn ripemd10_has_not_changed(#[case] data: &[u8], #[case] output: [u8; 20]) {
+        assert!(Ripemd160::digest(data) == output, "has changed")
+    }
+}

--- a/near-digest/src/ripemd/mod.rs
+++ b/near-digest/src/ripemd/mod.rs
@@ -1,0 +1,11 @@
+use crate::digest_cfg;
+
+#[cfg(near)]
+mod near;
+
+digest_cfg! {
+    pub struct Ripemd160 {
+        near => self::near::Ripemd160,
+        local => ::ripemd::Ripemd160,
+    }
+}

--- a/near-digest/src/ripemd/mod.rs
+++ b/near-digest/src/ripemd/mod.rs
@@ -34,6 +34,6 @@ mod test {
         hex!("320214cbbb6821fb23d3cd96dc0731ff5644323b"),
     )]
     fn ripemd160_has_not_changed(#[case] data: &[u8], #[case] output: [u8; 20]) {
-        assert!(Ripemd160::digest(data) == output, "has changed")
+        assert_eq!(Ripemd160::digest(data), output, "hash has changed")
     }
 }

--- a/near-digest/src/ripemd/mod.rs
+++ b/near-digest/src/ripemd/mod.rs
@@ -33,7 +33,7 @@ mod test {
         b"near is cool!",
         hex!("320214cbbb6821fb23d3cd96dc0731ff5644323b"),
     )]
-    fn ripemd10_has_not_changed(#[case] data: &[u8], #[case] output: [u8; 20]) {
+    fn ripemd160_has_not_changed(#[case] data: &[u8], #[case] output: [u8; 20]) {
         assert!(Ripemd160::digest(data) == output, "has changed")
     }
 }

--- a/near-digest/src/ripemd/near.rs
+++ b/near-digest/src/ripemd/near.rs
@@ -1,0 +1,16 @@
+use digest::{Output, OutputSizeUser, consts::U20};
+
+use crate::utils::{DigestFinalizer, DigestFn};
+
+pub type Ripemd160 = DigestFn<Ripemd160Fn>;
+pub struct Ripemd160Fn;
+
+impl OutputSizeUser for Ripemd160Fn {
+    type OutputSize = U20;
+}
+
+impl DigestFinalizer for Ripemd160Fn {
+    fn digest(bytes: &[u8]) -> Output<Self> {
+        near_sdk_env::ripemd160_array(bytes).into()
+    }
+}

--- a/near-digest/src/sha2/mod.rs
+++ b/near-digest/src/sha2/mod.rs
@@ -33,6 +33,6 @@ mod test {
         hex!("ba2b2a7c9d2c2c2505232a24f2b0e1b0c5781423957db7f8439b80a0292e9485"),
     )]
     fn sha256_has_not_changed(#[case] data: &[u8], #[case] output: [u8; 32]) {
-        assert!(Sha256::digest(data) == output, "has changed")
+        assert_eq!(Sha256::digest(data), output, "hash has changed")
     }
 }

--- a/near-digest/src/sha2/mod.rs
+++ b/near-digest/src/sha2/mod.rs
@@ -1,0 +1,18 @@
+use crate::digest_cfg;
+
+#[cfg(near)]
+mod near;
+
+digest_cfg! {
+    pub struct Sha256 {
+        near => self::near::Sha256,
+        local => ::sha2::Sha256,
+    }
+}
+
+digest_cfg! {
+    pub struct Sha512 {
+        near => self::near::Sha512,
+        local => ::sha2::Sha512,
+    }
+}

--- a/near-digest/src/sha2/mod.rs
+++ b/near-digest/src/sha2/mod.rs
@@ -9,10 +9,3 @@ digest_cfg! {
         local => ::sha2::Sha256,
     }
 }
-
-digest_cfg! {
-    pub struct Sha512 {
-        near => self::near::Sha512,
-        local => ::sha2::Sha512,
-    }
-}

--- a/near-digest/src/sha2/mod.rs
+++ b/near-digest/src/sha2/mod.rs
@@ -9,3 +9,11 @@ digest_cfg! {
         local => ::sha2::Sha256,
     }
 }
+
+#[cfg(feature = "unstable")]
+digest_cfg! {
+    pub struct Sha512 {
+        // TODO: Add `cfg(near)` path
+        local => ::sha2::Sha512,
+    }
+}

--- a/near-digest/src/sha2/mod.rs
+++ b/near-digest/src/sha2/mod.rs
@@ -35,4 +35,9 @@ mod test {
     fn sha256_has_not_changed(#[case] data: &[u8], #[case] output: [u8; 32]) {
         assert_eq!(Sha256::digest(data), output, "hash has changed")
     }
+
+    #[test]
+    fn sha256_resets_to_initial_state() {
+        crate::test_utils::assert_reset_roundtrip::<Sha256>();
+    }
 }

--- a/near-digest/src/sha2/mod.rs
+++ b/near-digest/src/sha2/mod.rs
@@ -10,10 +10,23 @@ digest_cfg! {
     }
 }
 
-#[cfg(feature = "unstable")]
-digest_cfg! {
-    pub struct Sha512 {
-        // TODO: Add `cfg(near)` path
-        _ => ::sha2::Sha512,
+#[cfg(test)]
+mod test {
+    use super::*;
+    use digest::Digest;
+    use hex_literal::hex;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(
+        b"",
+        hex!("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),
+    )]
+    #[case(
+        b"near is cool!",
+        hex!("ba2b2a7c9d2c2c2505232a24f2b0e1b0c5781423957db7f8439b80a0292e9485"),
+    )]
+    fn sha256_has_not_changed(#[case] data: &[u8], #[case] output: [u8; 32]) {
+        assert!(Sha256::digest(data) == output, "has changed")
     }
 }

--- a/near-digest/src/sha2/mod.rs
+++ b/near-digest/src/sha2/mod.rs
@@ -6,7 +6,7 @@ mod near;
 digest_cfg! {
     pub struct Sha256 {
         near => self::near::Sha256,
-        local => ::sha2::Sha256,
+        _ => ::sha2::Sha256,
     }
 }
 
@@ -14,6 +14,6 @@ digest_cfg! {
 digest_cfg! {
     pub struct Sha512 {
         // TODO: Add `cfg(near)` path
-        local => ::sha2::Sha512,
+        _ => ::sha2::Sha512,
     }
 }

--- a/near-digest/src/sha2/mod.rs
+++ b/near-digest/src/sha2/mod.rs
@@ -1,9 +1,15 @@
+//! SHA-2 hash family.
+
 use crate::digest_cfg;
 
 #[cfg(near)]
 mod near;
 
 digest_cfg! {
+    /// SHA-256 hasher.
+    ///
+    /// Backed by the `sha256_array` host function when compiled as a NEAR contract (`cfg(near)`),
+    /// and by the pure-Rust implementation from the [`sha2`](https://docs.rs/sha2) crate otherwise.
     pub struct Sha256 {
         near => self::near::Sha256,
         _ => ::sha2::Sha256,

--- a/near-digest/src/sha2/near.rs
+++ b/near-digest/src/sha2/near.rs
@@ -1,0 +1,32 @@
+use digest::{
+    Output, OutputSizeUser,
+    consts::{U32, U64},
+};
+
+use crate::utils::{DigestFinalizer, DigestFn};
+
+pub type Sha256 = DigestFn<Sha256Fn>;
+pub struct Sha256Fn;
+
+pub type Sha512 = DigestFn<Sha512Fn>;
+pub struct Sha512Fn;
+
+impl OutputSizeUser for Sha256Fn {
+    type OutputSize = U32;
+}
+
+impl DigestFinalizer for Sha256Fn {
+    fn digest(bytes: &[u8]) -> Output<Self> {
+        near_sdk_env::sha256_array(bytes).into()
+    }
+}
+
+impl OutputSizeUser for Sha512Fn {
+    type OutputSize = U64;
+}
+
+impl DigestFinalizer for Sha512Fn {
+    fn digest(bytes: &[u8]) -> Output<Self> {
+        near_sdk_env::sha512_array(bytes).into()
+    }
+}

--- a/near-digest/src/sha2/near.rs
+++ b/near-digest/src/sha2/near.rs
@@ -1,15 +1,9 @@
-use digest::{
-    Output, OutputSizeUser,
-    consts::{U32, U64},
-};
+use digest::{Output, OutputSizeUser, consts::U32};
 
 use crate::utils::{DigestFinalizer, DigestFn};
 
 pub type Sha256 = DigestFn<Sha256Fn>;
 pub struct Sha256Fn;
-
-pub type Sha512 = DigestFn<Sha512Fn>;
-pub struct Sha512Fn;
 
 impl OutputSizeUser for Sha256Fn {
     type OutputSize = U32;
@@ -18,15 +12,5 @@ impl OutputSizeUser for Sha256Fn {
 impl DigestFinalizer for Sha256Fn {
     fn digest(bytes: &[u8]) -> Output<Self> {
         near_sdk_env::sha256_array(bytes).into()
-    }
-}
-
-impl OutputSizeUser for Sha512Fn {
-    type OutputSize = U64;
-}
-
-impl DigestFinalizer for Sha512Fn {
-    fn digest(bytes: &[u8]) -> Output<Self> {
-        near_sdk_env::sha512_array(bytes).into()
     }
 }

--- a/near-digest/src/sha3/mod.rs
+++ b/near-digest/src/sha3/mod.rs
@@ -16,3 +16,19 @@ digest_cfg! {
         local => ::sha3::Keccak512,
     }
 }
+
+#[cfg(feature = "unstable")]
+digest_cfg! {
+    pub struct Sha3_256 {
+        // TODO: Add `cfg(near)` path
+        local => ::sha3::Sha3_256
+    }
+}
+
+#[cfg(feature = "unstable")]
+digest_cfg! {
+    pub struct Sha3_512 {
+        // TODO: Add `cfg(near)` path
+        local => ::sha3::Sha3_512
+    }
+}

--- a/near-digest/src/sha3/mod.rs
+++ b/near-digest/src/sha3/mod.rs
@@ -32,3 +32,65 @@ digest_cfg! {
         _ => ::sha3::Sha3_512
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use digest::Digest;
+    use hex_literal::hex;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(
+        b"",
+        hex!("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"),
+    )]
+    #[case(
+        b"near is cool!",
+        hex!("5e7a77762908019844ab5c5432f9fc030ace77d2776b9535c03a9a184c9d3c59"),
+    )]
+    fn keccak_256_has_not_changed(#[case] data: &[u8], #[case] output: [u8; 32]) {
+        assert!(Keccak256::digest(data) == output, "has changed")
+    }
+
+    #[rstest]
+    #[case(
+        b"",
+        hex!("0eab42de4c3ceb9235fc91acffe746b29c29a8c366b7c60e4e67c466f36a4304c00fa9caf9d87976ba469bcbe06713b435f091ef2769fb160cdab33d3670680e"),
+    )]
+    #[case(
+        b"near is cool!",
+        hex!("2e302ac2b8fca89a000940ff9264ffa2c46e3600bac574cddf3300b9b0d7cca7c974214a1b8ba2850ce894038c84bd835338b9673535da9fd13ab68ffd14df27"),
+    )]
+    fn keccak_512_has_not_changed(#[case] data: &[u8], #[case] output: [u8; 64]) {
+        assert!(Keccak512::digest(data) == output, "has changed")
+    }
+
+    #[cfg(feature = "unstable")]
+    #[rstest]
+    #[case(
+        b"",
+        hex!("a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a"),
+    )]
+    #[case(
+        b"near is cool!",
+        hex!("a839a0507ddbc3e7b23145a85bb11696e988cd771620b17de6be5063e8a721f7"),
+    )]
+    fn sha3_256_has_not_changed(#[case] data: &[u8], #[case] output: [u8; 32]) {
+        assert!(Sha3_256::digest(data) == output, "has changed")
+    }
+
+    #[cfg(feature = "unstable")]
+    #[rstest]
+    #[case(
+        b"",
+        hex!("a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26"),
+    )]
+    #[case(
+        b"near is cool!",
+        hex!("a787e4851d76e71c9ab4cd0061d31570a6511430faeffe5637a60340bbc94f2d1dde1080e4c2d6d22d01084b174bf214140b2dc5dae196e4741e6a42d1f49b96"),
+    )]
+    fn sha3_512_has_not_changed(#[case] data: &[u8], #[case] output: [u8; 64]) {
+        assert!(Sha3_512::digest(data) == output, "has changed")
+    }
+}

--- a/near-digest/src/sha3/mod.rs
+++ b/near-digest/src/sha3/mod.rs
@@ -1,9 +1,16 @@
+//! SHA-3 hash family: Keccak and (unstable) SHA-3 variants
+
 use crate::digest_cfg;
 
 #[cfg(near)]
 mod near;
 
 digest_cfg! {
+    /// Keccak-256 hasher
+    ///
+    /// Backed by the `keccak256_array` host function when compiled as a NEAR contract
+    /// (`cfg(near)`), and by the pure-Rust implementation from the [`sha3`](https://docs.rs/sha3)
+    /// crate otherwise.
     pub struct Keccak256 {
         near => self::near::Keccak256,
         _ => ::sha3::Keccak256,
@@ -11,6 +18,11 @@ digest_cfg! {
 }
 
 digest_cfg! {
+    /// Keccak-512 hasher
+    ///
+    /// Backed by the `keccak512_array` host function when compiled as a NEAR contract
+    /// (`cfg(near)`), and by the pure-Rust implementation from the [`sha3`](https://docs.rs/sha3)
+    /// crate otherwise.
     pub struct Keccak512 {
         near => self::near::Keccak512,
         _ => ::sha3::Keccak512,
@@ -19,6 +31,11 @@ digest_cfg! {
 
 #[cfg(feature = "unstable")]
 digest_cfg! {
+    /// Sha3-256 hasher
+    ///
+    /// There is currently no NEAR host function for SHA3, so this is computed in pure Rust on all
+    /// targets, including on-chain. A host-function backend may be added in the future - hence the
+    /// `unstable` feature gate.
     pub struct Sha3_256 {
         // TODO: Add `cfg(near)` path
         _ => ::sha3::Sha3_256
@@ -27,6 +44,11 @@ digest_cfg! {
 
 #[cfg(feature = "unstable")]
 digest_cfg! {
+    /// Sha3-512 hasher
+    ///
+    /// There is currently no NEAR host function for SHA3, so this is computed in pure Rust on all
+    /// targets, including on-chain. A host-function backend may be added in the future - hence the
+    /// `unstable` feature gate.
     pub struct Sha3_512 {
         // TODO: Add `cfg(near)` path
         _ => ::sha3::Sha3_512

--- a/near-digest/src/sha3/mod.rs
+++ b/near-digest/src/sha3/mod.rs
@@ -75,6 +75,11 @@ mod test {
         assert_eq!(Keccak256::digest(data), output, "hash has changed")
     }
 
+    #[test]
+    fn keccak256_resets_to_initial_state() {
+        crate::test_utils::assert_reset_roundtrip::<Keccak256>();
+    }
+
     #[rstest]
     #[case(
         b"",
@@ -86,6 +91,11 @@ mod test {
     )]
     fn keccak_512_has_not_changed(#[case] data: &[u8], #[case] output: [u8; 64]) {
         assert_eq!(Keccak512::digest(data), output, "hash has changed")
+    }
+
+    #[test]
+    fn keccak512_resets_to_initial_state() {
+        crate::test_utils::assert_reset_roundtrip::<Keccak512>();
     }
 
     #[cfg(feature = "unstable")]
@@ -103,6 +113,12 @@ mod test {
     }
 
     #[cfg(feature = "unstable")]
+    #[test]
+    fn sha3_256_resets_to_initial_state() {
+        crate::test_utils::assert_reset_roundtrip::<Sha3_256>();
+    }
+
+    #[cfg(feature = "unstable")]
     #[rstest]
     #[case(
         b"",
@@ -114,5 +130,11 @@ mod test {
     )]
     fn sha3_512_has_not_changed(#[case] data: &[u8], #[case] output: [u8; 64]) {
         assert_eq!(Sha3_512::digest(data), output, "hash has changed")
+    }
+
+    #[cfg(feature = "unstable")]
+    #[test]
+    fn sha3_512_resets_to_initial_state() {
+        crate::test_utils::assert_reset_roundtrip::<Sha3_512>();
     }
 }

--- a/near-digest/src/sha3/mod.rs
+++ b/near-digest/src/sha3/mod.rs
@@ -6,14 +6,14 @@ mod near;
 digest_cfg! {
     pub struct Keccak256 {
         near => self::near::Keccak256,
-        local => ::sha3::Keccak256,
+        _ => ::sha3::Keccak256,
     }
 }
 
 digest_cfg! {
     pub struct Keccak512 {
         near => self::near::Keccak512,
-        local => ::sha3::Keccak512,
+        _ => ::sha3::Keccak512,
     }
 }
 
@@ -21,7 +21,7 @@ digest_cfg! {
 digest_cfg! {
     pub struct Sha3_256 {
         // TODO: Add `cfg(near)` path
-        local => ::sha3::Sha3_256
+        _ => ::sha3::Sha3_256
     }
 }
 
@@ -29,6 +29,6 @@ digest_cfg! {
 digest_cfg! {
     pub struct Sha3_512 {
         // TODO: Add `cfg(near)` path
-        local => ::sha3::Sha3_512
+        _ => ::sha3::Sha3_512
     }
 }

--- a/near-digest/src/sha3/mod.rs
+++ b/near-digest/src/sha3/mod.rs
@@ -1,0 +1,18 @@
+use crate::digest_cfg;
+
+#[cfg(near)]
+mod near;
+
+digest_cfg! {
+    pub struct Keccak256 {
+        near => self::near::Keccak256,
+        local => ::sha3::Keccak256,
+    }
+}
+
+digest_cfg! {
+    pub struct Keccak512 {
+        near => self::near::Keccak512,
+        local => ::sha3::Keccak512,
+    }
+}

--- a/near-digest/src/sha3/mod.rs
+++ b/near-digest/src/sha3/mod.rs
@@ -72,7 +72,7 @@ mod test {
         hex!("5e7a77762908019844ab5c5432f9fc030ace77d2776b9535c03a9a184c9d3c59"),
     )]
     fn keccak_256_has_not_changed(#[case] data: &[u8], #[case] output: [u8; 32]) {
-        assert!(Keccak256::digest(data) == output, "has changed")
+        assert_eq!(Keccak256::digest(data), output, "hash has changed")
     }
 
     #[rstest]
@@ -85,7 +85,7 @@ mod test {
         hex!("2e302ac2b8fca89a000940ff9264ffa2c46e3600bac574cddf3300b9b0d7cca7c974214a1b8ba2850ce894038c84bd835338b9673535da9fd13ab68ffd14df27"),
     )]
     fn keccak_512_has_not_changed(#[case] data: &[u8], #[case] output: [u8; 64]) {
-        assert!(Keccak512::digest(data) == output, "has changed")
+        assert_eq!(Keccak512::digest(data), output, "hash has changed")
     }
 
     #[cfg(feature = "unstable")]
@@ -99,7 +99,7 @@ mod test {
         hex!("a839a0507ddbc3e7b23145a85bb11696e988cd771620b17de6be5063e8a721f7"),
     )]
     fn sha3_256_has_not_changed(#[case] data: &[u8], #[case] output: [u8; 32]) {
-        assert!(Sha3_256::digest(data) == output, "has changed")
+        assert_eq!(Sha3_256::digest(data), output, "hash has changed")
     }
 
     #[cfg(feature = "unstable")]
@@ -113,6 +113,6 @@ mod test {
         hex!("a787e4851d76e71c9ab4cd0061d31570a6511430faeffe5637a60340bbc94f2d1dde1080e4c2d6d22d01084b174bf214140b2dc5dae196e4741e6a42d1f49b96"),
     )]
     fn sha3_512_has_not_changed(#[case] data: &[u8], #[case] output: [u8; 64]) {
-        assert!(Sha3_512::digest(data) == output, "has changed")
+        assert_eq!(Sha3_512::digest(data), output, "hash has changed")
     }
 }

--- a/near-digest/src/sha3/near.rs
+++ b/near-digest/src/sha3/near.rs
@@ -1,0 +1,32 @@
+use digest::{
+    Output, OutputSizeUser,
+    consts::{U32, U64},
+};
+
+use crate::utils::{DigestFinalizer, DigestFn};
+
+pub type Keccak256 = DigestFn<Keccak256Fn>;
+pub struct Keccak256Fn;
+
+impl OutputSizeUser for Keccak256Fn {
+    type OutputSize = U32;
+}
+
+impl DigestFinalizer for Keccak256Fn {
+    fn digest(bytes: &[u8]) -> Output<Self> {
+        near_sdk_env::keccak256_array(bytes).into()
+    }
+}
+
+pub type Keccak512 = DigestFn<Keccak512Fn>;
+pub struct Keccak512Fn;
+
+impl OutputSizeUser for Keccak512Fn {
+    type OutputSize = U64;
+}
+
+impl DigestFinalizer for Keccak512Fn {
+    fn digest(bytes: &[u8]) -> Output<Self> {
+        near_sdk_env::keccak512_array(bytes).into()
+    }
+}

--- a/near-digest/src/utils.rs
+++ b/near-digest/src/utils.rs
@@ -1,0 +1,35 @@
+use std::marker::PhantomData;
+
+use digest::{FixedOutput, HashMarker, Output, OutputSizeUser, Update};
+use impl_tools::autoimpl;
+
+pub trait DigestFinalizer: OutputSizeUser {
+    fn digest(bytes: &[u8]) -> Output<Self>;
+}
+
+#[cfg_attr(feature = "zeroize", derive(::zeroize::ZeroizeOnDrop))]
+#[autoimpl(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DigestFn<F> {
+    data: Vec<u8>,
+    _fn: PhantomData<F>,
+}
+
+impl<F: OutputSizeUser> OutputSizeUser for DigestFn<F> {
+    type OutputSize = F::OutputSize;
+}
+
+impl<F> Update for DigestFn<F> {
+    #[inline]
+    fn update(&mut self, data: &[u8]) {
+        self.data.extend(data);
+    }
+}
+
+impl<F: DigestFinalizer> FixedOutput for DigestFn<F> {
+    #[inline]
+    fn finalize_into(self, out: &mut digest::Output<Self>) {
+        *out = F::digest(&self.data);
+    }
+}
+
+impl<F: DigestFinalizer> HashMarker for DigestFn<F> {}

--- a/near-digest/src/utils.rs
+++ b/near-digest/src/utils.rs
@@ -8,7 +8,7 @@ pub trait DigestFinalizer: OutputSizeUser {
 }
 
 #[cfg_attr(feature = "zeroize", derive(::zeroize::ZeroizeOnDrop))]
-#[autoimpl(Debug, Clone, Default, PartialEq, Eq)]
+#[autoimpl(Debug, Clone, Default)]
 pub struct DigestFn<F> {
     data: Vec<u8>,
     _fn: PhantomData<F>,

--- a/near-digest/src/utils.rs
+++ b/near-digest/src/utils.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use digest::{FixedOutput, HashMarker, Output, OutputSizeUser, Update};
+use digest::{FixedOutput, FixedOutputReset, HashMarker, Output, OutputSizeUser, Reset, Update};
 use impl_tools::autoimpl;
 
 pub trait DigestFinalizer: OutputSizeUser {
@@ -29,6 +29,21 @@ impl<F: DigestFinalizer> FixedOutput for DigestFn<F> {
     #[inline]
     fn finalize_into(self, out: &mut digest::Output<Self>) {
         *out = F::digest(&self.data);
+    }
+}
+
+impl<F> Reset for DigestFn<F> {
+    #[inline]
+    fn reset(&mut self) {
+        self.data.clear();
+    }
+}
+
+impl<F: DigestFinalizer> FixedOutputReset for DigestFn<F> {
+    #[inline]
+    fn finalize_into_reset(&mut self, out: &mut digest::Output<Self>) {
+        *out = F::digest(&self.data);
+        self.data.clear();
     }
 }
 

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -48,6 +48,12 @@ near-token = { version = "0.3", features = ["serde", "borsh"] }
 
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 
+near-digest = { path = "../near-digest/", version = "0.1.0", features = [
+    "sha2",
+    "sha3",
+    "ripemd",
+], optional = true }
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wee_alloc = { version = "0.4.5", default-features = false, optional = true }
 
@@ -101,6 +107,7 @@ arbitrary = [
 ]
 expensive-debug = []
 deterministic-account-ids = ["dep:hex", "near-sys/deterministic-account-ids"]
+digest = ["dep:near-digest"]
 unstable = []
 legacy = []
 global-contracts = []

--- a/near-sdk/src/lib.rs
+++ b/near-sdk/src/lib.rs
@@ -1628,6 +1628,9 @@ pub mod state;
 #[cfg(feature = "deterministic-account-ids")]
 pub mod state_init;
 
+#[cfg(feature = "digest")]
+pub use near_digest as digest;
+
 #[cfg(all(feature = "unit-testing", not(target_arch = "wasm32")))]
 pub use environment::mock;
 #[cfg(all(feature = "unit-testing", not(target_arch = "wasm32")))]


### PR DESCRIPTION
This PR introduces a `near-digest` crate implementing the RustCrypto `digest` traits with both on-chain and off-chain usage in mind:

- `--cfg near`: backed by NEAR host functions via `near-sdk-env`
- otherwise: falls back to RustCrypto implementations (`sha2`, `sha3`, `ripemd`)