### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.29.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.28.3...near-sdk-v5.29.0) - 2026-07-01
+
+### Added
+
+- add gas-key host functions (nearcore 2.13) ([#1568](https://github.com/near/near-sdk-rs/pull/1568))
+
 ## [5.28.3](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.28.2...near-sdk-v5.28.3) - 2026-06-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [5.29.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.28.3...near-sdk-v5.29.0) - 2026-07-01
+## [5.29.0-rc.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.28.3...near-sdk-v5.29.0-rc.1) - 2026-07-01
 
 ### Added
 
 - add gas-key host functions (nearcore 2.13) ([#1568](https://github.com/near/near-sdk-rs/pull/1568))
+- add yield-with-id host functions (`promise_yield_create_with_id`/`promise_yield_resume_with_yield_id`) (nearcore 2.13) ([#1568](https://github.com/near/near-sdk-rs/pull/1568))
+- support ML-DSA-65 (post-quantum) public keys ([#1557](https://github.com/near/near-sdk-rs/pull/1557))
 
 ## [5.28.3](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.28.2...near-sdk-v5.28.3) - 2026-06-26
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.28.3"
+version = "5.29.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 categories = ["wasm"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.29.0"
+version = "5.29.0-rc.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 categories = ["wasm"]

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -14,7 +14,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.29.0", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.29.0-rc.1", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -14,7 +14,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.28.3", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.29.0", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-global-contracts/Cargo.toml
+++ b/near-global-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-global-contracts"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 license.workspace = true
 categories.workspace = true
@@ -31,14 +31,14 @@ borsh = { version = "1.0.0", features = ["derive"], optional = true }
 
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 
-near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.2", optional = true }
+near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.3", optional = true }
 # Pinned to the published nearcore 2.13 release candidate `0.37.0-rc.2`; see near-sdk/Cargo.toml for the rationale.
 near-primitives-core = { version = "=0.37.0-rc.2", optional = true }
 
 schemars-v0_8 = { version = "0.8.22", optional = true, package = "schemars" }
 
 [target.'cfg(near)'.dependencies]
-near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.2" }
+near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.3" }
 
 [target.'cfg(not(near))'.dependencies]
 digest-io = { version = "0.1" }

--- a/near-sdk-core/Cargo.toml
+++ b/near-sdk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sdk-core"
-version = "4.1.3"
+version = "4.2.0"
 authors = ["Near Inc <hello@near.org>"]
 edition.workspace = true
 license.workspace = true
@@ -33,7 +33,7 @@ near-account-id = { version = "2.3.0" }
 near-gas = { version = "0.3" }
 near-token = { version = "0.3" }
 near-crypto-hash = { path = "../near-crypto-hash/", version = "~0.2.0" }
-near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.2", optional = true }
+near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.3", optional = true }
 
 schemars-v0_8 = { version = "0.8.22", optional = true, package = "schemars" }
 # Pinned to the published nearcore 2.13 release candidate `0.37.0-rc.2`; see near-sdk/Cargo.toml for
@@ -51,7 +51,7 @@ near-parameters = { version = "=0.37.0-rc.2", optional = true }
 near-crypto = { version = "=0.37.0-rc.2", default-features = false, optional = true }
 
 [target.'cfg(near)'.dependencies]
-near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.2" }
+near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.3" }
 
 [dev-dependencies]
 # XXX: `near-sdk` was added in order to enable tests and doctests compiling with mockchain

--- a/near-sdk-env/Cargo.toml
+++ b/near-sdk-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sdk-env"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Near Inc <hello@near.org>"]
 edition.workspace = true
 license.workspace = true
@@ -16,10 +16,10 @@ non-wasm32 (via pure-Rust crates).
 """
 
 [dependencies]
-near-sys = { path = "../near-sys/", version = "~0.2.10", optional = true }
+near-sys = { path = "../near-sys/", version = "~0.2.11", optional = true }
 
 [target.'cfg(near)'.dependencies]
-near-sys = { path = "../near-sys/", version = "~0.2.10" }
+near-sys = { path = "../near-sys/", version = "~0.2.11" }
 
 [target.'cfg(not(near))'.dependencies]
 ripemd = { version = "0.1.1" }

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -23,7 +23,7 @@ required-features = ["abi", "unstable"]
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_with = { version = "3", features = ["base64", "hex", "json"] }
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.29.0" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.29.0-rc.1" }
 near-sys = { path = "../near-sys", version = "0.2.11" }
 near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.3" }
 near-sdk-core = { path = "../near-sdk-core/", version = "~4.2.0", features = [

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -23,14 +23,14 @@ required-features = ["abi", "unstable"]
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_with = { version = "3", features = ["base64", "hex", "json"] }
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.28.3" }
-near-sys = { path = "../near-sys", version = "0.2.10" }
-near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.2" }
-near-sdk-core = { path = "../near-sdk-core/", version = "~4.1.3", features = [
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.29.0" }
+near-sys = { path = "../near-sys", version = "0.2.11" }
+near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.3" }
+near-sdk-core = { path = "../near-sdk-core/", version = "~4.2.0", features = [
     "serde",
     "borsh",
 ] }
-near-global-contracts = { path = "../near-global-contracts/", version = "~0.2.2", features = [
+near-global-contracts = { path = "../near-global-contracts/", version = "~0.2.3", features = [
     "serde",
     "borsh",
 ] }

--- a/near-sys/CHANGELOG.md
+++ b/near-sys/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.11](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.10...near-sys-v0.2.11) - 2026-07-01
+
+### Added
+
+- add gas-key host functions (nearcore 2.13) ([#1568](https://github.com/near/near-sdk-rs/pull/1568))
+
 ## [0.2.10](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.9...near-sys-v0.2.10) - 2026-06-09
 
 ### Fixed

--- a/near-sys/Cargo.toml
+++ b/near-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sys"
-version = "0.2.10"
+version = "0.2.11"
 authors = ["Near Inc <hello@near.org>"]
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `near-sys`: 0.2.10 -> 0.2.11 (✓ API compatible changes)
* `near-global-contracts`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `near-sdk-core`: 4.1.3 -> 4.2.0 (✓ API compatible changes)
* `near-sdk-macros`: 5.28.3 -> 5.29.0
* `near-sdk`: 5.28.3 -> 5.29.0 (✓ API compatible changes)
* `near-contract-standards`: 5.28.3 -> 5.29.0
* `near-sdk-env`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-sys`

<blockquote>


## [0.2.11](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.10...near-sys-v0.2.11) - 2026-07-01

### Added

- add gas-key host functions (nearcore 2.13) ([#1568](https://github.com/near/near-sdk-rs/pull/1568))
</blockquote>




## `near-sdk`

<blockquote>

## [5.29.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.28.3...near-sdk-v5.29.0) - 2026-07-01

### Added

- add gas-key host functions (nearcore 2.13) ([#1568](https://github.com/near/near-sdk-rs/pull/1568))
</blockquote>

## `near-contract-standards`

<blockquote>

## [5.25.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.24.1...near-contract-standards-v5.25.0) - 2026-03-26

### Added

- add `ext_self()` and document cross-contract call patterns ([#1504](https://github.com/near/near-sdk-rs/pull/1504))

### Other

- update to Rust edition 2024 ([#1480](https://github.com/near/near-sdk-rs/pull/1480))
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).