### PR TITLE
refactor(global-contracts): derive From for GlobalContractId via derive_more

### DIFF
--- a/near-global-contracts/Cargo.toml
+++ b/near-global-contracts/Cargo.toml
@@ -21,6 +21,7 @@ features = ["serde", "borsh", "abi", "near-primitives-interop"]
 [dependencies]
 near-account-id = { version = "2.3.0", features = ["internal_unstable"] }
 near-crypto-hash = { path = "../near-crypto-hash/", version = "~0.2.0" }
+derive_more = { version = "2", default-features = false, features = ["from"] }
 
 hex = { version = "0.4", optional = true }
 

--- a/near-global-contracts/src/global_contract_identifier.rs
+++ b/near-global-contracts/src/global_contract_identifier.rs
@@ -29,7 +29,7 @@ pub enum AccountContract {
     schemars(crate = "::schemars_v0_8")
 )]
 #[cfg_attr(feature = "abi", derive(borsh::BorshSchema))]
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::From)]
 #[repr(u8)]
 pub enum GlobalContractId {
     #[cfg_attr(feature = "serde", serde(rename = "hash"))]
@@ -38,20 +38,6 @@ pub enum GlobalContractId {
     ) = 0,
     #[cfg_attr(feature = "serde", serde(rename = "account_id"))]
     AccountId(AccountId) = 1,
-}
-
-impl From<CryptoHash> for GlobalContractId {
-    #[inline]
-    fn from(hash: CryptoHash) -> Self {
-        Self::CodeHash(hash)
-    }
-}
-
-impl From<AccountId> for GlobalContractId {
-    #[inline]
-    fn from(account_id: AccountId) -> Self {
-        Self::AccountId(account_id)
-    }
 }
 
 #[cfg(feature = "near-primitives-interop")]


### PR DESCRIPTION
## What

Replace the two hand-written `From` impls on `GlobalContractId` with `#[derive(derive_more::From)]`:

```rust
// before
impl From<CryptoHash> for GlobalContractId { fn from(h) -> Self { Self::CodeHash(h) } }
impl From<AccountId>  for GlobalContractId { fn from(a) -> Self { Self::AccountId(a) } }

// after
#[derive(..., derive_more::From)]
pub enum GlobalContractId { CodeHash(CryptoHash) = 0, AccountId(AccountId) = 1 }
```

`derive_more::From` generates one `From` per single-field variant, so this produces byte-identical `From<CryptoHash>` / `From<AccountId>` conversions. **No public API change** — purely removes boilerplate.

## Dependency

`derive_more = { version = "2", default-features = false, features = ["from"] }`. `derive_more` 2.1.1 is already in the workspace lockfile (transitive), so nothing new is compiled; `default-features = false` keeps it `no_std`-safe and avoids pulling in `std`.

## Context

Suggested by a downstream user wiring NEP-616 global contracts into integration tests via [`near-kit`](https://github.com/r-near/near-kit-rs) (the defuse / intents test suite).

## Testing

- `cargo check` across all feature combos: `{}`, `serde`, `borsh`, `serde,borsh`, `abi`, `near-primitives-interop`, and all-together — the `serde` + `serde_as` field-attribute path compiles fine.
- `cargo test -p near-global-contracts --features serde,borsh,abi,near-primitives-interop` — green.
- `cargo fmt --check` + `cargo clippy` clean. `cargo check --locked` passes.