### PR TITLE
chore: release

### DIFF
--- a/near-contract-standards/CHANGELOG.md
+++ b/near-contract-standards/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.29.0](https://github.com/near/near-sdk-rs/releases/tag/near-contract-standards-v5.29.0) - 2026-07-13
+
+### Other
+
+- pin to nearcore 2.13.0 stable ([#1586](https://github.com/near/near-sdk-rs/pull/1586))
+- fix outdated docs.near.org links in doc comments ([#1591](https://github.com/near/near-sdk-rs/pull/1591))
+
 ## [5.25.0](https://github.com/near/near-sdk-rs/compare/near-contract-standards-v5.24.1...near-contract-standards-v5.25.0) - 2026-03-26
 
 ### Added

--- a/near-digest/Cargo.toml
+++ b/near-digest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-digest"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 license.workspace = true
 categories.workspace = true
@@ -22,7 +22,7 @@ sha2 = { version = "0.11.0", optional = true }
 sha3 = { version = "0.11.0", optional = true }
 
 [target.'cfg(near)'.dependencies]
-near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.4" }
+near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.5" }
 impl-tools = "0.12.0"
 # for `unstable` Sha3-256/512
 sha3 = { version = "0.11.0", optional = true }

--- a/near-global-contracts/Cargo.toml
+++ b/near-global-contracts/Cargo.toml
@@ -31,13 +31,13 @@ borsh = { version = "1.0.0", features = ["derive"], optional = true }
 
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 
-near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.4", optional = true }
+near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.5", optional = true }
 near-primitives-core = { version = "0.37.0", optional = true }
 
 schemars-v0_8 = { version = "0.8.22", optional = true, package = "schemars" }
 
 [target.'cfg(near)'.dependencies]
-near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.4" }
+near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.5" }
 
 [target.'cfg(not(near))'.dependencies]
 digest-io = { version = "0.1" }

--- a/near-sdk-core/Cargo.toml
+++ b/near-sdk-core/Cargo.toml
@@ -33,7 +33,7 @@ near-account-id = { version = "2.3.0" }
 near-gas = { version = "0.3" }
 near-token = { version = "0.3" }
 near-crypto-hash = { path = "../near-crypto-hash/", version = "~0.2.0" }
-near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.4", optional = true }
+near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.5", optional = true }
 
 schemars-v0_8 = { version = "0.8.22", optional = true, package = "schemars" }
 near-primitives-core = { version = "0.37.0", optional = true }
@@ -48,7 +48,7 @@ near-parameters = { version = "0.37.0", optional = true }
 near-crypto = { version = "0.37.0", default-features = false, optional = true }
 
 [target.'cfg(near)'.dependencies]
-near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.4" }
+near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.5" }
 
 [dev-dependencies]
 # XXX: `near-sdk` was added in order to enable tests and doctests compiling with mockchain

--- a/near-sdk-env/Cargo.toml
+++ b/near-sdk-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sdk-env"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Near Inc <hello@near.org>"]
 edition.workspace = true
 license.workspace = true
@@ -16,10 +16,10 @@ non-wasm32 (via pure-Rust crates).
 """
 
 [dependencies]
-near-sys = { path = "../near-sys/", version = "~0.2.12", optional = true }
+near-sys = { path = "../near-sys/", version = "~0.2.13", optional = true }
 
 [target.'cfg(near)'.dependencies]
-near-sys = { path = "../near-sys/", version = "~0.2.12" }
+near-sys = { path = "../near-sys/", version = "~0.2.13" }
 
 [target.'cfg(not(near))'.dependencies]
 ripemd = { version = "0.1.1" }

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -24,8 +24,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_with = { version = "3", features = ["base64", "hex", "json"] }
 near-sdk-macros = { path = "../near-sdk-macros", version = "~5.29.0" }
-near-sys = { path = "../near-sys", version = "0.2.12" }
-near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.4" }
+near-sys = { path = "../near-sys", version = "0.2.13" }
+near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.5" }
 near-sdk-core = { path = "../near-sdk-core/", version = "~4.2.2", features = [
     "serde",
     "borsh",
@@ -48,7 +48,7 @@ near-token = { version = "0.3", features = ["serde", "borsh"] }
 
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 
-near-digest = { path = "../near-digest/", version = "0.1.0", features = [
+near-digest = { path = "../near-digest/", version = "0.1.1", features = [
     "sha2",
     "sha3",
     "ripemd",

--- a/near-sys/CHANGELOG.md
+++ b/near-sys/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.13](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.12...near-sys-v0.2.13) - 2026-07-13
+
+### Added
+
+- *(env)* add env::chain_id host-fn wrapper ([#1592](https://github.com/near/near-sdk-rs/pull/1592))
+
 ## [0.2.12](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.11...near-sys-v0.2.12) - 2026-07-08
 
 ### Added

--- a/near-sys/Cargo.toml
+++ b/near-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sys"
-version = "0.2.12"
+version = "0.2.13"
 authors = ["Near Inc <hello@near.org>"]
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `near-sys`: 0.2.12 -> 0.2.13 (✓ API compatible changes)
* `near-digest`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `near-global-contracts`: 0.2.5
* `near-sdk-core`: 4.2.2
* `near-sdk`: 5.29.0
* `near-contract-standards`: 5.29.0
* `near-sdk-env`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-sys`

<blockquote>


## [0.2.13](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.12...near-sys-v0.2.13) - 2026-07-13

### Added

- *(env)* add env::chain_id host-fn wrapper ([#1592](https://github.com/near/near-sdk-rs/pull/1592))
</blockquote>




## `near-sdk`

<blockquote>

## [5.29.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.29.0-rc.1...near-sdk-v5.29.0) - 2026-07-13

### Added

- add `env::chain_id` ([#1592](https://github.com/near/near-sdk-rs/pull/1592))
- `near-digest` crate ([#1571](https://github.com/near/near-sdk-rs/pull/1571))
- add `p256_verify` ([#1577](https://github.com/near/near-sdk-rs/pull/1577))

### Fixed

- return correct account id in `current_contract_code` for the `GlobalByAccount` case ([#1601](https://github.com/near/near-sdk-rs/pull/1601))
- read `LazyOption` value as `None` when the storage key does not exist ([#1599](https://github.com/near/near-sdk-rs/pull/1599))
- update indexes on `UnorderedSet::defrag` ([#1597](https://github.com/near/near-sdk-rs/pull/1597))
- remove correct indices on drop in `Vec` drain ([#1595](https://github.com/near/near-sdk-rs/pull/1595))
- remove stale entries for a partially consumed `Drain` after drop ([#1593](https://github.com/near/near-sdk-rs/pull/1593))
- unify `AsNep297Event` trait definition across the serde feature gate ([#1587](https://github.com/near/near-sdk-rs/pull/1587))
- re-key elements in `collections::Vector::to_v2()` ([#1581](https://github.com/near/near-sdk-rs/pull/1581))
- prevent `Lazy::remove()` from being resurrected by Drop-flush ([#1580](https://github.com/near/near-sdk-rs/pull/1580))
</blockquote>

## `near-contract-standards`

<blockquote>

## [5.29.0](https://github.com/near/near-sdk-rs/releases/tag/near-contract-standards-v5.29.0) - 2026-07-13

### Other

- pin to nearcore 2.13.0 stable ([#1586](https://github.com/near/near-sdk-rs/pull/1586))
- fix outdated docs.near.org links in doc comments ([#1591](https://github.com/near/near-sdk-rs/pull/1591))
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).