### PR TITLE
refactor: hash StateInit::derive_account_id via near-digest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,50 @@ jobs:
           RUSTFLAGS: "-D warnings --cfg near"
         run: cargo hack check -p ${{ matrix.crate }} --target "wasm32-unknown-unknown" --feature-powerset --exclude-features schemars-v0_8,abi,__near-sdk-unit-testing --no-dev-deps
 
+  # These leaf crates deliberately support an older MSRV than the workspace 1.93 so off-chain
+  # consumers on an older toolchain (indexers, CLIs, near-kit) can use them. Their `cfg(near)`
+  # on-chain path does need 1.93, but it is only ever built with a newer toolchain (cargo-near /
+  # the protocol version enforce it), so only the off-chain surface is checked here.
+  msrv:
+    runs-on: warp-ubuntu-latest-x64-4x
+    name: "MSRV off-chain ${{ matrix.crate }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        crate:
+          - "near-crypto-hash"
+          - "near-digest"
+          - "near-global-contracts"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install MSRV toolchain
+        run: |
+          # Read the crate's declared MSRV so this job always tests exactly what is published.
+          MSRV=$(grep -m1 '^rust-version = ' ${{ matrix.crate }}/Cargo.toml | sed -E 's/.*"([0-9.]+)".*/\1/')
+          if [ -z "$MSRV" ]; then echo "::error::could not read rust-version from ${{ matrix.crate }}/Cargo.toml"; exit 1; fi
+          echo "Package MSRV: $MSRV"
+          rustup toolchain install "$MSRV" --profile minimal
+          rustup override set "$MSRV"
+
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-provider: warpbuild
+          shared-key: "msrv-${{ matrix.crate }}"
+          cache-all-crates: true
+
+      - name: Print rustc version
+        run: rustc --version
+
+      # Off-chain surface only (no `--cfg near`); the on-chain path requires the workspace 1.93.
+      - name: Cargo hack check off-chain powerset on MSRV
+        run: cargo hack check -p ${{ matrix.crate }} --feature-powerset --no-dev-deps
+
   test:
     runs-on: ${{ matrix.platform.os }}
     name: "${{ matrix.platform.name }} ${{ matrix.platform.rs }} ${{ matrix.features }}"

--- a/near-digest/Cargo.toml
+++ b/near-digest/Cargo.toml
@@ -6,7 +6,13 @@ license.workspace = true
 categories.workspace = true
 repository.workspace = true
 homepage.workspace = true
-rust-version.workspace = true
+# Deliberately below the workspace 1.93. The off-chain surface (pure-Rust RustCrypto
+# backends) only needs edition 2024's 1.85 floor, and downstream off-chain consumers such as
+# near-kit depend on this crate at 1.88. The `cfg(near)` deps (near-sdk-env, impl-tools) do
+# require 1.93, but the on-chain path is always built with rustc 1.93+ (enforced by
+# cargo-near / the protocol version), so it never constrains an off-chain 1.88 build — the
+# same arrangement near-global-contracts and near-crypto-hash already use.
+rust-version = "1.88"
 description = """
 `digest` trait implementations for hash functions in NEAR smart contracts: backed by NEAR host functions on-chain, pure Rust off-chain.
 """

--- a/near-global-contracts/Cargo.toml
+++ b/near-global-contracts/Cargo.toml
@@ -6,21 +6,30 @@ license.workspace = true
 categories.workspace = true
 repository.workspace = true
 homepage.workspace = true
+# Kept below the workspace 1.93 for off-chain consumers (indexers, CLIs, near-kit, ...); the
+# off-chain hashing path (near-digest, also 1.88) builds on 1.88. See near-digest/Cargo.toml.
 rust-version = "1.88"
 readme = "./README.md"
 description = """
 Global contract identifiers and deterministic account derivation (NEP-616) for the NEAR SDK.
 """
 
-# Make `derive_account_id` visible on docs.rs (it requires `borsh`; the off-chain sha3
-# backend is pulled in unconditionally on the `cfg(not(near))` path). Including all of
-# serde/borsh/abi here surfaces the full type surface.
+# Make `derive_account_id` visible on docs.rs (it requires `borsh`, which pulls in the
+# `near-digest` hashing backend). Including all of serde/borsh/abi here surfaces the full
+# type surface.
 [package.metadata.docs.rs]
 features = ["serde", "borsh", "abi", "near-primitives-interop"]
 
 [dependencies]
 near-account-id = { version = "2.3.0", features = ["internal_unstable"] }
 near-crypto-hash = { path = "../near-crypto-hash/", version = "~0.2.0" }
+
+# keccak256 backend for `derive_account_id`: routed through the NEAR host function on-chain
+# (`--cfg near`) and pure-Rust off-chain, selected automatically by `near-digest`. `digest-io`
+# streams the borsh serialization straight into the hasher. Both are gated behind `borsh`, the
+# only feature that exposes `derive_account_id`.
+near-digest = { path = "../near-digest/", version = "0.1", features = ["sha3"], optional = true }
+digest-io = { version = "0.1", optional = true }
 
 hex = { version = "0.4", optional = true }
 
@@ -31,22 +40,12 @@ borsh = { version = "1.0.0", features = ["derive"], optional = true }
 
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 
-near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.4", optional = true }
 # Pinned to the published nearcore 2.13 release candidate `0.37.0-rc.2`; see near-sdk/Cargo.toml for the rationale.
 near-primitives-core = { version = "=0.37.0-rc.2", optional = true }
 
 schemars-v0_8 = { version = "0.8.22", optional = true, package = "schemars" }
 
-[target.'cfg(near)'.dependencies]
-near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.4" }
-
-[target.'cfg(not(near))'.dependencies]
-digest-io = { version = "0.1" }
-sha3 = { version = "0.11" }
-
 [dev-dependencies]
-# XXX: `near-sdk` was added in order to enable testing and doctests
-near-sdk = { path = "../near-sdk", features = ["unit-testing"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 
 [lints]
@@ -65,6 +64,8 @@ serde = [
 borsh = [
     "dep:borsh",
     "dep:hex",
+    "dep:near-digest",
+    "dep:digest-io",
     "near-account-id/borsh",
 ]
 
@@ -87,12 +88,3 @@ arbitrary = [
 ]
 
 near-primitives-interop = ["dep:near-primitives-core"]
-
-__near-sdk-unit-testing = [
-    "dep:near-sdk-env",
-    "dep:hex",
-    "serde",
-    "borsh",
-    "near-primitives-interop",
-    "near-sdk-env/__near-sdk-unit-testing",
-]

--- a/near-global-contracts/README.md
+++ b/near-global-contracts/README.md
@@ -49,10 +49,10 @@ pure-Rust hashing and does not import any NEAR host functions. You can verify wi
 | `arbitrary`                | `arbitrary::Arbitrary` impls for fuzzing                                |
 | `near-primitives-interop`  | `From`/`Into` between these types and the `near-primitives-core` ones   |
 
-`StateInit::derive_account_id` requires the `borsh` feature. Hashing backend is selected
-automatically: on `--cfg near` (set by `cargo-near`) it routes through NEAR host functions
-via `near-sdk-env`; otherwise it uses pure-Rust `sha3`, which is pulled in unconditionally on
-the `cfg(not(near))` path.
+`StateInit::derive_account_id` requires the `borsh` feature. The keccak256 backend is selected
+automatically by [`near-digest`](https://docs.rs/near-digest): on `--cfg near` (set by
+`cargo-near`) it routes through the NEAR host function; otherwise it uses a pure-Rust
+implementation. Both produce identical output.
 
 ## License
 

--- a/near-global-contracts/src/lib.rs
+++ b/near-global-contracts/src/lib.rs
@@ -16,12 +16,12 @@
 //!
 //! By default this crate exposes only the type definitions. To use
 //! [`StateInit::derive_account_id`] you must enable the `borsh` feature. The hashing
-//! backend is then selected automatically:
+//! backend is then selected automatically by the
+//! [`near-digest`](https://docs.rs/near-digest) crate:
 //!
 //! - On-chain contract builds: set `--cfg near` (the `cargo-near` toolchain does this
-//!   automatically). Hashing routes through the `keccak256` host function via `near-sdk-env`.
-//! - Off-chain / non-NEAR wasm builds: hashing is performed in pure Rust via [`sha3`],
-//!   pulled in unconditionally on the `cfg(not(near))` path.
+//!   automatically). Hashing routes through the `keccak256` host function.
+//! - Off-chain / non-NEAR wasm builds: hashing is performed in pure Rust.
 //!
 //! Both paths produce identical output, so you can verify on-chain derivations off-chain.
 //!
@@ -44,10 +44,6 @@
 //! let account_id = state_init.derive_account_id();
 //! println!("{account_id}"); // 0s<40 hex chars>
 //! ```
-
-#[cfg(all(test, feature = "__near-sdk-unit-testing"))]
-// XXX: `near-sdk` was added in order to enable doctests and tests that require mockchain
-use near_sdk as _;
 
 mod global_contract_identifier;
 pub use global_contract_identifier::*;

--- a/near-global-contracts/src/state_init.rs
+++ b/near-global-contracts/src/state_init.rs
@@ -28,37 +28,28 @@ impl StateInit {
     ///
     /// # Availability
     ///
-    /// This method is only compiled when:
-    /// - the `borsh` feature is enabled (needed to serialize the input for hashing), AND
-    /// - one of the following is true:
-    ///   - `--cfg near` is set (on-chain contract build; `cargo-near` sets this automatically) —
-    ///     routes through the `keccak256` host function via the `near-sdk-env` crate.
-    ///   - the `digest` feature is enabled (off-chain or non-NEAR wasm build) — uses pure-Rust
-    ///     `sha3::Keccak256`.
+    /// This method requires the `borsh` feature (needed to serialize the input for hashing).
+    /// If you see "no method named `derive_account_id`" on a `StateInit`, enable `borsh` on
+    /// your `near-global-contracts` dependency.
     ///
-    /// If you see "no method named `derive_account_id`" on a `StateInit`, add the `digest`
-    /// feature to your `near-global-contracts` dependency.
+    /// The keccak256 backend is selected automatically by
+    /// [`near-digest`](https://docs.rs/near-digest): on-chain contract builds (`--cfg near`, set
+    /// automatically by `cargo-near`) route through the `keccak256` host function, while
+    /// off-chain and non-NEAR wasm builds use the pure-Rust implementation. Both produce
+    /// identical output.
     #[inline]
     #[cfg(feature = "borsh")]
     pub fn derive_account_id(&self) -> near_account_id::AccountId {
-        let hash: [u8; 32];
+        use digest_io::IoWrapper;
+        use near_digest::{Digest, sha3::Keccak256};
 
-        #[cfg(any(near, feature = "__near-sdk-unit-testing"))]
-        {
-            let serialized = borsh::to_vec(self).unwrap_or_else(|_| unreachable!());
-            // SAFETY: keccak256 hash will always generate 32 bytes
-            hash = near_sdk_env::keccak256_array(&serialized);
-        }
-        #[cfg(not(any(near, feature = "__near-sdk-unit-testing")))]
-        {
-            use digest_io::IoWrapper;
-            use sha3::Digest;
-
-            let mut hasher = IoWrapper(sha3::Keccak256::new());
-            borsh::to_writer(&mut hasher, self).unwrap_or_else(|_| unreachable!());
-            // SAFETY: keccak256 hash will always generate 32 bytes
-            hash = hasher.0.finalize().into();
-        }
+        // Stream the borsh serialization straight into the hasher to avoid an intermediate
+        // `Vec`. On `--cfg near` the host function is one-shot, so `near-digest` buffers the
+        // input and hashes once at `finalize`.
+        let mut hasher = IoWrapper(Keccak256::new());
+        borsh::to_writer(&mut hasher, self).unwrap_or_else(|_| unreachable!());
+        // SAFETY: keccak256 hash will always generate 32 bytes
+        let hash: [u8; 32] = hasher.0.finalize().into();
 
         // SAFETY: 20 bytes-long hash will produce 40 hex chars.
         // "0s" + 40 hex chars = 42 chars, which is within `AccountId` length bounds (2-64).

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -139,7 +139,9 @@ unit-testing = [
     "near-parameters",
     "near-sdk-env/__near-sdk-unit-testing",
     "near-sdk-core/__near-sdk-unit-testing",
-    "near-global-contracts/__near-sdk-unit-testing",
+    # The mock converts nearcore's `DeterministicAccountStateInit` into this crate's `StateInit`
+    # (see `environment/mock/receipt.rs`), which needs the interop `From` impls.
+    "near-global-contracts/near-primitives-interop",
 ]
 non-contract-usage = [
     "ed25519-dalek",

--- a/near-sdk/src/state_init.rs
+++ b/near-sdk/src/state_init.rs
@@ -7,7 +7,7 @@
 //!
 //! When invoked from inside an on-chain contract (i.e. a build that sets `--cfg near` via
 //! `cargo-near`), `StateInit::derive_account_id` routes through the `keccak256` host
-//! function. Off-chain consumers should depend on `near-global-contracts` directly with the
-//! `digest` feature.
+//! function; off-chain it falls back to a pure-Rust implementation. Off-chain consumers can
+//! instead depend on `near-global-contracts` directly with the `borsh` feature.
 
 pub use near_global_contracts::{StateInit, StateInitV1};


### PR DESCRIPTION
## What

Follow-up to the `near-digest` crate (#1571). Per [Arseny's request in Slack](https://nearone.slack.com/archives/C0A64SAMDNG/p1783531653206219?thread_ts=1782478837.131179&cid=C0A64SAMDNG), now that `near-digest` v0.1.0 is [published](https://crates.io/crates/near-digest), this collapses the two keccak256 code paths in `near_global_contracts::StateInit::derive_account_id` into a single one backed by `near-digest`:

```rust
let mut hasher = IoWrapper(Keccak256::new());
borsh::to_writer(&mut hasher, self).unwrap_or_else(|_| unreachable!());
let hash: [u8; 32] = hasher.0.finalize().into();
```

`near-digest` selects the backend automatically — the `keccak256` host function on-chain (`--cfg near`) and pure-Rust off-chain — so the previous `#[cfg(any(near, feature = "__near-sdk-unit-testing"))]` / `#[cfg(not(...))]` split is no longer needed.

## Changes

- **near-global-contracts**
  - Single `derive_account_id` path via `near-digest`; drop the direct `near-sdk-env`, `sha3`, and `cfg(near)`/`cfg(not(near))` dependency blocks.
  - `near-digest` (`sha3` feature) + `digest-io` are now regular deps, gated behind `borsh` (the only feature that exposes `derive_account_id`) instead of being pulled in unconditionally per target.
  - Remove the now-dead `__near-sdk-unit-testing` feature (its only job was routing hashing through the `near-sdk-env` mock; the pure-Rust fallback produces identical output in unit tests).
  - Docs/README updated.
- **near-sdk**
  - `unit-testing` feature now enables `near-global-contracts/near-primitives-interop` directly (it previously got it transitively via `__near-sdk-unit-testing`). The unit-testing mock's `DeterministicAccountStateInit -> StateInit` conversion in `environment/mock/receipt.rs` needs those `From` impls.
  - Fixed a stale doc that referenced a non-existent `digest` feature on `near-global-contracts`.
- **near-digest**
  - Pin MSRV to **1.88** (previously inherited the workspace's 1.93). Its off-chain surface is pure-Rust RustCrypto and only needs edition 2024's 1.85 floor; the `cfg(near)` deps that require 1.93 are only ever built on-chain, where 1.93+ is enforced by cargo-near / the protocol version. This keeps `near-global-contracts` at **1.88** (unchanged) so off-chain consumers like near-kit keep working — same low-MSRV-leaf arrangement `near-global-contracts` and `near-crypto-hash` already use.
- **CI**
  - Add an `msrv` job that runs the off-chain feature powerset for the low-MSRV leaf crates (`near-crypto-hash`, `near-digest`, `near-global-contracts`) against each crate's *declared* `rust-version`, so the 1.88 promise is actually verified and can't silently rot (previously nothing tested these crates below 1.93).

## MSRV note

Earlier revision briefly bumped `near-global-contracts` to 1.93; that's reverted. The floor stays at 1.88, achieved by lowering `near-digest` to 1.88 instead — cargo's resolver keys off the *declared* MSRV, so both crates had to move together. Confirmed locally that `near-crypto-hash`, `near-digest`, and `near-global-contracts` all build the full off-chain feature powerset on the 1.88 toolchain with `-D warnings`.

## Verification

- `cargo test -p near-global-contracts --features serde,borsh` — derivation test passes; **derived account IDs are byte-for-byte unchanged** (the test asserts exact values).
- `cargo hack check` feature powersets for `near-global-contracts` on host, off-chain wasm, and on-chain (`--cfg near`) wasm targets.
- `cargo +1.88 hack check -p {near-crypto-hash,near-digest,near-global-contracts} --feature-powerset --no-dev-deps` with `-D warnings` — all green (this is what the new `msrv` CI job runs).
- `cargo test -p near-sdk --features unit-testing,deterministic-account-ids` deterministic-account-id mock tests pass; base `unit-testing` build clean.
- `cargo fmt --check` and `cargo clippy -p near-global-contracts --tests --all-features` clean.

Note: this touches audit-sensitive code (cryptographic account derivation), but the hash output is provably identical — same keccak256 over the same borsh bytes, just via a different backend selector.