### PR TITLE
fix(store): removed stale entries for partially consumed `Drain` after drop

### DIFF
--- a/near-sdk/src/store/iterable_map/iter.rs
+++ b/near-sdk/src/store/iterable_map/iter.rs
@@ -475,6 +475,19 @@ where
     }
 }
 
+impl<'a, K, V, H> Drop for Drain<'a, K, V, H>
+where
+    K: BorshSerialize + BorshDeserialize + Ord,
+    V: BorshSerialize,
+    H: ToKey,
+{
+    fn drop(&mut self) {
+        for key in self.keys.by_ref() {
+            self.values.set(key, None);
+        }
+    }
+}
+
 impl<'a, K, V, H> Iterator for Drain<'a, K, V, H>
 where
     K: BorshSerialize + BorshDeserialize + Ord + Clone,

--- a/near-sdk/src/store/iterable_map/mod.rs
+++ b/near-sdk/src/store/iterable_map/mod.rs
@@ -1421,4 +1421,30 @@ mod test_map {
 
         insta::assert_snapshot!(format!("{:#?}", defs));
     }
+
+    #[test]
+    fn test_drain_partial_consumption_clears_values() {
+        let mut map = IterableMap::new(b"b");
+        for i in 1..=3 {
+            map.insert(i, i * 10);
+        }
+
+        {
+            let mut drain = map.drain();
+            drain.next().unwrap();
+            // Dropped with two entries unconsumed
+        }
+
+        assert_eq!(map.len(), 0);
+        assert!(map.is_empty());
+
+        for i in 1..=3 {
+            assert!(!map.contains_key(&i), "stale value entry for key {} after partial drain", i);
+            assert_eq!(map.get(&i), None, "get({}) should be None on an empty map", i);
+            assert_eq!(map.remove(&i), None, "remove({}) should be a no-op on an empty map", i);
+            assert_eq!(map.insert(i, i * 100), None, "re-insert of {} should be a fresh insert", i);
+        }
+        assert_eq!(map.len(), 3);
+        assert_eq!(map.get(&2), Some(&200));
+    }
 }

--- a/near-sdk/src/store/iterable_set/iter.rs
+++ b/near-sdk/src/store/iterable_set/iter.rs
@@ -316,6 +316,18 @@ where
     }
 }
 
+impl<'a, T, H> Drop for Drain<'a, T, H>
+where
+    T: BorshSerialize + BorshDeserialize + Ord,
+    H: ToKey,
+{
+    fn drop(&mut self) {
+        for key in self.elements.by_ref() {
+            self.index.set(key, None);
+        }
+    }
+}
+
 impl<'a, T, H> Iterator for Drain<'a, T, H>
 where
     T: BorshSerialize + BorshDeserialize + Ord + Clone,

--- a/near-sdk/src/store/iterable_set/mod.rs
+++ b/near-sdk/src/store/iterable_set/mod.rs
@@ -435,6 +435,8 @@ where
 
     /// Clears the set, returning all elements in an iterator.
     ///
+    /// This will clear all elements, even if only some of them are yielded.
+    ///
     /// # Examples
     ///
     /// ```
@@ -950,5 +952,66 @@ mod tests {
         // Should be able to re-insert both
         assert!(set.insert(first));
         assert!(set.insert(last));
+    }
+
+    #[test]
+    fn test_drain_partial_consumption_clears_index() {
+        let mut set = IterableSet::new(b"t");
+        for i in 1..=3 {
+            set.insert(i);
+        }
+
+        {
+            let mut drain = set.drain();
+            drain.next().unwrap();
+            // Dropped with two elements unconsumed
+        }
+
+        assert_eq!(set.len(), 0);
+        assert!(set.is_empty());
+
+        for i in 1..=3 {
+            assert!(!set.contains(&i), "stale index entry for {} after partial drain", i);
+            assert!(!set.remove(&i), "remove({}) should be a no-op on an empty set", i);
+            assert!(set.insert(i), "re-insert of {} should succeed after drain", i);
+        }
+        assert_eq!(set.len(), 3);
+    }
+
+    #[test]
+    fn test_drain_unconsumed_clears_index() {
+        let mut set = IterableSet::new(b"t");
+        for i in 1..=3 {
+            set.insert(i);
+        }
+
+        set.drain(); // Bare statement: dropped without consuming anything
+
+        assert!(set.is_empty());
+        for i in 1..=3 {
+            assert!(!set.contains(&i), "stale index entry for {} after unconsumed drain", i);
+        }
+    }
+
+    #[test]
+    fn test_drain_mixed_direction_partial_consumption() {
+        let mut set = IterableSet::new(b"t");
+        for i in 1..=5 {
+            set.insert(i);
+        }
+
+        {
+            let mut drain = set.drain();
+            drain.next().unwrap();
+            drain.next_back().unwrap();
+            // Dropped with three elements unconsumed
+        }
+
+        assert!(set.is_empty());
+        for i in 1..=5 {
+            assert!(!set.contains(&i), "stale index entry for {} after mixed-direction drain", i);
+            assert!(set.insert(i), "re-insert of {} should succeed after drain", i);
+        }
+        assert_eq!(set.len(), 5);
     }
 }

--- a/near-sdk/src/store/unordered_map/iter.rs
+++ b/near-sdk/src/store/unordered_map/iter.rs
@@ -476,6 +476,19 @@ where
     }
 }
 
+impl<'a, K, V, H> Drop for Drain<'a, K, V, H>
+where
+    K: BorshSerialize + BorshDeserialize + Ord,
+    V: BorshSerialize,
+    H: ToKey,
+{
+    fn drop(&mut self) {
+        for key in self.keys.by_ref() {
+            self.values.set(key, None);
+        }
+    }
+}
+
 impl<'a, K, V, H> Iterator for Drain<'a, K, V, H>
 where
     K: BorshSerialize + BorshDeserialize + Ord + Clone,

--- a/near-sdk/src/store/unordered_map/mod.rs
+++ b/near-sdk/src/store/unordered_map/mod.rs
@@ -867,4 +867,64 @@ mod tests {
 
         insta::assert_snapshot!(format!("{:#?}", defs));
     }
+
+    #[test]
+    fn test_drain_partial_consumption_clears_values() {
+        let mut map = UnorderedMap::new(b"b");
+        for i in 1..=3 {
+            map.insert(i, i * 10);
+        }
+
+        {
+            let mut drain = map.drain();
+            drain.next().unwrap();
+            // Dropped with two entries unconsumed
+        }
+
+        assert_eq!(map.len(), 0);
+        assert!(map.is_empty());
+
+        for i in 1..=3 {
+            assert!(!map.contains_key(&i), "stale value entry for key {} after partial drain", i);
+            assert_eq!(map.get(&i), None, "get({}) should be None on an empty map", i);
+            assert_eq!(map.remove(&i), None, "remove({}) should be a no-op on an empty map", i);
+            assert_eq!(map.insert(i, i * 100), None, "re-insert of {} should be a fresh insert", i);
+        }
+        assert_eq!(map.len(), 3);
+        assert_eq!(map.get(&2), Some(&200));
+    }
+
+    #[test]
+    fn test_drain_partial_consumption_with_free_list_holes() {
+        let mut map = UnorderedMap::new(b"b");
+        for i in 1..=6 {
+            map.insert(i, i * 10);
+        }
+        // Create Slot::Empty holes in the backing key free list.
+        assert_eq!(map.remove(&2), Some(20));
+        assert_eq!(map.remove(&5), Some(50));
+        assert_eq!(map.len(), 4);
+
+        {
+            let mut drain = map.drain();
+            drain.next().unwrap();
+            drain.next_back().unwrap();
+            // Dropped with two entries unconsumed
+        }
+
+        assert_eq!(map.len(), 0);
+        assert!(map.is_empty());
+
+        for i in 1..=6 {
+            assert!(
+                !map.contains_key(&i),
+                "stale value entry for key {} after drain over holes",
+                i
+            );
+            assert_eq!(map.remove(&i), None, "remove({}) should be a no-op on an empty map", i);
+            assert_eq!(map.insert(i, i * 100), None, "re-insert of {} should be a fresh insert", i);
+        }
+        assert_eq!(map.len(), 6);
+        assert_eq!(map.get(&5), Some(&500));
+    }
 }

--- a/near-sdk/src/store/unordered_set/iter.rs
+++ b/near-sdk/src/store/unordered_set/iter.rs
@@ -316,6 +316,18 @@ where
     }
 }
 
+impl<'a, T, H> Drop for Drain<'a, T, H>
+where
+    T: BorshSerialize + BorshDeserialize + Ord,
+    H: ToKey,
+{
+    fn drop(&mut self) {
+        for key in self.elements.by_ref() {
+            self.index.set(key, None);
+        }
+    }
+}
+
 impl<'a, T, H> Iterator for Drain<'a, T, H>
 where
     T: BorshSerialize + BorshDeserialize + Ord + Clone,

--- a/near-sdk/src/store/unordered_set/mod.rs
+++ b/near-sdk/src/store/unordered_set/mod.rs
@@ -443,6 +443,8 @@ where
 
     /// Clears the set, returning all elements in an iterator.
     ///
+    /// This will clear all elements, even if only some of them are yielded.
+    ///
     /// # Examples
     ///
     /// ```
@@ -1025,5 +1027,79 @@ mod tests {
         // Should be able to re-insert both
         assert!(set.insert(first));
         assert!(set.insert(last));
+    }
+
+    #[test]
+    fn test_drain_partial_consumption_clears_index() {
+        let mut set = UnorderedSet::new(b"t");
+        for i in 1..=3 {
+            set.insert(i);
+        }
+
+        {
+            let mut drain = set.drain();
+            drain.next().unwrap();
+            // Dropped with two elements unconsumed
+        }
+
+        assert_eq!(set.len(), 0);
+        assert!(set.is_empty());
+
+        for i in 1..=3 {
+            assert!(!set.contains(&i), "stale index entry for {} after partial drain", i);
+            assert!(!set.remove(&i), "remove({}) should be a no-op on an empty set", i);
+            assert!(set.insert(i), "re-insert of {} should succeed after drain", i);
+        }
+        assert_eq!(set.len(), 3);
+    }
+
+    #[test]
+    fn test_drain_mixed_direction_partial_consumption() {
+        let mut set = UnorderedSet::new(b"t");
+        for i in 1..=5 {
+            set.insert(i);
+        }
+
+        {
+            let mut drain = set.drain();
+            drain.next().unwrap();
+            drain.next_back().unwrap();
+            // Dropped with three elements unconsumed
+        }
+
+        assert!(set.is_empty());
+        for i in 1..=5 {
+            assert!(!set.contains(&i), "stale index entry for {} after mixed-direction drain", i);
+            assert!(set.insert(i), "re-insert of {} should succeed after drain", i);
+        }
+        assert_eq!(set.len(), 5);
+    }
+
+    #[test]
+    fn test_drain_partial_consumption_with_free_list_holes() {
+        let mut set = UnorderedSet::new(b"t");
+        for i in 1..=6 {
+            set.insert(i);
+        }
+        // Create Slot::Empty holes in the backing free list.
+        assert!(set.remove(&2));
+        assert!(set.remove(&5));
+        assert_eq!(set.len(), 4);
+
+        {
+            let mut drain = set.drain();
+            drain.next().unwrap();
+            drain.next_back().unwrap();
+            // Dropped with two elements unconsumed
+        }
+
+        assert_eq!(set.len(), 0);
+        assert!(set.is_empty());
+
+        for i in 1..=6 {
+            assert!(!set.contains(&i), "stale index entry for {} after drain over holes", i);
+            assert!(set.insert(i), "re-insert of {} should succeed after drain", i);
+        }
+        assert_eq!(set.len(), 6);
     }
 }


### PR DESCRIPTION
closes #1582
