### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.29.0-rc.2](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.29.0-rc.1...near-sdk-v5.29.0-rc.2) - 2026-07-08
+
+### Added
+
+- `near-digest` crate ([#1571](https://github.com/near/near-sdk-rs/pull/1571))
+- add `p256_verify` ([#1577](https://github.com/near/near-sdk-rs/pull/1577))
+
 ## [5.29.0-rc.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.28.3...near-sdk-v5.29.0-rc.1) - 2026-07-01
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.29.0-rc.1"
+version = "5.29.0-rc.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 categories = ["wasm"]

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -14,7 +14,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.29.0-rc.1", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.29.0-rc.2", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-digest/Cargo.toml
+++ b/near-digest/Cargo.toml
@@ -22,7 +22,7 @@ sha2 = { version = "0.11.0", optional = true }
 sha3 = { version = "0.11.0", optional = true }
 
 [target.'cfg(near)'.dependencies]
-near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.1" }
+near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.4" }
 impl-tools = "0.12.0"
 # for `unstable` Sha3-256/512
 sha3 = { version = "0.11.0", optional = true }

--- a/near-global-contracts/Cargo.toml
+++ b/near-global-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-global-contracts"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 license.workspace = true
 categories.workspace = true
@@ -31,14 +31,14 @@ borsh = { version = "1.0.0", features = ["derive"], optional = true }
 
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 
-near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.3", optional = true }
+near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.4", optional = true }
 # Pinned to the published nearcore 2.13 release candidate `0.37.0-rc.2`; see near-sdk/Cargo.toml for the rationale.
 near-primitives-core = { version = "=0.37.0-rc.2", optional = true }
 
 schemars-v0_8 = { version = "0.8.22", optional = true, package = "schemars" }
 
 [target.'cfg(near)'.dependencies]
-near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.3" }
+near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.4" }
 
 [target.'cfg(not(near))'.dependencies]
 digest-io = { version = "0.1" }

--- a/near-sdk-core/Cargo.toml
+++ b/near-sdk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sdk-core"
-version = "4.2.0"
+version = "4.2.1"
 authors = ["Near Inc <hello@near.org>"]
 edition.workspace = true
 license.workspace = true
@@ -33,7 +33,7 @@ near-account-id = { version = "2.3.0" }
 near-gas = { version = "0.3" }
 near-token = { version = "0.3" }
 near-crypto-hash = { path = "../near-crypto-hash/", version = "~0.2.0" }
-near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.3", optional = true }
+near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.4", optional = true }
 
 schemars-v0_8 = { version = "0.8.22", optional = true, package = "schemars" }
 # Pinned to the published nearcore 2.13 release candidate `0.37.0-rc.2`; see near-sdk/Cargo.toml for
@@ -51,7 +51,7 @@ near-parameters = { version = "=0.37.0-rc.2", optional = true }
 near-crypto = { version = "=0.37.0-rc.2", default-features = false, optional = true }
 
 [target.'cfg(near)'.dependencies]
-near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.3" }
+near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.4" }
 
 [dev-dependencies]
 # XXX: `near-sdk` was added in order to enable tests and doctests compiling with mockchain

--- a/near-sdk-env/Cargo.toml
+++ b/near-sdk-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sdk-env"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Near Inc <hello@near.org>"]
 edition.workspace = true
 license.workspace = true
@@ -16,10 +16,10 @@ non-wasm32 (via pure-Rust crates).
 """
 
 [dependencies]
-near-sys = { path = "../near-sys/", version = "~0.2.11", optional = true }
+near-sys = { path = "../near-sys/", version = "~0.2.12", optional = true }
 
 [target.'cfg(near)'.dependencies]
-near-sys = { path = "../near-sys/", version = "~0.2.11" }
+near-sys = { path = "../near-sys/", version = "~0.2.12" }
 
 [target.'cfg(not(near))'.dependencies]
 ripemd = { version = "0.1.1" }

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -23,14 +23,14 @@ required-features = ["abi", "unstable"]
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_with = { version = "3", features = ["base64", "hex", "json"] }
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.29.0-rc.1" }
-near-sys = { path = "../near-sys", version = "0.2.11" }
-near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.3" }
-near-sdk-core = { path = "../near-sdk-core/", version = "~4.2.0", features = [
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.29.0-rc.2" }
+near-sys = { path = "../near-sys", version = "0.2.12" }
+near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.4" }
+near-sdk-core = { path = "../near-sdk-core/", version = "~4.2.1", features = [
     "serde",
     "borsh",
 ] }
-near-global-contracts = { path = "../near-global-contracts/", version = "~0.2.3", features = [
+near-global-contracts = { path = "../near-global-contracts/", version = "~0.2.4", features = [
     "serde",
     "borsh",
 ] }

--- a/near-sys/CHANGELOG.md
+++ b/near-sys/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.12](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.11...near-sys-v0.2.12) - 2026-07-08
+
+### Added
+
+- add `p256_verify` ([#1577](https://github.com/near/near-sdk-rs/pull/1577))
+
 ## [0.2.11](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.10...near-sys-v0.2.11) - 2026-07-01
 
 ### Added

--- a/near-sys/Cargo.toml
+++ b/near-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sys"
-version = "0.2.11"
+version = "0.2.12"
 authors = ["Near Inc <hello@near.org>"]
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `near-sys`: 0.2.11 -> 0.2.12 (✓ API compatible changes)
* `near-digest`: 0.1.0
* `near-sdk-macros`: 5.29.0-rc.1 -> 5.29.0-rc.2
* `near-sdk`: 5.29.0-rc.1 -> 5.29.0-rc.2 (✓ API compatible changes)
* `near-contract-standards`: 5.29.0-rc.1 -> 5.29.0-rc.2
* `near-sdk-env`: 0.1.3 -> 0.1.4
* `near-global-contracts`: 0.2.3 -> 0.2.4
* `near-sdk-core`: 4.2.0 -> 4.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-sys`

<blockquote>


## [0.2.12](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.11...near-sys-v0.2.12) - 2026-07-08

### Added

- add `p256_verify` ([#1577](https://github.com/near/near-sdk-rs/pull/1577))
</blockquote>



## `near-sdk`

<blockquote>

## [5.29.0-rc.2](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.29.0-rc.1...near-sdk-v5.29.0-rc.2) - 2026-07-08

### Added

- `near-digest` crate ([#1571](https://github.com/near/near-sdk-rs/pull/1571))
- add `p256_verify` ([#1577](https://github.com/near/near-sdk-rs/pull/1577))
</blockquote>

## `near-contract-standards`

<blockquote>

## [5.25.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.24.1...near-contract-standards-v5.25.0) - 2026-03-26

### Added

- add `ext_self()` and document cross-contract call patterns ([#1504](https://github.com/near/near-sdk-rs/pull/1504))

### Other

- update to Rust edition 2024 ([#1480](https://github.com/near/near-sdk-rs/pull/1480))
</blockquote>





</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).