### PR TITLE
docs: fix outdated docs.near.org links in doc comments

### DIFF
--- a/near-contract-standards/src/lib.rs
+++ b/near-contract-standards/src/lib.rs
@@ -7,7 +7,7 @@ pub mod fungible_token;
 /// Non-fungible tokens as described in [by the spec](https://nomicon.io/Standards/Tokens/NonFungibleToken).
 pub mod non_fungible_token;
 
-/// Storage management deals with handling [state storage](https://docs.near.org/docs/concepts/storage-staking) on NEAR. This follows the [storage management standard](https://nomicon.io/Standards/StorageManagement.html).
+/// Storage management deals with handling [state storage](https://docs.near.org/protocol/storage/storage-staking) on NEAR. This follows the [storage management standard](https://nomicon.io/Standards/StorageManagement.html).
 pub mod storage_management;
 
 /// This upgrade standard is a use case where a staging area exists for a WASM

--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -542,7 +542,7 @@ pub fn random_seed() -> Vec<u8> {
 ///     }
 /// }
 /// ```
-/// More info in [documentation](https://docs.near.org/develop/contracts/security/random)
+/// More info in [documentation](https://docs.near.org/smart-contracts/security/random)
 pub fn random_seed_array() -> [u8; 32] {
     maybe_cached!([u8; 32]: {
         //* SAFETY: random_seed syscall will always generate 32 bytes inside of the atomic op register
@@ -1039,7 +1039,7 @@ pub fn bls12381_p2_decompress(value: impl AsRef<[u8]>) -> Vec<u8> {
 /// );
 /// ```
 ///
-/// More info about promises in [NEAR documentation](https://docs.near.org/build/smart-contracts/anatomy/crosscontract#promises)
+/// More info about promises in [NEAR documentation](https://docs.near.org/smart-contracts/anatomy/crosscontract#promises)
 ///
 /// More low-level info here: [`near_vm_runner::logic::VMLogic::promise_create`]
 ///
@@ -1200,7 +1200,7 @@ pub fn promise_and(promise_indices: &[PromiseIndex]) -> PromiseIndex {
 /// ```
 /// All actions in a batch are executed in the order they were added.
 /// Batched actions act as a unit: they execute in the same receipt, and if any fails, then they all get reverted.
-/// More information about batching actions can be found in [NEAR documentation](https://docs.near.org/build/smart-contracts/anatomy/actions)
+/// More information about batching actions can be found in [NEAR documentation](https://docs.near.org/smart-contracts/anatomy/actions)
 /// More low-level info here: [`near_vm_runner::logic::VMLogic::promise_batch_create`]
 /// See example of usage [here](https://github.com/near/near-sdk-rs/blob/master/examples/factory-contract/low-level/src/lib.rs)
 pub fn promise_batch_create(account_id: &AccountId) -> PromiseIndex {

--- a/near-sdk/src/lib.rs
+++ b/near-sdk/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! `near-sdk` is a Rust toolkit for developing smart contracts on the [NEAR blockchain](https://near.org).
 //! It provides abstractions, macros, and utilities to make building robust and secure contracts easy.
-//! More information on how to develop smart contracts can be found in the [NEAR documentation](https://docs.near.org/build/smart-contracts/what-is).
+//! More information on how to develop smart contracts can be found in the [NEAR documentation](https://docs.near.org/smart-contracts/what-is).
 //! With near-sdk you can create DeFi applications, NFTs and marketplaces, DAOs, gaming and metaverse apps, and much more.
 //!
 //! ## Features
@@ -394,7 +394,7 @@ compile_error!(
 /// - [`Promise`] - The type returned by `<ContractType>Ext` methods
 /// - [`#[callback_unwrap]`](near#callback_unwrap-annotates-function-arguments) - For handling results from cross-contract calls
 /// - [`#[private]`](near#private-annotates-methods-of-a-type-in-its-impl-block) - For restricting callback methods
-/// - [NEAR Cross-Contract Calls Documentation](https://docs.near.org/build/smart-contracts/anatomy/crosscontract)
+/// - [NEAR Cross-Contract Calls Documentation](https://docs.near.org/smart-contracts/anatomy/crosscontract)
 ///
 /// ## `#[near(serializers=[...])` (annotates structs/enums)
 ///
@@ -577,7 +577,7 @@ compile_error!(
 ///
 /// ## `#[init]` (annotates methods of a type in its `impl` block)
 ///
-/// Contract initialization method annotation. More details can be found [here](https://docs.near.org/build/smart-contracts/anatomy/storage#initializing-the-state)
+/// Contract initialization method annotation. More details can be found [here](https://docs.near.org/smart-contracts/anatomy/storage#initializing-the-state)
 ///
 /// By default, the `Default::default()` implementation of a contract will be used to initialize a contract.
 /// There can be a custom initialization function which takes parameters or performs custom logic with the following `#[init]` annotation.
@@ -624,7 +624,7 @@ compile_error!(
 ///
 /// ## `#[payable]` (annotates methods of a type in its `impl` block)
 ///
-/// Specifies that the method can accept NEAR tokens. More details can be found [here](https://docs.near.org/build/smart-contracts/anatomy/functions#payable-functions)
+/// Specifies that the method can accept NEAR tokens. More details can be found [here](https://docs.near.org/smart-contracts/anatomy/functions#payable-functions)
 ///
 /// Methods can be annotated with `#[payable]` to allow tokens to be transferred with the method invocation. For more information, see payable methods.
 ///
@@ -669,7 +669,7 @@ compile_error!(
 /// The attribute forbids to call the method except from within the contract.
 /// This is useful for internal methods that should not be called from outside the contract.
 ///
-/// More details can be found [here](https://docs.near.org/build/smart-contracts/anatomy/functions#private-functions)
+/// More details can be found [here](https://docs.near.org/smart-contracts/anatomy/functions#private-functions)
 ///
 /// ### Basic example
 ///
@@ -1485,14 +1485,14 @@ pub use near_sdk_macros::near_bindgen;
 /// }
 /// ```
 ///
-/// See more information about cross-contract calls in the [NEAR documentation](https://docs.near.org/build/smart-contracts/anatomy/crosscontract).
+/// See more information about cross-contract calls in the [NEAR documentation](https://docs.near.org/smart-contracts/anatomy/crosscontract).
 pub use near_sdk_macros::ext_contract;
 
 /// `BorshStorageKey` generates implementation for [BorshIntoStorageKey](crate::__private::BorshIntoStorageKey) trait.
 /// It allows the type to be passed as a unique prefix for persistent collections.
 /// The type should also implement or derive [BorshSerialize](borsh::BorshSerialize) trait.
 ///
-/// More information about storage keys in [NEAR documentation](https://docs.near.org/build/smart-contracts/anatomy/storage)
+/// More information about storage keys in [NEAR documentation](https://docs.near.org/smart-contracts/anatomy/storage)
 /// ## Example
 /// ```rust
 /// use near_sdk::{BorshStorageKey, collections::Vector, near};

--- a/near-sdk/src/promise.rs
+++ b/near-sdk/src/promise.rs
@@ -342,7 +342,7 @@ impl PromiseJoint {
 ///   .add_full_access_key(env::signer_account_pk());
 /// ```
 ///
-/// More information about promises in [NEAR documentation](https://docs.near.org/build/smart-contracts/anatomy/crosscontract#promises)
+/// More information about promises in [NEAR documentation](https://docs.near.org/smart-contracts/anatomy/crosscontract#promises)
 #[must_use = "return or detach explicitly via `.detach()`"]
 pub struct Promise {
     subtype: PromiseSubtype,

--- a/near-sdk/src/store/mod.rs
+++ b/near-sdk/src/store/mod.rs
@@ -135,7 +135,7 @@
 //!   place of a type [`Option<T>`](Option). Will only be loaded when interacted with and will
 //!   persist on [`Drop`].
 //!
-//! * More information about collections can be found in [NEAR documentation](https://docs.near.org/build/smart-contracts/anatomy/collections)
+//! * More information about collections can be found in [NEAR documentation](https://docs.near.org/smart-contracts/anatomy/collections)
 //! * Benchmarking results of the NEAR-SDK store collections vs native collections can be found in [github](https://github.com/volodymyr-matselyukh/near-benchmarking)
 
 mod lazy;

--- a/near-sdk/src/utils/storage_key_impl.rs
+++ b/near-sdk/src/utils/storage_key_impl.rs
@@ -2,7 +2,7 @@
 ///
 /// [`into_storage_key`]: IntoStorageKey::into_storage_key
 ///
-/// More information about storage is in [NEAR documentation](https://docs.near.org/build/smart-contracts/anatomy/storage).
+/// More information about storage is in [NEAR documentation](https://docs.near.org/smart-contracts/anatomy/storage).
 pub trait IntoStorageKey {
     /// Consumes self and returns [`Vec<u8>`] bytes which are used as a storage key.
     fn into_storage_key(self) -> Vec<u8>;


### PR DESCRIPTION
Fixes #1589

The NEAR docs site restructure dropped the `/build/` prefix from the smart-contract pages and moved a couple of older paths, so most `docs.near.org` links in our doc comments were hard 404s.

Changes (matching the table in the issue):

- `/build/smart-contracts/*` → `/smart-contracts/*` (12 links across `near-sdk/src/lib.rs`, `env.rs`, `promise.rs`, `store/mod.rs`, `storage_key_impl.rs`)
- `/develop/contracts/security/random` → `/smart-contracts/security/random` (the originally reported `random_seed_array` link)
- `/docs/concepts/storage-staking` → `/protocol/storage/storage-staking` in `near-contract-standards/src/lib.rs` (was only a 301, updated to the canonical URL)

Every replacement URL was checked and returns 200. Anchor fragments (`#promises`, `#payable-functions`, `#private-functions`, `#initializing-the-state`) were kept since they still resolve on the new pages.

I left the `nomicon.io` redirects in `near-contract-standards` alone — they still resolve, and the issue marks them as optional cleanup.