### PR TITLE
fix(env): return correct account id in `current_contract_code` for `GlobalByAccount`

### DIFF
--- a/near-sdk/src/environment/env.rs
+++ b/near-sdk/src/environment/env.rs
@@ -212,9 +212,9 @@ pub fn current_contract_code() -> AccountContract {
             0 => AccountContract::None,
             1 => AccountContract::Local(unsafe { read_register_fixed(ATOMIC_OP_REGISTER) }),
             2 => AccountContract::Global(unsafe { read_register_fixed(ATOMIC_OP_REGISTER) }),
-            3 => AccountContract::GlobalByAccount(assert_valid_account_id(method_into_register(
-                sys::current_account_id,
-            ))),
+            3 => AccountContract::GlobalByAccount(assert_valid_account_id(expect_register(
+              read_register(ATOMIC_OP_REGISTER),
+          ))),
             _ => panic!("Invalid contract mode"),
         }
     })

--- a/near-sdk/src/environment/mock/mocked_blockchain.rs
+++ b/near-sdk/src/environment/mock/mocked_blockchain.rs
@@ -1088,6 +1088,29 @@ mod tests {
         }
 
         #[test]
+        fn test_current_contract_code_global_by_account_returns_referenced_account() {
+            let provider: AccountId = "a.near".parse().unwrap();
+            let context = VMContextBuilder::new()
+                .current_account_id("b.near".parse().unwrap())
+                .account_contract(AccountContract::GlobalByAccount(provider.clone()))
+                .build();
+            testing_env!(context);
+
+            assert_eq!(
+                env::current_contract_code(),
+                crate::AccountContract::GlobalByAccount(provider.clone()),
+                "current_contract_code() must return the referenced global-code provider \
+         (a.near), not the executing account (b.near)"
+            );
+
+            assert_eq!(
+                env::current_global_contract_id(),
+                Some(GlobalContractId::AccountId(provider)),
+                "current_global_contract_id() must map to the referenced provider account"
+            );
+        }
+
+        #[test]
         fn test_deterministic_update() {
             let context = VMContextBuilder::new().build();
 


### PR DESCRIPTION
closes #1600
