### PR TITLE
fix: prevent Lazy::remove() from being resurrected by Drop-flush

### DIFF
--- a/near-sdk/src/store/lazy/mod.rs
+++ b/near-sdk/src/store/lazy/mod.rs
@@ -126,7 +126,11 @@ where
 
     /// Removes the underlying storage item. Useful for deprecating the obsolete [`Lazy`] values.
     pub fn remove(&mut self) -> bool {
-        env::storage_remove(&self.storage_key)
+        let existed = env::storage_remove(&self.storage_key);
+        // Reset the cache to a non-modified `None` so a later flush (e.g. on Drop) does
+        // not resurrect the removed value.
+        self.cache = OnceCell::from(CacheEntry::new_cached(None));
+        existed
     }
 }
 
@@ -201,6 +205,56 @@ mod tests {
         assert!(env::storage_has_key(b"m"));
         lazy.remove();
         assert!(!env::storage_has_key(b"m"));
+    }
+
+    #[test]
+    fn remove_after_mutation_is_reverted_by_drop() {
+        {
+            let mut a: Lazy<u32> = Lazy::new(b"remove_drop_key".to_vec(), 1u32);
+            a.flush(); // persist 1; cache state -> Cached
+            assert!(env::storage_has_key(b"remove_drop_key"), "precondition: value persisted");
+
+            a.set(7); // cache state -> Modified (holds 7)
+            assert!(a.remove(), "remove() reports the key existed and was removed");
+            assert!(
+                !env::storage_has_key(b"remove_drop_key"),
+                "key is gone immediately after remove()"
+            );
+        } // <- Drop runs flush(); with the bug, cache is Modified(7) and re-writes key
+
+        // After the fix the removed key must stay gone.
+        assert!(
+            !env::storage_has_key(b"remove_drop_key"),
+            "removed key must not be resurrected by Drop-flush"
+        );
+    }
+
+    #[test]
+    fn remove_then_explicit_flush_keeps_key_gone() {
+        let mut a: Lazy<u32> = Lazy::new(b"remove_flush_key".to_vec(), 1u32);
+        a.flush();
+        assert!(env::storage_has_key(b"remove_flush_key"));
+
+        a.set(7);
+        assert!(a.remove());
+        assert!(!env::storage_has_key(b"remove_flush_key"));
+
+        // An explicit flush after remove() must also not resurrect the key.
+        a.flush();
+        assert!(!env::storage_has_key(b"remove_flush_key"));
+    }
+
+    #[test]
+    fn remove_never_persisted_value_leaves_nothing_after_drop() {
+        {
+            // Value was never flushed, so nothing has been written to storage yet.
+            let mut a: Lazy<u32> = Lazy::new(b"remove_never_persisted_key".to_vec(), 1u32);
+            a.set(7);
+            assert!(!a.remove(), "remove() reports the key never existed in storage");
+            assert!(!env::storage_has_key(b"remove_never_persisted_key"));
+        } // <- Drop runs flush(); must remain a no-op.
+
+        assert!(!env::storage_has_key(b"remove_never_persisted_key"));
     }
 
     #[test]

--- a/near-sdk/src/store/lazy/mod.rs
+++ b/near-sdk/src/store/lazy/mod.rs
@@ -127,9 +127,11 @@ where
     /// Removes the underlying storage item. Useful for deprecating the obsolete [`Lazy`] values.
     pub fn remove(&mut self) -> bool {
         let existed = env::storage_remove(&self.storage_key);
-        // Reset the cache to a non-modified `None` so a later flush (e.g. on Drop) does
-        // not resurrect the removed value.
-        self.cache = OnceCell::from(CacheEntry::new_cached(None));
+        // Clear the cache so a later flush (e.g. on Drop) cannot resurrect the removed value:
+        // an uninitialized cache makes `flush` a no-op. A subsequent read then reloads from
+        // storage and reports the value as absent (`ERR_NOT_FOUND`), matching the documented
+        // `get`/`get_mut` behavior, instead of a misleading inconsistent-state error.
+        self.cache = OnceCell::new();
         existed
     }
 }

--- a/near-sdk/src/store/lazy/mod.rs
+++ b/near-sdk/src/store/lazy/mod.rs
@@ -210,7 +210,7 @@ mod tests {
     }
 
     #[test]
-    fn remove_after_mutation_is_reverted_by_drop() {
+    fn remove_after_mutation_not_resurrected_by_drop() {
         {
             let mut a: Lazy<u32> = Lazy::new(b"remove_drop_key".to_vec(), 1u32);
             a.flush(); // persist 1; cache state -> Cached


### PR DESCRIPTION
## Summary

`store::Lazy::remove()` cleared the underlying storage key but left the in-memory cache untouched. When the cache entry was in the `Modified` state (e.g. after a `set(...)`), the `flush()` that runs automatically on `Drop` re-serialized and re-wrote the value to the same key — silently resurrecting the "removed" entry.

## Root cause

```rust
pub fn remove(&mut self) -> bool {
    env::storage_remove(&self.storage_key)   // storage cleared, cache still Modified(v)
}
```

On `Drop` → `flush()`, a `Modified` cache entry is written back, undoing the removal.

## Fix

Clear the cache so the later flush is a no-op, and a subsequent read reloads from storage:

```rust
pub fn remove(&mut self) -> bool {
    let existed = env::storage_remove(&self.storage_key);
    // Uninitialized cache => flush is a no-op; a later read reloads from storage and
    // reports the value as absent (ERR_NOT_FOUND), matching documented get/get_mut behavior.
    self.cache = OnceCell::new();
    existed
}
```

The return value (whether the key existed in storage) is preserved. Resetting to an empty `OnceCell` (rather than a cached `None`) means a read-after-remove reports the documented `ERR_NOT_FOUND` instead of a misleading inconsistent-state error.

## Tests

Three regression tests added to `store::lazy::tests`:
- `remove_after_mutation_not_resurrected_by_drop` — the exact scenario from the issue (flush, `set`, `remove`, drop; key must stay gone).
- `remove_then_explicit_flush_keeps_key_gone` — same but with an explicit `flush()` after `remove()`.
- `remove_never_persisted_value_leaves_nothing_after_drop` — `new` + `set` + `remove` with nothing ever persisted; `remove()` returns `false` and Drop stays a no-op.

All three fail without the fix and pass with it.

## Other collections

Audited `LookupMap`, `LookupSet`, `IndexMap`, and `LazyOption`: they all route removal through the cache (`replace(None)` / `value_mut()`), so their `flush()` handles the removal consistently. `Lazy::remove()` was the only public method that bypassed the cache with a direct `env::storage_remove`, so no other changes are needed.

Closes #1578
