### PR TITLE
feat(env): add env::chain_id host-fn wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- add `env::chain_id` ([#1592](https://github.com/near/near-sdk-rs/pull/1592))
+
 ## [5.29.0-rc.2](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.29.0-rc.1...near-sdk-v5.29.0-rc.2) - 2026-07-08
 
 ### Added

--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -337,7 +337,9 @@ pub fn input() -> Option<Vec<u8>> {
 /// assert_eq!(chain_id(), "test");
 /// ```
 pub fn chain_id() -> String {
-    String::from_utf8(method_into_register(sys::chain_id)).unwrap_or_else(|_| abort())
+    maybe_cached!(String: {
+        String::from_utf8(method_into_register(sys::chain_id)).unwrap_or_else(|_| abort())
+    })
 }
 
 /// Current block index.

--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -325,6 +325,21 @@ pub fn input() -> Option<Vec<u8>> {
     try_method_into_register(sys::input)
 }
 
+/// Returns the chain ID of the NEAR network the contract is deployed on, as configured in the
+/// network's `genesis.config.chain_id` (for example `"mainnet"` or `"testnet"`).
+///
+/// In unit tests the mocked environment always returns `"test"`.
+///
+/// # Examples
+/// ```
+/// use near_sdk::env::chain_id;
+///
+/// assert_eq!(chain_id(), "test");
+/// ```
+pub fn chain_id() -> String {
+    String::from_utf8(method_into_register(sys::chain_id)).unwrap_or_else(|_| abort())
+}
+
 /// Current block index.
 ///
 /// # Examples
@@ -2854,6 +2869,15 @@ mod tests {
         );
 
         assert_eq!(super::random_seed(), [8; 32]);
+    }
+
+    #[test]
+    fn chain_id_returns_mock_value() {
+        // The mocked runtime backs `chain_id` with a hardcoded `"test"` value that isn't
+        // configurable via `VMContextBuilder`; on-chain it returns `genesis.config.chain_id`.
+        crate::testing_env!(crate::test_utils::VMContextBuilder::new().build());
+
+        assert_eq!(super::chain_id(), "test");
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/near-sdk/src/environment/mock/mocked_blockchain.rs
+++ b/near-sdk/src/environment/mock/mocked_blockchain.rs
@@ -242,6 +242,10 @@ mod mock_chain {
         with_mock_interface(|b| b.input(register_id))
     }
     #[unsafe(no_mangle)]
+    extern "C-unwind" fn chain_id(register_id: u64) {
+        with_mock_interface(|b| b.chain_id(register_id))
+    }
+    #[unsafe(no_mangle)]
     extern "C-unwind" fn block_index() -> u64 {
         with_mock_interface(|b| b.block_index())
     }

--- a/near-sys/src/lib.rs
+++ b/near-sys/src/lib.rs
@@ -20,6 +20,7 @@ unsafe extern "C" {
     pub fn signer_account_pk(register_id: u64);
     pub fn predecessor_account_id(register_id: u64);
     pub fn input(register_id: u64);
+    pub fn chain_id(register_id: u64);
     pub fn block_index() -> u64;
     pub fn block_timestamp() -> u64;
     pub fn epoch_height() -> u64;


### PR DESCRIPTION
## What

Adds `env::chain_id() -> String`, wrapping the `chain_id` host function.

## Why

The `chain_id` host function has been live on mainnet since protocol 85 (it returns `genesis.config.chain_id`, e.g. `"mainnet"` / `"testnet"`), but near-sdk-rs had no wrapper for it. Contracts that want to branch on the network they're deployed on had to go without.

## How

- `near-sys`: declare the `chain_id(register_id: u64)` extern in the Context API block.
- `near-sdk/env`: add the `chain_id()` getter, following the existing `current_account_id` / `input` register-read pattern (reads the register, converts to `String`, aborts on invalid UTF-8).
- Mock: bind the `extern "C-unwind" fn chain_id` in `mock_chain` so the SDK links off-wasm; it delegates to `VMLogic::chain_id`.
- Unit test asserting the wiring links and returns the mock value.

## Note on unit-test behavior

On-chain this returns the real `genesis.config.chain_id`. In unit tests it always returns `"test"`: the mock is backed by `near-vm-runner`'s `MockedExternal`, whose `chain_id()` is hardcoded and has no settable field. Making it configurable via `VMContextBuilder` is a follow-up that requires an upstream `near-vm-runner` change, so no (non-functional, misleading) setter is added here.
