### PR TITLE
fix: unify AsNep297Event trait definition across serde feature gate

### DIFF
--- a/near-sdk-core/src/events.rs
+++ b/near-sdk-core/src/events.rs
@@ -92,17 +92,6 @@ where
 }
 
 /// Helper trait implemented by events that expose a NEP-297 representation.
-#[cfg(feature = "serde")]
-pub trait AsNep297Event: serde::Serialize + Sized {
-    /// Converts the event into a [`Nep297Event`] representation.
-    ///
-    /// Wraps the event with its NEP-297 metadata. The payload is borrowed so it can be serialized
-    /// on demand without cloning.
-    fn to_nep297_event(&self) -> Nep297Event<'_, Self>;
-}
-
-/// Helper trait implemented by events that expose a NEP-297 representation.
-#[cfg(not(feature = "serde"))]
 pub trait AsNep297Event: Sized {
     /// Converts the event into a [`Nep297Event`] representation.
     ///

--- a/near-sdk-core/src/events.rs
+++ b/near-sdk-core/src/events.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 ///
 /// # Type Parameters
 /// - `T`: Event payload that is borrowed so it can be serialized lazily. Must implement
-///   [`serde::Serialize`] when the `serde` feature is enabled.
+///   `serde::Serialize` to use the serialization helpers available with the `serde` feature.
 #[derive(Debug)]
 #[cfg_attr(
     feature = "serde",
@@ -92,6 +92,11 @@ where
 }
 
 /// Helper trait implemented by events that expose a NEP-297 representation.
+///
+/// This trait does not require `serde::Serialize`, regardless of enabled cargo features, so its
+/// shape stays the same across feature combinations (feature additivity). Serialization-dependent
+/// functionality (e.g. `Nep297Event::to_event_log`) is gated behind the `serde` feature and
+/// bounded on `T: serde::Serialize` at the impl level instead.
 pub trait AsNep297Event: Sized {
     /// Converts the event into a [`Nep297Event`] representation.
     ///

--- a/near-sdk/src/lib.rs
+++ b/near-sdk/src/lib.rs
@@ -498,7 +498,7 @@ compile_error!(
 /// You can also use [`#[serde_as(as = "...")]` attributes](https://docs.rs/serde_with/latest/serde_with/attr.serde_as.html)
 /// as if `#[serde_as]` is added to the type (which is what actually happens under the hood of `#[near(serializers = [json])]` implementation).
 ///
-/// Note: When using the `abi` feature with base64/hex encoding, prefer the SDK's [`json_types`](crate::json_types)
+/// Note: When using the `abi` feature with base64/hex encoding, prefer the SDK's [`json_types`]
 /// like [`Base64VecU8`](crate::json_types::Base64VecU8), which have full JSON Schema support.
 ///
 /// For hex encoding with ABI support, you can use `#[serde_as(as = "serde_with::hex::Hex")]` by enabling
@@ -612,7 +612,7 @@ compile_error!(
 /// For a method annotated with `#[init]`:
 ///
 /// 1. Before invoking the constructor, the macro checks if the contract state already exists by calling
-///    [`state::ContractState::state_exists`](crate::state::ContractState::state_exists), which internally uses
+///    [`state::ContractState::state_exists`], which internally uses
 ///    [`env::storage_has_key`] to check for the state key
 /// 2. If the state already exists, [`env::panic_str`] host function is called with the message
 ///    `"The contract has already been initialized"`
@@ -1105,7 +1105,7 @@ compile_error!(
 ///    - `#[serde(tag = "event", content = "data")]` for the NEP-297 format
 ///    - `#[serde(rename_all = "snake_case")]` for event name formatting
 /// 3. A constant `{EnumName}_event_standard` is generated with the standard name
-/// 4. The [`EventMetadata`](crate::EventMetadata) derive macro generates:
+/// 4. The [`EventMetadata`] derive macro generates:
 ///    - `emit()` method: Serializes the event to JSON and calls [`env::log_str`] with the format
 ///      `EVENT_JSON:{json}` as specified by [NEP-297](https://github.com/near/NEPs/blob/master/neps/nep-0297.md)
 ///    - `to_json()` method: Returns the event as a [`serde_json::Value`]


### PR DESCRIPTION
## Problem

`near-sdk-core/src/events.rs` defined `AsNep297Event` twice behind `#[cfg(feature = "serde")]`: with serde on, the trait was `AsNep297Event: serde::Serialize + Sized`; with serde off, the `Serialize` supertrait was dropped. A cargo feature changing a public trait's shape breaks feature additivity — a crate compiled with serde off can stop compiling once any other crate in the dependency graph enables `near-sdk-core/serde`.

## Fix

Collapsed to a single unconditional `pub trait AsNep297Event: Sized`. The serde requirements already live where they're actually needed: the serde-gated inherent methods on `Nep297Event` and its `Serialize` impl carry `T: serde::Serialize` bounds at the impl level, so behavior for serde-on users is unchanged.

Note: removing the supertrait is itself a minor breaking change for any code relying on the implied `AsNep297Event: Serialize` bound.

Fixes #1585