### PR TITLE
chore: pin to nearcore 2.13.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [5.29.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.29.0-rc.1...near-sdk-v5.29.0) - 2026-07-09
+## [5.29.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.29.0-rc.1...near-sdk-v5.29.0) - 2026-07-13
 
 ### Added
 
 - add `env::chain_id` ([#1592](https://github.com/near/near-sdk-rs/pull/1592))
 - `near-digest` crate ([#1571](https://github.com/near/near-sdk-rs/pull/1571))
 - add `p256_verify` ([#1577](https://github.com/near/near-sdk-rs/pull/1577))
+
+### Fixed
+
+- return correct account id in `current_contract_code` for the `GlobalByAccount` case ([#1601](https://github.com/near/near-sdk-rs/pull/1601))
+- read `LazyOption` value as `None` when the storage key does not exist ([#1599](https://github.com/near/near-sdk-rs/pull/1599))
+- update indexes on `UnorderedSet::defrag` ([#1597](https://github.com/near/near-sdk-rs/pull/1597))
+- remove correct indices on drop in `Vec` drain ([#1595](https://github.com/near/near-sdk-rs/pull/1595))
+- remove stale entries for a partially consumed `Drain` after drop ([#1593](https://github.com/near/near-sdk-rs/pull/1593))
+- unify `AsNep297Event` trait definition across the serde feature gate ([#1587](https://github.com/near/near-sdk-rs/pull/1587))
+- re-key elements in `collections::Vector::to_v2()` ([#1581](https://github.com/near/near-sdk-rs/pull/1581))
+- prevent `Lazy::remove()` from being resurrected by Drop-flush ([#1580](https://github.com/near/near-sdk-rs/pull/1580))
 
 ## [5.29.0-rc.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.28.3...near-sdk-v5.29.0-rc.1) - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [5.29.0-rc.2](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.29.0-rc.1...near-sdk-v5.29.0-rc.2) - 2026-07-08
+## [5.29.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.29.0-rc.1...near-sdk-v5.29.0) - 2026-07-09
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.29.0-rc.2"
+version = "5.29.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 categories = ["wasm"]

--- a/examples/adder/src/lib.rs
+++ b/examples/adder/src/lib.rs
@@ -55,7 +55,7 @@ mod tests {
     async fn test_add_callback_vec() -> anyhow::Result<()> {
         let wasm = near_workspaces::compile_project("./").await?;
         // TODO: drop explicit version once near-sandbox-rs ships a v85 DEFAULT_NEAR_SANDBOX_VERSION
-        let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
+        let worker = near_workspaces::sandbox().await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         let res = contract

--- a/examples/adder/src/lib.rs
+++ b/examples/adder/src/lib.rs
@@ -54,7 +54,6 @@ mod tests {
     #[tokio::test]
     async fn test_add_callback_vec() -> anyhow::Result<()> {
         let wasm = near_workspaces::compile_project("./").await?;
-        // TODO: drop explicit version once near-sandbox-rs ships a v85 DEFAULT_NEAR_SANDBOX_VERSION
         let worker = near_workspaces::sandbox().await?;
         let contract = worker.dev_deploy(&wasm).await?;
 

--- a/examples/adder/src/lib.rs
+++ b/examples/adder/src/lib.rs
@@ -55,7 +55,7 @@ mod tests {
     async fn test_add_callback_vec() -> anyhow::Result<()> {
         let wasm = near_workspaces::compile_project("./").await?;
         // TODO: drop explicit version once near-sandbox-rs ships a v85 DEFAULT_NEAR_SANDBOX_VERSION
-        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         let res = contract

--- a/examples/callback-results/src/lib.rs
+++ b/examples/callback-results/src/lib.rs
@@ -93,7 +93,7 @@ mod tests {
     #[tokio::test]
     async fn workspaces_test() -> anyhow::Result<()> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         // Call function a only to ensure it has correct behaviour
@@ -151,7 +151,7 @@ mod tests {
     #[tokio::test]
     async fn workspaces_test_reverse() -> anyhow::Result<()> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         // No failures

--- a/examples/callback-results/src/lib.rs
+++ b/examples/callback-results/src/lib.rs
@@ -93,7 +93,7 @@ mod tests {
     #[tokio::test]
     async fn workspaces_test() -> anyhow::Result<()> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
+        let worker = near_workspaces::sandbox().await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         // Call function a only to ensure it has correct behaviour
@@ -151,7 +151,7 @@ mod tests {
     #[tokio::test]
     async fn workspaces_test_reverse() -> anyhow::Result<()> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
+        let worker = near_workspaces::sandbox().await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         // No failures

--- a/examples/cross-contract-calls/tests/workspaces.rs
+++ b/examples/cross-contract-calls/tests/workspaces.rs
@@ -5,7 +5,7 @@ use test_case::test_case;
 #[tokio::test]
 async fn test_factorial(contract_path: &str) -> anyhow::Result<()> {
     let wasm = near_workspaces::compile_project(contract_path).await?;
-    let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
+    let worker = near_workspaces::sandbox().await?;
     let contract = worker.dev_deploy(&wasm).await?;
 
     let res = contract.call("factorial").args_json((1,)).max_gas().transact().await?;

--- a/examples/cross-contract-calls/tests/workspaces.rs
+++ b/examples/cross-contract-calls/tests/workspaces.rs
@@ -5,7 +5,7 @@ use test_case::test_case;
 #[tokio::test]
 async fn test_factorial(contract_path: &str) -> anyhow::Result<()> {
     let wasm = near_workspaces::compile_project(contract_path).await?;
-    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
     let contract = worker.dev_deploy(&wasm).await?;
 
     let res = contract.call("factorial").args_json((1,)).max_gas().transact().await?;

--- a/examples/factory-contract-global/tests/workspaces.rs
+++ b/examples/factory-contract-global/tests/workspaces.rs
@@ -9,7 +9,7 @@ const GLOBAL_STORAGE_COST_PER_BYTE: NearToken = STORAGE_DEPOSIT_PER_BYTE.saturat
 async fn test_deploy_global_contract() -> anyhow::Result<()> {
     // Initialize the sandbox environment with specific commit that includes global contract support
     println!("Initializing worker");
-    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
 
     println!("Deploying global contract");
 
@@ -57,7 +57,7 @@ async fn test_deploy_global_contract() -> anyhow::Result<()> {
 /// Test using a global contract by hash
 #[tokio::test]
 async fn test_use_global_contract_by_hash() -> anyhow::Result<()> {
-    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
     let factory_wasm = near_workspaces::compile_project(".").await?;
     let factory_contract = worker.dev_deploy(&factory_wasm).await?;
 
@@ -102,7 +102,7 @@ async fn test_use_global_contract_by_hash() -> anyhow::Result<()> {
 /// Test using a global contract by account ID
 #[tokio::test]
 async fn test_use_global_contract_by_account() -> anyhow::Result<()> {
-    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
     let factory_wasm = near_workspaces::compile_project(".").await?;
     let factory_contract = worker.dev_deploy(&factory_wasm).await?;
 
@@ -139,7 +139,7 @@ async fn test_use_global_contract_by_account() -> anyhow::Result<()> {
 /// Test error cases and edge conditions
 #[tokio::test]
 async fn test_global_contract_edge_cases() -> anyhow::Result<()> {
-    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
     let factory_wasm = near_workspaces::compile_project(".").await?;
     let factory_contract = worker.dev_deploy(&factory_wasm).await?;
 

--- a/examples/factory-contract-global/tests/workspaces.rs
+++ b/examples/factory-contract-global/tests/workspaces.rs
@@ -9,7 +9,7 @@ const GLOBAL_STORAGE_COST_PER_BYTE: NearToken = STORAGE_DEPOSIT_PER_BYTE.saturat
 async fn test_deploy_global_contract() -> anyhow::Result<()> {
     // Initialize the sandbox environment with specific commit that includes global contract support
     println!("Initializing worker");
-    let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
+    let worker = near_workspaces::sandbox().await?;
 
     println!("Deploying global contract");
 
@@ -57,7 +57,7 @@ async fn test_deploy_global_contract() -> anyhow::Result<()> {
 /// Test using a global contract by hash
 #[tokio::test]
 async fn test_use_global_contract_by_hash() -> anyhow::Result<()> {
-    let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
+    let worker = near_workspaces::sandbox().await?;
     let factory_wasm = near_workspaces::compile_project(".").await?;
     let factory_contract = worker.dev_deploy(&factory_wasm).await?;
 
@@ -102,7 +102,7 @@ async fn test_use_global_contract_by_hash() -> anyhow::Result<()> {
 /// Test using a global contract by account ID
 #[tokio::test]
 async fn test_use_global_contract_by_account() -> anyhow::Result<()> {
-    let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
+    let worker = near_workspaces::sandbox().await?;
     let factory_wasm = near_workspaces::compile_project(".").await?;
     let factory_contract = worker.dev_deploy(&factory_wasm).await?;
 
@@ -139,7 +139,7 @@ async fn test_use_global_contract_by_account() -> anyhow::Result<()> {
 /// Test error cases and edge conditions
 #[tokio::test]
 async fn test_global_contract_edge_cases() -> anyhow::Result<()> {
-    let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
+    let worker = near_workspaces::sandbox().await?;
     let factory_wasm = near_workspaces::compile_project(".").await?;
     let factory_contract = worker.dev_deploy(&factory_wasm).await?;
 

--- a/examples/factory-contract/tests/workspaces.rs
+++ b/examples/factory-contract/tests/workspaces.rs
@@ -26,7 +26,7 @@ async fn build_contract(path: &str) -> anyhow::Result<Vec<u8>> {
 #[tokio::test]
 async fn test_deploy_status_message(contract_path: &str) -> anyhow::Result<()> {
     let wasm = build_contract(contract_path).await?;
-    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
     let contract = worker.dev_deploy(&wasm).await?;
 
     let status_id: AccountId = format!("status.{}", contract.id()).parse()?;

--- a/examples/factory-contract/tests/workspaces.rs
+++ b/examples/factory-contract/tests/workspaces.rs
@@ -26,7 +26,7 @@ async fn build_contract(path: &str) -> anyhow::Result<Vec<u8>> {
 #[tokio::test]
 async fn test_deploy_status_message(contract_path: &str) -> anyhow::Result<()> {
     let wasm = build_contract(contract_path).await?;
-    let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
+    let worker = near_workspaces::sandbox().await?;
     let contract = worker.dev_deploy(&wasm).await?;
 
     let status_id: AccountId = format!("status.{}", contract.id()).parse()?;

--- a/examples/fungible-token/tests/workspaces.rs
+++ b/examples/fungible-token/tests/workspaces.rs
@@ -60,7 +60,7 @@ async fn initialized_contracts(
     fungible_contract_wasm: &Vec<u8>,
     defi_contract_wasm: &Vec<u8>,
 ) -> anyhow::Result<(Contract, Account, Contract)> {
-    let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
+    let worker = near_workspaces::sandbox().await?;
 
     let ft_contract = worker.dev_deploy(fungible_contract_wasm).await?;
 

--- a/examples/fungible-token/tests/workspaces.rs
+++ b/examples/fungible-token/tests/workspaces.rs
@@ -60,7 +60,7 @@ async fn initialized_contracts(
     fungible_contract_wasm: &Vec<u8>,
     defi_contract_wasm: &Vec<u8>,
 ) -> anyhow::Result<(Contract, Account, Contract)> {
-    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
 
     let ft_contract = worker.dev_deploy(fungible_contract_wasm).await?;
 
@@ -151,7 +151,7 @@ async fn test_storage_deposit_not_enough_deposit(
     // contract receives a gas rewards for the function call, so it should gain some NEAR
     assert!(contract_balance_diff > NearToken::from_near(0));
     // raised for protocol v85 (nearcore 2.13): function-call gas reward increased vs v84
-    // (measured ~502e18 yocto under 2.13.0-rc.2; bound kept well under 1 milliNEAR)
+    // (measured ~502e18 yocto under 2.13.0; bound kept well under 1 milliNEAR)
     assert!(contract_balance_diff < NearToken::from_yoctonear(800_000_000_000_000_000_000));
 
     Ok(())
@@ -286,7 +286,7 @@ async fn test_storage_deposit_refunds_excessive_deposit(
     // contract receives a gas rewards for the function call, so the difference should be slightly more than minimal_deposit
     assert!(contract_balance_diff > minimal_deposit);
     // raised for protocol v85 (nearcore 2.13): function-call gas reward increased vs v84
-    // (measured ~517e18 yocto over minimal_deposit under 2.13.0-rc.2)
+    // (measured ~517e18 yocto over minimal_deposit under 2.13.0)
     assert!(
         contract_balance_diff
             < minimal_deposit.saturating_add(NearToken::from_yoctonear(800_000_000_000_000_000_000))

--- a/examples/lockable-fungible-token/tests/workspaces.rs
+++ b/examples/lockable-fungible-token/tests/workspaces.rs
@@ -36,7 +36,7 @@ async fn initialized_contract(
     initial_balance: U128,
     lockable_fungible_contract_wasm: &Vec<u8>,
 ) -> anyhow::Result<(Contract, Account)> {
-    let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
+    let worker = near_workspaces::sandbox().await?;
 
     let contract = worker.dev_deploy(lockable_fungible_contract_wasm).await?;
 

--- a/examples/lockable-fungible-token/tests/workspaces.rs
+++ b/examples/lockable-fungible-token/tests/workspaces.rs
@@ -36,7 +36,7 @@ async fn initialized_contract(
     initial_balance: U128,
     lockable_fungible_contract_wasm: &Vec<u8>,
 ) -> anyhow::Result<(Contract, Account)> {
-    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
 
     let contract = worker.dev_deploy(lockable_fungible_contract_wasm).await?;
 

--- a/examples/mission-control/src/mission_control.rs
+++ b/examples/mission-control/src/mission_control.rs
@@ -103,7 +103,7 @@ mod tests {
     #[tokio::test]
     async fn embedded_abi_test() -> anyhow::Result<()> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         let res = contract.view("__contract_abi").await?;

--- a/examples/mission-control/src/mission_control.rs
+++ b/examples/mission-control/src/mission_control.rs
@@ -103,7 +103,7 @@ mod tests {
     #[tokio::test]
     async fn embedded_abi_test() -> anyhow::Result<()> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
+        let worker = near_workspaces::sandbox().await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         let res = contract.view("__contract_abi").await?;

--- a/examples/mpc-contract/src/lib.rs
+++ b/examples/mpc-contract/src/lib.rs
@@ -292,7 +292,7 @@ mod tests {
     #[tokio::test]
     async fn happy_path() -> Result<(), Box<dyn std::error::Error>> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let workspace = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
+        let workspace = near_workspaces::sandbox_with_version("2.13.0").await?;
 
         let contract_account = workspace.dev_create_account().await?;
         let contract = contract_account.deploy(wasm.as_slice()).await?.into_result()?;
@@ -323,7 +323,7 @@ mod tests {
     #[tokio::test]
     async fn negative_path() -> Result<(), Box<dyn std::error::Error>> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let workspace = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
+        let workspace = near_workspaces::sandbox_with_version("2.13.0").await?;
 
         let contract_account = workspace.dev_create_account().await?;
         let contract = contract_account.deploy(wasm.as_slice()).await?.into_result()?;

--- a/examples/mpc-contract/src/lib.rs
+++ b/examples/mpc-contract/src/lib.rs
@@ -292,7 +292,7 @@ mod tests {
     #[tokio::test]
     async fn happy_path() -> Result<(), Box<dyn std::error::Error>> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let workspace = near_workspaces::sandbox_with_version("2.13.0").await?;
+        let workspace = near_workspaces::sandbox().await?;
 
         let contract_account = workspace.dev_create_account().await?;
         let contract = contract_account.deploy(wasm.as_slice()).await?.into_result()?;
@@ -323,7 +323,7 @@ mod tests {
     #[tokio::test]
     async fn negative_path() -> Result<(), Box<dyn std::error::Error>> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let workspace = near_workspaces::sandbox_with_version("2.13.0").await?;
+        let workspace = near_workspaces::sandbox().await?;
 
         let contract_account = workspace.dev_create_account().await?;
         let contract = contract_account.deploy(wasm.as_slice()).await?.into_result()?;

--- a/examples/non-fungible-token/tests/workspaces/utils.rs
+++ b/examples/non-fungible-token/tests/workspaces/utils.rs
@@ -85,7 +85,7 @@ pub async fn initialized_contracts(
     token_receiver_contract_wasm: &Vec<u8>,
     approval_receiver_contract_wasm: &Vec<u8>,
 ) -> anyhow::Result<(Contract, Account, Contract, Contract)> {
-    let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
+    let worker = near_workspaces::sandbox().await?;
     let nft_contract = worker.dev_deploy(non_fungible_contract_wasm).await?;
 
     let res = nft_contract

--- a/examples/non-fungible-token/tests/workspaces/utils.rs
+++ b/examples/non-fungible-token/tests/workspaces/utils.rs
@@ -85,7 +85,7 @@ pub async fn initialized_contracts(
     token_receiver_contract_wasm: &Vec<u8>,
     approval_receiver_contract_wasm: &Vec<u8>,
 ) -> anyhow::Result<(Contract, Account, Contract, Contract)> {
-    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
     let nft_contract = worker.dev_deploy(non_fungible_contract_wasm).await?;
 
     let res = nft_contract

--- a/examples/status-message/src/lib.rs
+++ b/examples/status-message/src/lib.rs
@@ -78,7 +78,7 @@ mod tests {
     #[tokio::test]
     async fn embedded_abi_test() -> anyhow::Result<()> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         let res = contract.view("__contract_abi").await?;

--- a/examples/status-message/src/lib.rs
+++ b/examples/status-message/src/lib.rs
@@ -78,7 +78,7 @@ mod tests {
     #[tokio::test]
     async fn embedded_abi_test() -> anyhow::Result<()> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
+        let worker = near_workspaces::sandbox().await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         let res = contract.view("__contract_abi").await?;

--- a/examples/test-contract/src/lib.rs
+++ b/examples/test-contract/src/lib.rs
@@ -81,7 +81,7 @@ mod tests {
     #[tokio::test]
     async fn embedded_abi_test() -> anyhow::Result<()> {
         let wasm = build_contract("./").await?;
-        let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
+        let worker = near_workspaces::sandbox().await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         let res = contract.view("__contract_abi").await?;
@@ -99,7 +99,7 @@ mod tests {
     #[tokio::test]
     async fn private_init_cannot_be_called_by_external_account() -> anyhow::Result<()> {
         let wasm = build_contract("./").await?;
-        let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
+        let worker = near_workspaces::sandbox().await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         // Create an external account (alice)
@@ -129,7 +129,7 @@ mod tests {
     #[tokio::test]
     async fn private_init_can_be_called_by_current_account() -> anyhow::Result<()> {
         let wasm = build_contract("./").await?;
-        let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
+        let worker = near_workspaces::sandbox().await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         // Contract calls its own private init method - should succeed

--- a/examples/test-contract/src/lib.rs
+++ b/examples/test-contract/src/lib.rs
@@ -81,7 +81,7 @@ mod tests {
     #[tokio::test]
     async fn embedded_abi_test() -> anyhow::Result<()> {
         let wasm = build_contract("./").await?;
-        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         let res = contract.view("__contract_abi").await?;
@@ -99,7 +99,7 @@ mod tests {
     #[tokio::test]
     async fn private_init_cannot_be_called_by_external_account() -> anyhow::Result<()> {
         let wasm = build_contract("./").await?;
-        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         // Create an external account (alice)
@@ -129,7 +129,7 @@ mod tests {
     #[tokio::test]
     async fn private_init_can_be_called_by_current_account() -> anyhow::Result<()> {
         let wasm = build_contract("./").await?;
-        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         // Contract calls its own private init method - should succeed

--- a/examples/versioned/src/lib.rs
+++ b/examples/versioned/src/lib.rs
@@ -152,7 +152,7 @@ mod tests {
     #[tokio::test]
     async fn embedded_abi_test() -> anyhow::Result<()> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let worker = near_workspaces::sandbox_with_version("2.13.0-rc.2").await?;
+        let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         let res = contract.view("__contract_abi").await?;

--- a/examples/versioned/src/lib.rs
+++ b/examples/versioned/src/lib.rs
@@ -152,7 +152,7 @@ mod tests {
     #[tokio::test]
     async fn embedded_abi_test() -> anyhow::Result<()> {
         let wasm = near_workspaces::compile_project("./").await?;
-        let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
+        let worker = near_workspaces::sandbox().await?;
         let contract = worker.dev_deploy(&wasm).await?;
 
         let res = contract.view("__contract_abi").await?;

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -14,7 +14,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.29.0-rc.2", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.29.0", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-global-contracts/Cargo.toml
+++ b/near-global-contracts/Cargo.toml
@@ -32,8 +32,8 @@ borsh = { version = "1.0.0", features = ["derive"], optional = true }
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 
 near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.4", optional = true }
-# Pinned to the published nearcore 2.13 release candidate `0.37.0-rc.2`; see near-sdk/Cargo.toml for the rationale.
-near-primitives-core = { version = "=0.37.0-rc.2", optional = true }
+# Pinned to the nearcore 2.13.0 stable release `0.37.0`; see near-sdk/Cargo.toml for the rationale.
+near-primitives-core = { version = "0.37.0", optional = true }
 
 schemars-v0_8 = { version = "0.8.22", optional = true, package = "schemars" }
 

--- a/near-global-contracts/Cargo.toml
+++ b/near-global-contracts/Cargo.toml
@@ -32,7 +32,6 @@ borsh = { version = "1.0.0", features = ["derive"], optional = true }
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 
 near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.4", optional = true }
-# Tracks the nearcore 2.13.0 stable release (`^0.37.0`); see near-sdk/Cargo.toml for the rationale.
 near-primitives-core = { version = "0.37.0", optional = true }
 
 schemars-v0_8 = { version = "0.8.22", optional = true, package = "schemars" }

--- a/near-global-contracts/Cargo.toml
+++ b/near-global-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-global-contracts"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 license.workspace = true
 categories.workspace = true
@@ -32,7 +32,7 @@ borsh = { version = "1.0.0", features = ["derive"], optional = true }
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 
 near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.4", optional = true }
-# Pinned to the nearcore 2.13.0 stable release `0.37.0`; see near-sdk/Cargo.toml for the rationale.
+# Tracks the nearcore 2.13.0 stable release (`^0.37.0`); see near-sdk/Cargo.toml for the rationale.
 near-primitives-core = { version = "0.37.0", optional = true }
 
 schemars-v0_8 = { version = "0.8.22", optional = true, package = "schemars" }

--- a/near-sdk-core/Cargo.toml
+++ b/near-sdk-core/Cargo.toml
@@ -36,19 +36,18 @@ near-crypto-hash = { path = "../near-crypto-hash/", version = "~0.2.0" }
 near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.4", optional = true }
 
 schemars-v0_8 = { version = "0.8.22", optional = true, package = "schemars" }
-# Pinned to the published nearcore 2.13 release candidate `0.37.0-rc.2`; see near-sdk/Cargo.toml for
-# the rationale. All nearcore-versioned crates across the workspace must use the same version so their
-# types unify. Bump to `0.37.0` (drop the `=`) once 2.13 ships stable.
-near-primitives-core = { version = "=0.37.0-rc.2", optional = true }
+# Pinned to the nearcore 2.13.0 stable release `0.37.0`; see near-sdk/Cargo.toml for the rationale.
+# All nearcore-versioned crates across the workspace must use the same version so their types unify.
+near-primitives-core = { version = "0.37.0", optional = true }
 unicode-segmentation = { version = "1", optional = true }
-near-parameters = { version = "=0.37.0-rc.2", optional = true }
+near-parameters = { version = "0.37.0", optional = true }
 
 # near-crypto is only used by the `near-crypto-interop` conversions, which are host-only (gated
 # `cfg(all(not(target_arch = "wasm32"), feature = "near-crypto-interop"))`). Keep it off wasm targets
 # so contracts that enable `unit-testing` still build for wasm — since nearcore 2.13, near-crypto
 # pulls a non-optional aws-lc-rs (C) dependency that cannot compile for wasm32. Mirrors near-sdk.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-near-crypto = { version = "=0.37.0-rc.2", default-features = false, optional = true }
+near-crypto = { version = "0.37.0", default-features = false, optional = true }
 
 [target.'cfg(near)'.dependencies]
 near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.4" }

--- a/near-sdk-core/Cargo.toml
+++ b/near-sdk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sdk-core"
-version = "4.2.1"
+version = "4.2.2"
 authors = ["Near Inc <hello@near.org>"]
 edition.workspace = true
 license.workspace = true
@@ -36,8 +36,9 @@ near-crypto-hash = { path = "../near-crypto-hash/", version = "~0.2.0" }
 near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.4", optional = true }
 
 schemars-v0_8 = { version = "0.8.22", optional = true, package = "schemars" }
-# Pinned to the nearcore 2.13.0 stable release `0.37.0`; see near-sdk/Cargo.toml for the rationale.
-# All nearcore-versioned crates across the workspace must use the same version so their types unify.
+# Tracks the nearcore 2.13.0 stable release (`^0.37.0`); see near-sdk/Cargo.toml for the rationale.
+# All nearcore-versioned crates across the workspace share the same requirement so a single 0.37.x
+# resolves for all of them and their types unify.
 near-primitives-core = { version = "0.37.0", optional = true }
 unicode-segmentation = { version = "1", optional = true }
 near-parameters = { version = "0.37.0", optional = true }

--- a/near-sdk-core/Cargo.toml
+++ b/near-sdk-core/Cargo.toml
@@ -36,9 +36,6 @@ near-crypto-hash = { path = "../near-crypto-hash/", version = "~0.2.0" }
 near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.4", optional = true }
 
 schemars-v0_8 = { version = "0.8.22", optional = true, package = "schemars" }
-# Tracks the nearcore 2.13.0 stable release (`^0.37.0`); see near-sdk/Cargo.toml for the rationale.
-# All nearcore-versioned crates across the workspace share the same requirement so a single 0.37.x
-# resolves for all of them and their types unify.
 near-primitives-core = { version = "0.37.0", optional = true }
 unicode-segmentation = { version = "1", optional = true }
 near-parameters = { version = "0.37.0", optional = true }

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -23,7 +23,7 @@ required-features = ["abi", "unstable"]
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_with = { version = "3", features = ["base64", "hex", "json"] }
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.29.0-rc.2" }
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.29.0" }
 near-sys = { path = "../near-sys", version = "0.2.12" }
 near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.4" }
 near-sdk-core = { path = "../near-sdk-core/", version = "~4.2.1", features = [
@@ -69,13 +69,13 @@ near-abi = { version = "0.4.0", features = [
 ], optional = true }
 # nearcore 2.13 adds the promise_yield_create_with_id / promise_yield_resume_with_yield_id host
 # functions (protocol v85), so the unit-testing mock can delegate to VMLogic for them. Pinned to the
-# published 2.13 release candidate `0.37.0-rc.2`. Bump to `0.37.0` (drop the `=`) once 2.13 ships stable.
-near-vm-runner = { version = "=0.37.0-rc.2", optional = true }
-near-primitives-core = { version = "=0.37.0-rc.2", optional = true }
-near-primitives = { version = "=0.37.0-rc.2", optional = true }
-near-crypto = { version = "=0.37.0-rc.2", default-features = false, optional = true }
+# nearcore 2.13.0 stable release `0.37.0`.
+near-vm-runner = { version = "0.37.0", optional = true }
+near-primitives-core = { version = "0.37.0", optional = true }
+near-primitives = { version = "0.37.0", optional = true }
+near-crypto = { version = "0.37.0", default-features = false, optional = true }
 unicode-segmentation = { version = "1", optional = true }
-near-parameters = { version = "=0.37.0-rc.2", optional = true }
+near-parameters = { version = "0.37.0", optional = true }
 
 [dev-dependencies]
 openssl = { version = "0.10", features = ["vendored"] }

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -67,10 +67,6 @@ p256 = { version = "0.13.2", default-features = false, features = [
 near-abi = { version = "0.4.0", features = [
     "__chunked-entries",
 ], optional = true }
-# nearcore 2.13 adds the promise_yield_create_with_id / promise_yield_resume_with_yield_id host
-# functions (protocol v85), so the unit-testing mock can delegate to VMLogic for them. Tracks the
-# nearcore 2.13.0 stable release (`^0.37.0`). Every nearcore-versioned crate across the workspace
-# shares this requirement so a single 0.37.x resolves for all of them and their types unify.
 near-vm-runner = { version = "0.37.0", optional = true }
 near-primitives-core = { version = "0.37.0", optional = true }
 near-primitives = { version = "0.37.0", optional = true }
@@ -94,7 +90,7 @@ rand_chacha = "0.3.1"
 near-rng = "0.1.1"
 near-abi = { version = "0.4.0", features = ["__chunked-entries"] }
 symbolic-debuginfo = "12"
-near-workspaces = { version = "0.22.4", features = ["unstable"] }
+near-workspaces = { version = "0.23.0", features = ["unstable"] }
 anyhow = "1.0"
 tokio = { version = "1", features = ["full"] }
 strum = "0.25.0"

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -26,11 +26,11 @@ serde_with = { version = "3", features = ["base64", "hex", "json"] }
 near-sdk-macros = { path = "../near-sdk-macros", version = "~5.29.0" }
 near-sys = { path = "../near-sys", version = "0.2.12" }
 near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.4" }
-near-sdk-core = { path = "../near-sdk-core/", version = "~4.2.1", features = [
+near-sdk-core = { path = "../near-sdk-core/", version = "~4.2.2", features = [
     "serde",
     "borsh",
 ] }
-near-global-contracts = { path = "../near-global-contracts/", version = "~0.2.4", features = [
+near-global-contracts = { path = "../near-global-contracts/", version = "~0.2.5", features = [
     "serde",
     "borsh",
 ] }
@@ -68,8 +68,9 @@ near-abi = { version = "0.4.0", features = [
     "__chunked-entries",
 ], optional = true }
 # nearcore 2.13 adds the promise_yield_create_with_id / promise_yield_resume_with_yield_id host
-# functions (protocol v85), so the unit-testing mock can delegate to VMLogic for them. Pinned to the
-# nearcore 2.13.0 stable release `0.37.0`.
+# functions (protocol v85), so the unit-testing mock can delegate to VMLogic for them. Tracks the
+# nearcore 2.13.0 stable release (`^0.37.0`). Every nearcore-versioned crate across the workspace
+# shares this requirement so a single 0.37.x resolves for all of them and their types unify.
 near-vm-runner = { version = "0.37.0", optional = true }
 near-primitives-core = { version = "0.37.0", optional = true }
 near-primitives = { version = "0.37.0", optional = true }

--- a/near-sdk/src/lib.rs
+++ b/near-sdk/src/lib.rs
@@ -498,7 +498,7 @@ compile_error!(
 /// You can also use [`#[serde_as(as = "...")]` attributes](https://docs.rs/serde_with/latest/serde_with/attr.serde_as.html)
 /// as if `#[serde_as]` is added to the type (which is what actually happens under the hood of `#[near(serializers = [json])]` implementation).
 ///
-/// Note: When using the `abi` feature with base64/hex encoding, prefer the SDK's [`json_types`](crate::json_types)
+/// Note: When using the `abi` feature with base64/hex encoding, prefer the SDK's [`json_types`]
 /// like [`Base64VecU8`](crate::json_types::Base64VecU8), which have full JSON Schema support.
 ///
 /// For hex encoding with ABI support, you can use `#[serde_as(as = "serde_with::hex::Hex")]` by enabling
@@ -612,7 +612,7 @@ compile_error!(
 /// For a method annotated with `#[init]`:
 ///
 /// 1. Before invoking the constructor, the macro checks if the contract state already exists by calling
-///    [`state::ContractState::state_exists`](crate::state::ContractState::state_exists), which internally uses
+///    [`state::ContractState::state_exists`], which internally uses
 ///    [`env::storage_has_key`] to check for the state key
 /// 2. If the state already exists, [`env::panic_str`] host function is called with the message
 ///    `"The contract has already been initialized"`
@@ -1105,7 +1105,7 @@ compile_error!(
 ///    - `#[serde(tag = "event", content = "data")]` for the NEP-297 format
 ///    - `#[serde(rename_all = "snake_case")]` for event name formatting
 /// 3. A constant `{EnumName}_event_standard` is generated with the standard name
-/// 4. The [`EventMetadata`](crate::EventMetadata) derive macro generates:
+/// 4. The [`EventMetadata`] derive macro generates:
 ///    - `emit()` method: Serializes the event to JSON and calls [`env::log_str`] with the format
 ///      `EVENT_JSON:{json}` as specified by [NEP-297](https://github.com/near/NEPs/blob/master/neps/nep-0297.md)
 ///    - `to_json()` method: Returns the event as a [`serde_json::Value`]


### PR DESCRIPTION
nearcore 2.13.0 is on crates.io, so this builds against the live stable crates.

- Swaps the nearcore pins (`near-primitives`, `near-primitives-core`, `near-crypto`, `near-vm-runner`, `near-parameters`) from `=0.37.0-rc.2` to `0.37.0`.
- Releases `near-sdk` 5.29.0 (from `5.29.0-rc.2`); also deps-only bumps `near-sdk-core` 4.2.2 and `near-global-contracts` 0.2.5 so their published manifests pick up the stable nearcore crates.
- Bumps the `near-workspaces` dev-dep to 0.23.0 and returns the examples to bare `sandbox()` (which now defaults to the stable 2.13.0 binary).
