### PR TITLE
feat: support #[near(crate = "...")] for re-exported/renamed near-sdk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "near-global-contracts",
     "near-crypto-hash",
     "near-digest",
+    "crate-rename-tests",
 ]
 exclude = ["examples/"]
 

--- a/crate-rename-tests/Cargo.toml
+++ b/crate-rename-tests/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "near-sdk-crate-rename-test"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+# Renamed so that this crate never depends on a crate literally named `near_sdk` -- exercises
+# `#[near(crate = "...")]` (near/near-sdk-rs#1059) under the exact conditions that break today:
+# a re-exported, renamed `near-sdk` dependency.
+renamed_near_sdk = { package = "near-sdk", path = "../near-sdk" }
+
+[dev-dependencies]
+renamed_near_sdk = { package = "near-sdk", path = "../near-sdk", features = ["unit-testing"] }

--- a/crate-rename-tests/src/lib.rs
+++ b/crate-rename-tests/src/lib.rs
@@ -40,6 +40,15 @@ impl Counter {
     }
 }
 
+// NEP-297 events go through a separate `near_events`/`EventMetadata` codegen path (not
+// `near_bindgen`), which needed its own fix to accept `crate = "..."` -- see
+// near-sdk-rs#1059 review discussion. Covered here so a regression doesn't slip back in.
+#[vendor::near_sdk::near(event_json(standard = "nep297"), crate = "crate::vendor::near_sdk")]
+pub enum Nep297Event {
+    #[event_version("1.0.0")]
+    Incremented { value: u64 },
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -50,5 +59,17 @@ mod tests {
         assert_eq!(counter.increment(), 1);
         assert_eq!(counter.increment(), 2);
         assert_eq!(counter.get(), 2);
+    }
+
+    #[test]
+    fn nep297_event_emits_without_a_direct_near_sdk_dependency() {
+        let event = Nep297Event::Incremented { value: 1 };
+        event.emit();
+
+        let logs = vendor::near_sdk::test_utils::get_logs();
+        assert_eq!(logs.len(), 1);
+        assert!(logs[0].starts_with("EVENT_JSON:"));
+        assert!(logs[0].contains(r#""standard":"nep297""#));
+        assert!(logs[0].contains(r#""version":"1.0.0""#));
     }
 }

--- a/crate-rename-tests/src/lib.rs
+++ b/crate-rename-tests/src/lib.rs
@@ -1,0 +1,54 @@
+//! Compile-level regression test for `#[near(crate = "...")]` (near/near-sdk-rs#1059).
+//!
+//! Simulates a downstream wrapper crate (like `defuse_wallet` in `near/intents`, which wraps
+//! `#[near]` in its own `wallet!` macro) that re-exports `near-sdk` under a renamed dependency
+//! and a nested module path, so that consumers of the wrapper never need `near-sdk` as a direct
+//! dependency with a matching version.
+//!
+//! `near-sdk` is renamed to `renamed_near_sdk` in `Cargo.toml`, and re-exported one module level
+//! deep below that -- both details a naive implementation could get away with hardcoding around.
+
+pub mod vendor {
+    pub use renamed_near_sdk as near_sdk;
+}
+
+// `#[near]` derives `BorshSerialize`/`BorshDeserialize` itself (via the resolved `crate = "..."`
+// path below), so only `Debug`/`PanicOnDefault` need to be added here. `PanicOnDefault` also
+// takes its own `crate` argument (via the `#[panic_on_default(...)]` helper attribute), which
+// gets exercised here too.
+#[vendor::near_sdk::near(contract_state, crate = "crate::vendor::near_sdk")]
+#[derive(Debug, vendor::near_sdk::PanicOnDefault)]
+#[panic_on_default(crate = "crate::vendor::near_sdk")]
+pub struct Counter {
+    value: u64,
+}
+
+#[vendor::near_sdk::near(crate = "crate::vendor::near_sdk")]
+impl Counter {
+    #[init]
+    pub fn new() -> Self {
+        Self { value: 0 }
+    }
+
+    pub fn increment(&mut self) -> u64 {
+        self.value += 1;
+        self.value
+    }
+
+    pub fn get(&self) -> u64 {
+        self.value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn works_without_a_direct_near_sdk_dependency() {
+        let mut counter = Counter::new();
+        assert_eq!(counter.increment(), 1);
+        assert_eq!(counter.increment(), 2);
+        assert_eq!(counter.get(), 2);
+    }
+}

--- a/near-sdk-macros/src/core_impl/abi/abi_embed.rs
+++ b/near-sdk-macros/src/core_impl/abi/abi_embed.rs
@@ -1,14 +1,14 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 
-pub fn embed() -> TokenStream2 {
+pub fn embed(near_sdk_crate: &syn::Path) -> TokenStream2 {
     let abi_path = env!("CARGO_NEAR_ABI_PATH");
     quote! {
         const _: () = {
             const __CONTRACT_ABI: &'static [u8] = ::std::include_bytes!(#abi_path);
             #[unsafe(no_mangle)]
             pub extern "C" fn __contract_abi() {
-                ::near_sdk::env::value_return(__CONTRACT_ABI);
+                #near_sdk_crate::env::value_return(__CONTRACT_ABI);
             }
         };
     }

--- a/near-sdk-macros/src/core_impl/abi/abi_generator.rs
+++ b/near-sdk-macros/src/core_impl/abi/abi_generator.rs
@@ -13,6 +13,7 @@ pub fn generate(i: &ItemImplInfo) -> TokenStream2 {
         return TokenStream2::new();
     }
 
+    let krate = &i.krate;
     let functions: Vec<TokenStream2> = i.methods.iter().map(|m| m.abi_struct()).collect();
     let first_function_name = &i.methods[0].attr_signature_info.ident;
     let near_abi_symbol = format_ident!("__near_abi_{}", first_function_name);
@@ -23,10 +24,10 @@ pub fn generate(i: &ItemImplInfo) -> TokenStream2 {
             pub extern "C" fn #near_abi_symbol() -> (*const u8, usize) {
                 use ::std::string::String;
 
-                let mut schema_generator = ::near_sdk::schemars::r#gen::SchemaGenerator::default();
+                let mut schema_generator = #krate::schemars::r#gen::SchemaGenerator::default();
                 let functions = vec![#(#functions),*];
                 let mut data = ::std::mem::ManuallyDrop::new(
-                    ::near_sdk::serde_json::to_vec(&::near_sdk::__private::ChunkedAbiEntry::new(
+                    #krate::serde_json::to_vec(&#krate::__private::ChunkedAbiEntry::new(
                         functions,
                         schema_generator.into_root_schema_for::<String>(),
                     ))
@@ -79,6 +80,7 @@ impl ImplItemMethodInfo {
     /// If args are serialized with Borsh it will not include `#[derive(::near_sdk::borsh::BorshSchema)]`.
     pub fn abi_struct(&self) -> TokenStream2 {
         let attr_signature_info = &self.attr_signature_info;
+        let krate = &attr_signature_info.krate;
 
         let function_name_str = attr_signature_info.ident.to_string();
         let function_doc = match parse_rustdoc(&attr_signature_info.non_bindgen_attrs) {
@@ -87,20 +89,20 @@ impl ImplItemMethodInfo {
         };
         let mut modifiers = vec![];
         let kind = match &attr_signature_info.method_kind {
-            MethodKind::View(_) => quote! { ::near_sdk::__private::AbiFunctionKind::View },
+            MethodKind::View(_) => quote! { #krate::__private::AbiFunctionKind::View },
             MethodKind::Call(_) => {
-                quote! { ::near_sdk::__private::AbiFunctionKind::Call }
+                quote! { #krate::__private::AbiFunctionKind::Call }
             }
             MethodKind::Init(_) => {
-                modifiers.push(quote! { ::near_sdk::__private::AbiFunctionModifier::Init });
-                quote! { ::near_sdk::__private::AbiFunctionKind::Call }
+                modifiers.push(quote! { #krate::__private::AbiFunctionModifier::Init });
+                quote! { #krate::__private::AbiFunctionKind::Call }
             }
         };
         if attr_signature_info.is_payable() {
-            modifiers.push(quote! { ::near_sdk::__private::AbiFunctionModifier::Payable });
+            modifiers.push(quote! { #krate::__private::AbiFunctionModifier::Payable });
         }
         if attr_signature_info.is_private() {
-            modifiers.push(quote! { ::near_sdk::__private::AbiFunctionModifier::Private });
+            modifiers.push(quote! { #krate::__private::AbiFunctionModifier::Private });
         }
         let modifiers = quote! {
             ::std::vec![#(#modifiers),*]
@@ -114,16 +116,16 @@ impl ImplItemMethodInfo {
             let arg_name = arg.ident.to_string();
             match arg.bindgen_ty {
                 BindgenArgType::Regular => {
-                    let schema = generate_schema(typ, &arg.serializer_ty);
+                    let schema = generate_schema(typ, &arg.serializer_ty, krate);
                     match arg.serializer_ty {
                         SerializerType::JSON => params.push(quote! {
-                            ::near_sdk::__private::AbiJsonParameter {
+                            #krate::__private::AbiJsonParameter {
                                 name: ::std::string::String::from(#arg_name),
                                 type_schema: #schema,
                             }
                         }),
                         SerializerType::Borsh => params.push(quote! {
-                            ::near_sdk::__private::AbiBorshParameter {
+                            #krate::__private::AbiBorshParameter {
                                 name: ::std::string::String::from(#arg_name),
                                 type_schema: #schema,
                             }
@@ -131,7 +133,7 @@ impl ImplItemMethodInfo {
                     };
                 }
                 BindgenArgType::Callback { ty: CallbackBindgenArgType::Arg, .. } => {
-                    callbacks.push(generate_abi_type(typ, &arg.serializer_ty));
+                    callbacks.push(generate_abi_type(typ, &arg.serializer_ty, krate));
                 }
                 BindgenArgType::Callback { ty: CallbackBindgenArgType::ResultArg, .. } => {
                     let typ = if let Some(ok_type) = utils::extract_ok_type(typ) {
@@ -144,7 +146,7 @@ impl ImplItemMethodInfo {
                         )
                         .into_compile_error();
                     };
-                    callbacks.push(generate_abi_type(typ, &arg.serializer_ty));
+                    callbacks.push(generate_abi_type(typ, &arg.serializer_ty, krate));
                 }
                 BindgenArgType::Callback { ty: CallbackBindgenArgType::ArgVec, .. } => {
                     if callback_vec.is_none() {
@@ -171,12 +173,12 @@ impl ImplItemMethodInfo {
         }
         let params = match attr_signature_info.input_serializer {
             SerializerType::JSON => quote! {
-                ::near_sdk::__private::AbiParameters::Json {
+                #krate::__private::AbiParameters::Json {
                     args: ::std::vec![#(#params),*]
                 }
             },
             SerializerType::Borsh => quote! {
-                ::near_sdk::__private::AbiParameters::Borsh {
+                #krate::__private::AbiParameters::Borsh {
                     args: ::std::vec![#(#params),*]
                 }
             },
@@ -186,7 +188,7 @@ impl ImplItemMethodInfo {
         let result = self.abi_result_tokens();
 
         quote! {
-             ::near_sdk::__private::AbiFunction {
+             #krate::__private::AbiFunction {
                  name: ::std::string::String::from(#function_name_str),
                  doc: #function_doc,
                  kind: #kind,
@@ -202,12 +204,13 @@ impl ImplItemMethodInfo {
     fn abi_result_tokens(&self) -> TokenStream2 {
         use ReturnKind::*;
 
+        let krate = &self.attr_signature_info.krate;
         match &self.attr_signature_info.returns.kind {
             Default => quote! { ::std::option::Option::None },
             General(ty) => self.abi_result_tokens_with_return_value(ty),
             HandlesResult(ty) => {
                 // extract the `Ok` type from the result
-                let ty = parse_quote! { <#ty as near_sdk::__private::ResultTypeExt>::Okay };
+                let ty = parse_quote! { <#ty as #krate::__private::ResultTypeExt>::Okay };
                 self.abi_result_tokens_with_return_value(&ty)
             }
         }
@@ -216,8 +219,9 @@ impl ImplItemMethodInfo {
     fn abi_result_tokens_with_return_value(&self, return_value_type: &Type) -> TokenStream2 {
         use MethodKind::*;
 
+        let krate = &self.attr_signature_info.krate;
         let some_abi_type = |result_serializer: &SerializerType| {
-            let abi_type = generate_abi_type(return_value_type, result_serializer);
+            let abi_type = generate_abi_type(return_value_type, result_serializer, krate);
             quote! { ::std::option::Option::Some(#abi_type) }
         };
 
@@ -230,8 +234,9 @@ impl ImplItemMethodInfo {
     }
 
     fn abi_callback_vec_tokens(&self, callback_vec_type: &Type) -> TokenStream2 {
+        let krate = &self.attr_signature_info.krate;
         let abi_type = |result_serializer: &SerializerType| {
-            let tokens = generate_abi_type(callback_vec_type, result_serializer);
+            let tokens = generate_abi_type(callback_vec_type, result_serializer, krate);
             quote! {
                 ::std::option::Option::Some(#tokens)
             }
@@ -245,27 +250,31 @@ impl ImplItemMethodInfo {
     }
 }
 
-fn generate_schema(ty: &Type, serializer_type: &SerializerType) -> TokenStream2 {
+fn generate_schema(ty: &Type, serializer_type: &SerializerType, krate: &syn::Path) -> TokenStream2 {
     match serializer_type {
         SerializerType::JSON => quote! {
             schema_generator.subschema_for::<#ty>()
         },
         SerializerType::Borsh => quote! {
-            ::near_sdk::borsh::schema_container_of::<#ty>()
+            #krate::borsh::schema_container_of::<#ty>()
         },
     }
 }
 
-fn generate_abi_type(ty: &Type, serializer_type: &SerializerType) -> TokenStream2 {
-    let schema = generate_schema(ty, serializer_type);
+fn generate_abi_type(
+    ty: &Type,
+    serializer_type: &SerializerType,
+    krate: &syn::Path,
+) -> TokenStream2 {
+    let schema = generate_schema(ty, serializer_type, krate);
     match serializer_type {
         SerializerType::JSON => quote! {
-            ::near_sdk::__private::AbiType::Json {
+            #krate::__private::AbiType::Json {
                 type_schema: #schema,
             }
         },
         SerializerType::Borsh => quote! {
-            ::near_sdk::__private::AbiType::Borsh {
+            #krate::__private::AbiType::Borsh {
                 type_schema: #schema,
             }
         },

--- a/near-sdk-macros/src/core_impl/abi/snapshots/generate_abi_fallible_borsh.snap
+++ b/near-sdk-macros/src/core_impl/abi/snapshots/generate_abi_fallible_borsh.snap
@@ -18,8 +18,7 @@ expression: pretty_print_fn_body_syn_str(actual)
         callbacks_vec: ::std::option::Option::None,
         result: ::std::option::Option::Some(::near_sdk::__private::AbiType::Borsh {
             type_schema: ::near_sdk::borsh::schema_container_of::<
-                <Result<IsOk, Error> as near_sdk::__private::ResultTypeExt>::Okay,
+                <Result<IsOk, Error> as ::near_sdk::__private::ResultTypeExt>::Okay,
             >(),
         }),
     }
-

--- a/near-sdk-macros/src/core_impl/abi/snapshots/generate_abi_fallible_json.snap
+++ b/near-sdk-macros/src/core_impl/abi/snapshots/generate_abi_fallible_json.snap
@@ -24,7 +24,7 @@ expression: pretty_print_fn_body_syn_str(actual)
         result: ::std::option::Option::Some(::near_sdk::__private::AbiType::Json {
             type_schema: schema_generator
                 .subschema_for::<
-                    <Result<IsOk, Error> as near_sdk::__private::ResultTypeExt>::Okay,
+                    <Result<IsOk, Error> as ::near_sdk::__private::ResultTypeExt>::Okay,
                 >(),
         }),
     }

--- a/near-sdk-macros/src/core_impl/code_generator/attr_sig_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/attr_sig_info.rs
@@ -53,14 +53,17 @@ impl AttrSigInfo {
             !args.is_empty(),
             "Can only generate input struct for when input args are specified"
         );
+        let krate = &self.krate;
+        let serde_crate = format!("{}::serde", utils::crate_path_string(krate));
+        let borsh_crate = format!("{}::borsh", utils::crate_path_string(krate));
         let attribute = match &self.input_serializer {
             SerializerType::JSON => quote! {
-                #[derive(::near_sdk::serde::Serialize)]
-                #[serde(crate = "::near_sdk::serde")]
+                #[derive(#krate::serde::Serialize)]
+                #[serde(crate = #serde_crate)]
             },
             SerializerType::Borsh => quote! {
-                #[derive(::near_sdk::borsh::BorshSerialize)]
-                #[borsh(crate = "::near_sdk::borsh")]
+                #[derive(#krate::borsh::BorshSerialize)]
+                #[borsh(crate = #borsh_crate)]
             },
         };
         let mut fields = TokenStream2::new();
@@ -100,6 +103,9 @@ impl AttrSigInfo {
             !args.is_empty(),
             "Can only generate input struct for when input args are specified"
         );
+        let krate = &self.krate;
+        let serde_crate = format!("{}::serde", utils::crate_path_string(krate));
+        let borsh_crate = format!("{}::borsh", utils::crate_path_string(krate));
         let attribute = match &self.input_serializer {
             SerializerType::JSON => {
                 let deny_fields_attr = if self.deny_unknown_arguments() {
@@ -108,13 +114,13 @@ impl AttrSigInfo {
                     quote! {}
                 };
                 quote! {
-                    #[derive(::near_sdk::serde::Deserialize)]
-                    #[serde(crate = "::near_sdk::serde", #deny_fields_attr)]
+                    #[derive(#krate::serde::Deserialize)]
+                    #[serde(crate = #serde_crate, #deny_fields_attr)]
                 }
             }
             SerializerType::Borsh => quote! {
-                #[derive(::near_sdk::borsh::BorshDeserialize)]
-                #[borsh(crate = "::near_sdk::borsh")]
+                #[derive(#krate::borsh::BorshDeserialize)]
+                #[borsh(crate = #borsh_crate)]
             },
         };
         let mut fields = TokenStream2::new();
@@ -227,6 +233,7 @@ impl AttrSigInfo {
 
     /// Create code that deserializes arguments that were decorated with `#[callback*]`
     pub fn callback_deserialization(&self) -> TokenStream2 {
+        let krate = &self.krate;
         self.args
             .iter()
             .filter(|arg| {
@@ -245,12 +252,12 @@ impl AttrSigInfo {
                 match &bindgen_ty {
                     BindgenArgType::Callback { ty: CallbackBindgenArgType::Arg, max_bytes } => {
                         let error_msg = format!("Callback computation {idx} was not successful");
-                        let invocation = deserialize_data(serializer_ty);
+                        let invocation = deserialize_data(serializer_ty, krate);
                         quote! {
                             #acc
                             let #mutability #ident: #ty = {
-                                let data = ::near_sdk::env::promise_result_checked(#idx, #max_bytes)
-                                    .unwrap_or_else(|_| ::near_sdk::env::panic_str(#error_msg));
+                                let data = #krate::env::promise_result_checked(#idx, #max_bytes)
+                                    .unwrap_or_else(|_| #krate::env::panic_str(#error_msg));
                                 #invocation
                             };
                         }
@@ -269,7 +276,7 @@ impl AttrSigInfo {
                             )
                             .into_compile_error();
                         };
-                        let deserialize = deserialize_data(serializer_ty);
+                        let deserialize = deserialize_data(serializer_ty, krate);
                         let deserialization_tweak = match ok_type {
                             // The unit type in this context is a bit special because functions
                             // without an explicit return type do not serialize their response.
@@ -291,7 +298,7 @@ impl AttrSigInfo {
                             _ => None,
                         };
                         let result = quote! {
-                            ::near_sdk::env::promise_result_checked(#idx, #max_bytes)
+                            #krate::env::promise_result_checked(#idx, #max_bytes)
                                 .map(|data| {
                                     #deserialization_tweak
                                     #deserialize
@@ -309,6 +316,7 @@ impl AttrSigInfo {
 
     /// Create code that deserializes arguments that were decorated with `#[callback_vec]`.
     pub fn callback_vec_deserialization(&self) -> TokenStream2 {
+        let krate = &self.krate;
         self
             .args
             .iter()
@@ -320,14 +328,14 @@ impl AttrSigInfo {
             })
             .fold(TokenStream2::new(), |acc, (arg, max_bytes)| {
                 let ArgInfo { mutability, ident, ty, .. } = arg;
-                let invocation = deserialize_data(&arg.serializer_ty);
+                let invocation = deserialize_data(&arg.serializer_ty, krate);
                 quote! {
                     #acc
                     let #mutability #ident: #ty = ::std::iter::Iterator::collect(::std::iter::Iterator::map(
-                        0..::near_sdk::env::promise_results_count(),
+                        0..#krate::env::promise_results_count(),
                         |i| {
-                            let data = ::near_sdk::env::promise_result_checked(i, #max_bytes)
-                                .unwrap_or_else(|_| ::near_sdk::env::panic_str(&::std::format!("Callback computation {} was not successful", i)));
+                            let data = #krate::env::promise_result_checked(i, #max_bytes)
+                                .unwrap_or_else(|_| #krate::env::panic_str(&::std::format!("Callback computation {} was not successful", i)));
                             #invocation
                         }));
                 }
@@ -335,15 +343,15 @@ impl AttrSigInfo {
     }
 }
 
-fn deserialize_data(ty: &SerializerType) -> TokenStream2 {
+fn deserialize_data(ty: &SerializerType, krate: &syn::Path) -> TokenStream2 {
     match ty {
         SerializerType::JSON => quote! {
-            ::near_sdk::serde_json::from_slice(&data)
-                .unwrap_or_else(|e| ::near_sdk::env::panic_str(&format!("Failed to deserialize callback using JSON. Error: `{e}`")))
+            #krate::serde_json::from_slice(&data)
+                .unwrap_or_else(|e| #krate::env::panic_str(&format!("Failed to deserialize callback using JSON. Error: `{e}`")))
         },
         SerializerType::Borsh => quote! {
-            ::near_sdk::borsh::BorshDeserialize::try_from_slice(&data)
-                .unwrap_or_else(|e| ::near_sdk::env::panic_str(&format!("Failed to deserialize callback using Borsh. Error: `{e}`")))
+            #krate::borsh::BorshDeserialize::try_from_slice(&data)
+                .unwrap_or_else(|e| #krate::env::panic_str(&format!("Failed to deserialize callback using Borsh. Error: `{e}`")))
         },
     }
 }

--- a/near-sdk-macros/src/core_impl/code_generator/ext.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/ext.rs
@@ -39,7 +39,7 @@ pub(crate) fn generate_ext_structs(
         quote! {
             /// Convenience method for creating a cross-contract call to the current contract.
             ///
-            /// Equivalent to `Self::ext(near_sdk::env::current_account_id())`.
+            /// Equivalent to `Self::ext(env::current_account_id())`.
             pub fn ext_self() -> #name {
                 #name {
                     promise_or_create_on: #near_sdk_crate::PromiseOrValue::Value(

--- a/near-sdk-macros/src/core_impl/code_generator/ext.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/ext.rs
@@ -5,29 +5,31 @@ use syn::{Attribute, Generics, Path, Signature, parse_quote};
 
 /// Generates inner ext code for structs and modules. If intended for a struct, generic details
 /// for the struct should be passed in through `generic_details` and the `ext` method will be
-/// added as an impl to the struct ident.
+/// added as an impl to the struct ident. `near_sdk_crate` is the path to the `near-sdk` crate to
+/// use in the generated code (defaults to `::near_sdk`).
 pub(crate) fn generate_ext_structs(
     ident: &Ident,
     generic_details: Option<&Generics>,
+    near_sdk_crate: &syn::Path,
 ) -> proc_macro2::TokenStream {
     let name = format_ident!("{}Ext", ident);
     let mut ext_code = quote! {
         /// API for calling this contract's functions in a subsequent execution.
-        pub fn ext(account_id: ::near_sdk::AccountId) -> #name {
+        pub fn ext(account_id: #near_sdk_crate::AccountId) -> #name {
             #name {
-                promise_or_create_on: ::near_sdk::PromiseOrValue::Value(account_id),
-                deposit: ::near_sdk::NearToken::from_near(0),
-                static_gas: ::near_sdk::Gas::from_gas(0),
-                gas_weight: ::near_sdk::GasWeight::default(),
+                promise_or_create_on: #near_sdk_crate::PromiseOrValue::Value(account_id),
+                deposit: #near_sdk_crate::NearToken::from_near(0),
+                static_gas: #near_sdk_crate::Gas::from_gas(0),
+                gas_weight: #near_sdk_crate::GasWeight::default(),
             }
         }
 
-        pub fn ext_on(promise: ::near_sdk::Promise) -> #name {
+        pub fn ext_on(promise: #near_sdk_crate::Promise) -> #name {
             #name {
-                promise_or_create_on: ::near_sdk::PromiseOrValue::Promise(promise),
-                deposit: ::near_sdk::NearToken::from_near(0),
-                static_gas: ::near_sdk::Gas::from_gas(0),
-                gas_weight: ::near_sdk::GasWeight::default(),
+                promise_or_create_on: #near_sdk_crate::PromiseOrValue::Promise(promise),
+                deposit: #near_sdk_crate::NearToken::from_near(0),
+                static_gas: #near_sdk_crate::Gas::from_gas(0),
+                gas_weight: #near_sdk_crate::GasWeight::default(),
             }
         }
     };
@@ -40,12 +42,12 @@ pub(crate) fn generate_ext_structs(
             /// Equivalent to `Self::ext(near_sdk::env::current_account_id())`.
             pub fn ext_self() -> #name {
                 #name {
-                    promise_or_create_on: ::near_sdk::PromiseOrValue::Value(
-                        ::near_sdk::env::current_account_id(),
+                    promise_or_create_on: #near_sdk_crate::PromiseOrValue::Value(
+                        #near_sdk_crate::env::current_account_id(),
                     ),
-                    deposit: ::near_sdk::NearToken::from_near(0),
-                    static_gas: ::near_sdk::Gas::from_gas(0),
-                    gas_weight: ::near_sdk::GasWeight::default(),
+                    deposit: #near_sdk_crate::NearToken::from_near(0),
+                    static_gas: #near_sdk_crate::Gas::from_gas(0),
+                    gas_weight: #near_sdk_crate::GasWeight::default(),
                 }
             }
         }
@@ -65,23 +67,23 @@ pub(crate) fn generate_ext_structs(
     quote! {
       #[must_use]
       pub struct #name {
-          pub(crate) promise_or_create_on: ::near_sdk::PromiseOrValue<::near_sdk::AccountId>,
-          pub(crate) deposit: ::near_sdk::NearToken,
-          pub(crate) static_gas: ::near_sdk::Gas,
-          pub(crate) gas_weight: ::near_sdk::GasWeight,
+          pub(crate) promise_or_create_on: #near_sdk_crate::PromiseOrValue<#near_sdk_crate::AccountId>,
+          pub(crate) deposit: #near_sdk_crate::NearToken,
+          pub(crate) static_gas: #near_sdk_crate::Gas,
+          pub(crate) gas_weight: #near_sdk_crate::GasWeight,
       }
 
       impl #name {
-          pub fn with_attached_deposit(mut self, amount: ::near_sdk::NearToken) -> Self {
+          pub fn with_attached_deposit(mut self, amount: #near_sdk_crate::NearToken) -> Self {
               self.deposit = amount;
               self
           }
-          pub fn with_static_gas(mut self, static_gas: ::near_sdk::Gas) -> Self {
+          pub fn with_static_gas(mut self, static_gas: #near_sdk_crate::Gas) -> Self {
               self.static_gas = static_gas;
               self
           }
           pub fn with_unused_gas_weight(mut self, gas_weight: u64) -> Self {
-              self.gas_weight = ::near_sdk::GasWeight(gas_weight);
+              self.gas_weight = #near_sdk_crate::GasWeight(gas_weight);
               self
           }
       }
@@ -153,6 +155,7 @@ pub(crate) fn generate_ext_function_wrappers<'a>(
 }
 
 fn generate_ext_function(attr_signature_info: &AttrSigInfo) -> TokenStream2 {
+    let krate = &attr_signature_info.krate;
     let pat_type_list = attr_signature_info.pat_type_list();
     let serialize =
         serializer::generate_serializer(attr_signature_info, &attr_signature_info.input_serializer);
@@ -168,12 +171,12 @@ fn generate_ext_function(attr_signature_info: &AttrSigInfo) -> TokenStream2 {
     let Signature { generics, .. } = original_sig;
     quote! {
         #new_non_bindgen_attrs
-        pub fn #ident #generics(self, #pat_type_list) -> ::near_sdk::Promise {
+        pub fn #ident #generics(self, #pat_type_list) -> #krate::Promise {
             let __args = #serialize;
             match self.promise_or_create_on {
-                ::near_sdk::PromiseOrValue::Promise(p) => p,
-                ::near_sdk::PromiseOrValue::Value(account_id) => {
-                    ::near_sdk::Promise::new(account_id)
+                #krate::PromiseOrValue::Promise(p) => p,
+                #krate::PromiseOrValue::Value(account_id) => {
+                    #krate::Promise::new(account_id)
                 }
             }
                 .function_call_weight(
@@ -199,15 +202,27 @@ mod tests {
     #[test]
     fn ext_gen() {
         let st: ItemStruct = parse_quote! { struct Test { a: u8 } };
-        let actual = generate_ext_structs(&st.ident, Some(&st.generics));
-       
+        let actual = generate_ext_structs(&st.ident, Some(&st.generics), &parse_quote!(::near_sdk));
+
+        local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
+    }
+
+    #[test]
+    fn ext_gen_custom_crate() {
+        let st: ItemStruct = parse_quote! { struct Test { a: u8 } };
+        let actual = generate_ext_structs(
+            &st.ident,
+            Some(&st.generics),
+            &parse_quote!(::renamed_sdk::near_sdk),
+        );
+
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
 
     #[test]
     fn module_ext_gen() {
         let ident: Ident = parse_quote! { Test };
-        let actual = generate_ext_structs(&ident, None);
+        let actual = generate_ext_structs(&ident, None, &parse_quote!(::near_sdk));
     
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
@@ -238,7 +253,22 @@ mod tests {
         };
         let method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
         let actual = generate_ext_function(&method_info.attr_signature_info);
-     
+
+        local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
+    }
+
+    /// Exercises `#[near(crate = "...")]`-style overrides: the `_Ext` wrapper should
+    /// reference the custom crate path instead of the hardcoded `::near_sdk`.
+    #[test]
+    fn ext_basic_json_custom_crate() {
+        let impl_type: Type = parse_quote! { Hello };
+        let mut method: ImplItemFn = parse_quote! {
+            pub fn method(&self, k: &String) { }
+        };
+        let mut method_info = ImplItemMethodInfo::new(&mut method, None, impl_type).unwrap().unwrap();
+        method_info.attr_signature_info.krate = parse_quote!(::renamed_sdk::near_sdk);
+        let actual = generate_ext_function(&method_info.attr_signature_info);
+
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
 

--- a/near-sdk-macros/src/core_impl/code_generator/impl_item_method_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/impl_item_method_info.rs
@@ -78,6 +78,7 @@ impl ImplItemMethodInfo {
     }
 
     fn result_return_body_tokens(&self) -> TokenStream2 {
+        let krate = &self.attr_signature_info.krate;
         let contract_init = self.contract_init_tokens();
         let method_invocation_with_return = self.method_invocation_with_return_tokens();
         let contract_ser = self.contract_ser_tokens();
@@ -94,14 +95,15 @@ impl ImplItemMethodInfo {
                     #value_return
                     #contract_ser
                 }
-                ::std::result::Result::Err(err) => ::near_sdk::FunctionError::panic(&err)
+                ::std::result::Result::Err(err) => #krate::FunctionError::panic(&err)
             }
         }
     }
 
     fn panic_hook_tokens(&self) -> TokenStream2 {
+        let krate = &self.attr_signature_info.krate;
         quote! {
-            ::near_sdk::env::setup_panic_hook();
+            #krate::env::setup_panic_hook();
         }
     }
 
@@ -115,28 +117,29 @@ impl ImplItemMethodInfo {
 
     fn arg_parsing_tokens(&self) -> TokenStream2 {
         if self.attr_signature_info.has_input_args() {
+            let krate = &self.attr_signature_info.krate;
             let decomposition = self.attr_signature_info.decomposition_pattern();
             let serializer_invocation = match self.attr_signature_info.input_serializer {
                 SerializerType::JSON => quote! {
-                    match ::near_sdk::env::input() {
-                        Some(input) => match ::near_sdk::serde_json::from_slice(&input) {
+                    match #krate::env::input() {
+                        Some(input) => match #krate::serde_json::from_slice(&input) {
                             Ok(deserialized) => deserialized,
                             Err(e) => {
-                                ::near_sdk::env::panic_str(&format!("Failed to deserialize input from JSON. Error: `{e}`"));
+                                #krate::env::panic_str(&format!("Failed to deserialize input from JSON. Error: `{e}`"));
                             }
                         },
-                        None => ::near_sdk::env::panic_str("Expected input since method has arguments.")
+                        None => #krate::env::panic_str("Expected input since method has arguments.")
                     };
                 },
                 SerializerType::Borsh => quote! {
-                    match ::near_sdk::env::input() {
-                        Some(input) => match ::near_sdk::borsh::BorshDeserialize::try_from_slice(&input) {
+                    match #krate::env::input() {
+                        Some(input) => match #krate::borsh::BorshDeserialize::try_from_slice(&input) {
                             Ok(deserialized) => deserialized,
                             Err(e) => {
-                                ::near_sdk::env::panic_str(&format!("Failed to deserialize input from Borsh. Error: `{e}`"));
+                                #krate::env::panic_str(&format!("Failed to deserialize input from Borsh. Error: `{e}`"));
                             }
                         },
-                        None => ::near_sdk::env::panic_str("Expected input since method has arguments.")
+                        None => #krate::env::panic_str("Expected input since method has arguments.")
                     };
                 },
             };
@@ -151,12 +154,13 @@ impl ImplItemMethodInfo {
     fn deposit_check_tokens(&self) -> TokenStream2 {
         use MethodKind::*;
 
+        let krate = &self.attr_signature_info.krate;
         let reject_deposit_code = || {
             // If method is not payable, do a check to make sure that it doesn't consume deposit
             let error = format!("Method {} doesn't accept deposit", self.attr_signature_info.ident);
             quote! {
-                if ::near_sdk::env::attached_deposit().as_yoctonear() != 0 {
-                    ::near_sdk::env::panic_str(#error);
+                if #krate::env::attached_deposit().as_yoctonear() != 0 {
+                    #krate::env::panic_str(#error);
                 }
             }
         };
@@ -184,10 +188,11 @@ impl ImplItemMethodInfo {
 
     fn private_check_tokens(&self) -> TokenStream2 {
         if self.attr_signature_info.is_private() {
+            let krate = &self.attr_signature_info.krate;
             let error = format!("Method {} is private", self.attr_signature_info.ident);
             quote! {
-                if ::near_sdk::env::current_account_id() != ::near_sdk::env::predecessor_account_id() {
-                    ::near_sdk::env::panic_str(#error);
+                if #krate::env::current_account_id() != #krate::env::predecessor_account_id() {
+                    #krate::env::panic_str(#error);
                 }
             }
         } else {
@@ -198,6 +203,7 @@ impl ImplItemMethodInfo {
     fn state_check_tokens(&self) -> TokenStream2 {
         use MethodKind::*;
 
+        let krate = &self.attr_signature_info.krate;
         // The purpose of the state check is to prevent the contract from being initialized twice,
         // so it's not applicable to Call and View methods.
         match &self.attr_signature_info.method_kind {
@@ -207,8 +213,8 @@ impl ImplItemMethodInfo {
                 if !init_method.ignores_state {
                     let struct_type = &self.struct_type;
                     quote! {
-                        if <#struct_type as ::near_sdk::state::ContractState>::state_exists() {
-                            ::near_sdk::env::panic_str("The contract has already been initialized");
+                        if <#struct_type as #krate::state::ContractState>::state_exists() {
+                            #krate::env::panic_str("The contract has already been initialized");
                         }
                     }
                 } else {
@@ -223,6 +229,7 @@ impl ImplItemMethodInfo {
     fn contract_init_tokens(&self) -> TokenStream2 {
         use MethodKind::*;
 
+        let krate = &self.attr_signature_info.krate;
         let struct_type = &self.struct_type;
         let ident = &self.attr_signature_info.ident;
         let arg_list = self.attr_signature_info.arg_list();
@@ -231,7 +238,7 @@ impl ImplItemMethodInfo {
             let mutability = receiver.mutability;
 
             quote! {
-                let #mutability contract = <#struct_type as ::near_sdk::state::ContractState>::state_read().unwrap_or_default();
+                let #mutability contract = <#struct_type as #krate::state::ContractState>::state_read().unwrap_or_default();
             }
         };
 
@@ -263,10 +270,11 @@ impl ImplItemMethodInfo {
     fn contract_ser_tokens(&self) -> TokenStream2 {
         use MethodKind::*;
 
+        let krate = &self.attr_signature_info.krate;
         let contract_ser = || {
             let struct_type = &self.struct_type;
             quote! {
-                <#struct_type as ::near_sdk::state::ContractState>::state_write(&contract);
+                <#struct_type as #krate::state::ContractState>::state_write(&contract);
             }
         };
 
@@ -366,17 +374,18 @@ impl ImplItemMethodInfo {
     fn value_ser_tokens(&self) -> TokenStream2 {
         use MethodKind::*;
 
+        let krate = &self.attr_signature_info.krate;
         let value_ser = |result_serializer: &SerializerType| match result_serializer {
             SerializerType::JSON => quote! {
-                let result = match near_sdk::serde_json::to_vec(&result) {
+                let result = match #krate::serde_json::to_vec(&result) {
                     Ok(v) => v,
-                    Err(_) => ::near_sdk::env::panic_str("Failed to serialize the return value using JSON."),
+                    Err(_) => #krate::env::panic_str("Failed to serialize the return value using JSON."),
                 };
             },
             SerializerType::Borsh => quote! {
-                let result = match near_sdk::borsh::to_vec(&result) {
+                let result = match #krate::borsh::to_vec(&result) {
                     Ok(v) => v,
-                    Err(_) => ::near_sdk::env::panic_str("Failed to serialize the return value using Borsh."),
+                    Err(_) => #krate::env::panic_str("Failed to serialize the return value using Borsh."),
                 };
             },
         };
@@ -395,9 +404,10 @@ impl ImplItemMethodInfo {
     fn value_return_tokens(&self) -> TokenStream2 {
         use MethodKind::*;
 
+        let krate = &self.attr_signature_info.krate;
         let value_return = || {
             quote! {
-                ::near_sdk::env::value_return(&result);
+                #krate::env::value_return(&result);
             }
         };
 

--- a/near-sdk-macros/src/core_impl/code_generator/item_trait_info.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/item_trait_info.rs
@@ -2,12 +2,17 @@ use crate::core_impl::ext::{generate_ext_function_wrappers, generate_ext_structs
 use crate::core_impl::info_extractor::ItemTraitInfo;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
+use syn::parse_quote;
 
 impl ItemTraitInfo {
     /// Generate code that wraps external calls.
+    ///
+    /// `ext_contract` doesn't support customizing the `near-sdk` crate path (out of scope for
+    /// now), so this always uses the default `::near_sdk`.
     pub fn wrap_trait_ext(&self) -> TokenStream2 {
         let mod_name = &self.mod_name;
-        let ext_structs = generate_ext_structs(&self.original.ident, None);
+        let ext_structs =
+            generate_ext_structs(&self.original.ident, None, &parse_quote!(::near_sdk));
 
         let ext_methods = generate_ext_function_wrappers(
             &self.original.ident,

--- a/near-sdk-macros/src/core_impl/code_generator/metadata.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/metadata.rs
@@ -6,11 +6,12 @@ use syn::Generics;
 pub(crate) fn generate_contract_metadata_method(
     ident: &Ident,
     generics: &Generics,
+    near_sdk_crate: &syn::Path,
 ) -> proc_macro2::TokenStream {
     quote! {
         impl #generics #ident #generics {
             pub fn contract_source_metadata() {
-                near_sdk::env::value_return(CONTRACT_SOURCE_METADATA.as_bytes())
+                #near_sdk_crate::env::value_return(CONTRACT_SOURCE_METADATA.as_bytes())
             }
         }
     }

--- a/near-sdk-macros/src/core_impl/code_generator/serializer.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/serializer.rs
@@ -6,6 +6,7 @@ pub fn generate_serializer(
     attr_sig_info: &AttrSigInfo,
     serializer: &SerializerType,
 ) -> TokenStream2 {
+    let krate = &attr_sig_info.krate;
     let has_input_args = attr_sig_info.input_args().next().is_some();
     if !has_input_args {
         return quote! { ::std::vec![] };
@@ -15,15 +16,15 @@ pub fn generate_serializer(
     let constructor = quote! { let __args = #constructor_call; };
     let value_ser = match serializer {
         SerializerType::JSON => quote! {
-            match near_sdk::serde_json::to_vec(&__args) {
+            match #krate::serde_json::to_vec(&__args) {
                 Ok(serialized) => serialized,
-                Err(_) => ::near_sdk::env::panic_str("Failed to serialize the cross contract args using JSON."),
+                Err(_) => #krate::env::panic_str("Failed to serialize the cross contract args using JSON."),
             }
         },
         SerializerType::Borsh => quote! {
-            match near_sdk::borsh::to_vec(&__args) {
+            match #krate::borsh::to_vec(&__args) {
                 Ok(serialized) => serialized,
-                Err(_) => ::near_sdk::env::panic_str("Failed to serialize the cross contract args using Borsh."),
+                Err(_) => #krate::env::panic_str("Failed to serialize the cross contract args using Borsh."),
             }
         },
     };

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/args_return_mut.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/args_return_mut.snap
@@ -31,7 +31,7 @@ pub extern "C" fn method() {
     let mut contract = <Hello as ::near_sdk::state::ContractState>::state_read()
         .unwrap_or_default();
     let result = Hello::method(&mut contract, k, m);
-    let result = match near_sdk::serde_json::to_vec(&result) {
+    let result = match ::near_sdk::serde_json::to_vec(&result) {
         Ok(v) => v,
         Err(_) => {
             ::near_sdk::env::panic_str(

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/args_return_mut_borsh.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/args_return_mut_borsh.snap
@@ -31,7 +31,7 @@ pub extern "C" fn method() {
     let mut contract = <Hello as ::near_sdk::state::ContractState>::state_read()
         .unwrap_or_default();
     let result = Hello::method(&mut contract, k, m);
-    let result = match near_sdk::borsh::to_vec(&result) {
+    let result = match ::near_sdk::borsh::to_vec(&result) {
         Ok(v) => v,
         Err(_) => {
             ::near_sdk::env::panic_str(

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/args_return_ref.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/args_return_ref.snap
@@ -9,7 +9,7 @@ pub extern "C" fn method() {
     let contract = <Hello as ::near_sdk::state::ContractState>::state_read()
         .unwrap_or_default();
     let result = Hello::method(&contract);
-    let result = match near_sdk::serde_json::to_vec(&result) {
+    let result = match ::near_sdk::serde_json::to_vec(&result) {
         Ok(v) => v,
         Err(_) => {
             ::near_sdk::env::panic_str(

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/deny_unknown_arguments_return_mut_method.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/deny_unknown_arguments_return_mut_method.snap
@@ -31,7 +31,7 @@ pub extern "C" fn method() {
     let mut contract = <Hello as ::near_sdk::state::ContractState>::state_read()
         .unwrap_or_default();
     let result = Hello::method(&mut contract, k, m);
-    let result = match near_sdk::serde_json::to_vec(&result) {
+    let result = match ::near_sdk::serde_json::to_vec(&result) {
         Ok(v) => v,
         Err(_) => {
             ::near_sdk::env::panic_str(

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_basic.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_basic.snap
@@ -1,6 +1,5 @@
 ---
 source: near-sdk-macros/src/core_impl/code_generator/item_trait_info.rs
-assertion_line: 56
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 pub mod external_cross_contract {
@@ -54,7 +53,7 @@ pub mod external_cross_contract {
                     arr: &'nearinput Vec<u8>,
                 }
                 let __args = Input { arr: &arr };
-                match near_sdk::serde_json::to_vec(&__args) {
+                match ::near_sdk::serde_json::to_vec(&__args) {
                     Ok(serialized) => serialized,
                     Err(_) => {
                         ::near_sdk::env::panic_str(

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_basic_borsh.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_basic_borsh.snap
@@ -1,6 +1,5 @@
 ---
 source: near-sdk-macros/src/core_impl/code_generator/ext.rs
-assertion_line: 221
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 pub fn borsh_test(self, a: String) -> ::near_sdk::Promise {
@@ -11,7 +10,7 @@ pub fn borsh_test(self, a: String) -> ::near_sdk::Promise {
             a: &'nearinput String,
         }
         let __args = Input { a: &a };
-        match near_sdk::borsh::to_vec(&__args) {
+        match ::near_sdk::borsh::to_vec(&__args) {
             Ok(serialized) => serialized,
             Err(_) => {
                 ::near_sdk::env::panic_str(

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_basic_json_custom_crate.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_basic_json_custom_crate.snap
@@ -2,27 +2,27 @@
 source: near-sdk-macros/src/core_impl/code_generator/ext.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
-pub fn method(self, k: &String) -> ::near_sdk::Promise {
+pub fn method(self, k: &String) -> ::renamed_sdk::near_sdk::Promise {
     let __args = {
-        #[derive(::near_sdk::serde::Serialize)]
-        #[serde(crate = "::near_sdk::serde")]
+        #[derive(::renamed_sdk::near_sdk::serde::Serialize)]
+        #[serde(crate = "::renamed_sdk::near_sdk::serde")]
         struct Input<'nearinput> {
             k: &'nearinput String,
         }
         let __args = Input { k: &k };
-        match ::near_sdk::serde_json::to_vec(&__args) {
+        match ::renamed_sdk::near_sdk::serde_json::to_vec(&__args) {
             Ok(serialized) => serialized,
             Err(_) => {
-                ::near_sdk::env::panic_str(
+                ::renamed_sdk::near_sdk::env::panic_str(
                     "Failed to serialize the cross contract args using JSON.",
                 )
             }
         }
     };
     match self.promise_or_create_on {
-        ::near_sdk::PromiseOrValue::Promise(p) => p,
-        ::near_sdk::PromiseOrValue::Value(account_id) => {
-            ::near_sdk::Promise::new(account_id)
+        ::renamed_sdk::near_sdk::PromiseOrValue::Promise(p) => p,
+        ::renamed_sdk::near_sdk::PromiseOrValue::Value(account_id) => {
+            ::renamed_sdk::near_sdk::Promise::new(account_id)
         }
     }
         .function_call_weight(

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_gen.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_gen.snap
@@ -43,7 +43,7 @@ impl Test {
     }
     /// Convenience method for creating a cross-contract call to the current contract.
     ///
-    /// Equivalent to `Self::ext(near_sdk::env::current_account_id())`.
+    /// Equivalent to `Self::ext(env::current_account_id())`.
     pub fn ext_self() -> TestExt {
         TestExt {
             promise_or_create_on: ::near_sdk::PromiseOrValue::Value(

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_gen_custom_crate.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_gen_custom_crate.snap
@@ -1,0 +1,66 @@
+---
+source: near-sdk-macros/src/core_impl/code_generator/ext.rs
+expression: pretty_print_syn_str(&actual).unwrap()
+---
+#[must_use]
+pub struct TestExt {
+    pub(crate) promise_or_create_on: ::renamed_sdk::near_sdk::PromiseOrValue<
+        ::renamed_sdk::near_sdk::AccountId,
+    >,
+    pub(crate) deposit: ::renamed_sdk::near_sdk::NearToken,
+    pub(crate) static_gas: ::renamed_sdk::near_sdk::Gas,
+    pub(crate) gas_weight: ::renamed_sdk::near_sdk::GasWeight,
+}
+impl TestExt {
+    pub fn with_attached_deposit(
+        mut self,
+        amount: ::renamed_sdk::near_sdk::NearToken,
+    ) -> Self {
+        self.deposit = amount;
+        self
+    }
+    pub fn with_static_gas(mut self, static_gas: ::renamed_sdk::near_sdk::Gas) -> Self {
+        self.static_gas = static_gas;
+        self
+    }
+    pub fn with_unused_gas_weight(mut self, gas_weight: u64) -> Self {
+        self.gas_weight = ::renamed_sdk::near_sdk::GasWeight(gas_weight);
+        self
+    }
+}
+impl Test {
+    /// API for calling this contract's functions in a subsequent execution.
+    pub fn ext(account_id: ::renamed_sdk::near_sdk::AccountId) -> TestExt {
+        TestExt {
+            promise_or_create_on: ::renamed_sdk::near_sdk::PromiseOrValue::Value(
+                account_id,
+            ),
+            deposit: ::renamed_sdk::near_sdk::NearToken::from_near(0),
+            static_gas: ::renamed_sdk::near_sdk::Gas::from_gas(0),
+            gas_weight: ::renamed_sdk::near_sdk::GasWeight::default(),
+        }
+    }
+    pub fn ext_on(promise: ::renamed_sdk::near_sdk::Promise) -> TestExt {
+        TestExt {
+            promise_or_create_on: ::renamed_sdk::near_sdk::PromiseOrValue::Promise(
+                promise,
+            ),
+            deposit: ::renamed_sdk::near_sdk::NearToken::from_near(0),
+            static_gas: ::renamed_sdk::near_sdk::Gas::from_gas(0),
+            gas_weight: ::renamed_sdk::near_sdk::GasWeight::default(),
+        }
+    }
+    /// Convenience method for creating a cross-contract call to the current contract.
+    ///
+    /// Equivalent to `Self::ext(near_sdk::env::current_account_id())`.
+    pub fn ext_self() -> TestExt {
+        TestExt {
+            promise_or_create_on: ::renamed_sdk::near_sdk::PromiseOrValue::Value(
+                ::renamed_sdk::near_sdk::env::current_account_id(),
+            ),
+            deposit: ::renamed_sdk::near_sdk::NearToken::from_near(0),
+            static_gas: ::renamed_sdk::near_sdk::Gas::from_gas(0),
+            gas_weight: ::renamed_sdk::near_sdk::GasWeight::default(),
+        }
+    }
+}

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_gen_custom_crate.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/ext_gen_custom_crate.snap
@@ -52,7 +52,7 @@ impl Test {
     }
     /// Convenience method for creating a cross-contract call to the current contract.
     ///
-    /// Equivalent to `Self::ext(near_sdk::env::current_account_id())`.
+    /// Equivalent to `Self::ext(env::current_account_id())`.
     pub fn ext_self() -> TestExt {
         TestExt {
             promise_or_create_on: ::renamed_sdk::near_sdk::PromiseOrValue::Value(

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/handle_result_borsh.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/handle_result_borsh.snap
@@ -11,7 +11,7 @@ pub extern "C" fn method() {
     let result = Hello::method(&contract);
     match result {
         ::std::result::Result::Ok(result) => {
-            let result = match near_sdk::borsh::to_vec(&result) {
+            let result = match ::near_sdk::borsh::to_vec(&result) {
                 Ok(v) => v,
                 Err(_) => {
                     ::near_sdk::env::panic_str(

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/handle_result_json.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/handle_result_json.snap
@@ -11,7 +11,7 @@ pub extern "C" fn method() {
     let result = Hello::method(&contract);
     match result {
         ::std::result::Result::Ok(result) => {
-            let result = match near_sdk::serde_json::to_vec(&result) {
+            let result = match ::near_sdk::serde_json::to_vec(&result) {
                 Ok(v) => v,
                 Err(_) => {
                     ::near_sdk::env::panic_str(

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/handle_result_mut.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/handle_result_mut.snap
@@ -14,7 +14,7 @@ pub extern "C" fn method() {
     let result = Hello::method(&mut contract);
     match result {
         ::std::result::Result::Ok(result) => {
-            let result = match near_sdk::serde_json::to_vec(&result) {
+            let result = match ::near_sdk::serde_json::to_vec(&result) {
                 Ok(v) => v,
                 Err(_) => {
                     ::near_sdk::env::panic_str(

--- a/near-sdk-macros/src/core_impl/code_generator/snapshots/serialize_with_borsh.snap
+++ b/near-sdk-macros/src/core_impl/code_generator/snapshots/serialize_with_borsh.snap
@@ -1,6 +1,5 @@
 ---
 source: near-sdk-macros/src/core_impl/code_generator/item_trait_info.rs
-assertion_line: 72
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 pub mod test {
@@ -54,7 +53,7 @@ pub mod test {
                     v: &'nearinput Vec<String>,
                 }
                 let __args = Input { v: &v };
-                match near_sdk::borsh::to_vec(&__args) {
+                match ::near_sdk::borsh::to_vec(&__args) {
                     Ok(serialized) => serialized,
                     Err(_) => {
                         ::near_sdk::env::panic_str(

--- a/near-sdk-macros/src/core_impl/code_generator/state.rs
+++ b/near-sdk-macros/src/core_impl/code_generator/state.rs
@@ -22,6 +22,7 @@ impl ContractStateArgs {
         self,
         ident: &Ident,
         generics: &Generics,
+        near_sdk_crate: &syn::Path,
     ) -> proc_macro2::TokenStream {
         let key = self.key.map(|key| {
             quote! {
@@ -33,7 +34,7 @@ impl ContractStateArgs {
         });
         quote! {
             const _: () = {
-                impl ::near_sdk::state::ContractState for #generics #ident #generics {
+                impl #near_sdk_crate::state::ContractState for #generics #ident #generics {
                     #key
                 }
             };

--- a/near-sdk-macros/src/core_impl/event/mod.rs
+++ b/near-sdk-macros/src/core_impl/event/mod.rs
@@ -8,9 +8,17 @@ use darling::FromMeta;
 use darling::ast::NestedMeta;
 use syn::{ItemEnum, LitStr, parse_quote};
 
+use crate::core_impl::utils::crate_path_string;
+
 #[derive(Default, FromMeta, Clone, Debug)]
 pub struct MacroConfig {
     pub event_json: Option<EventsConfig>,
+    /// Path to the `near-sdk` crate to use in the generated code, forwarded from
+    /// `#[near(event_json(...), crate = "...")]` / `#[near_bindgen(event_json(...), crate =
+    /// "...")]`. Also forwarded into the `EventMetadata` derive via `#[event_metadata(crate =
+    /// "...")]`, since that derive has no other way to learn the resolved crate path.
+    #[darling(rename = "crate")]
+    krate: Option<syn::Path>,
 }
 #[derive(Default, FromMeta, Clone, Debug)]
 pub struct EventsConfig {
@@ -36,6 +44,9 @@ pub(crate) fn near_events(attr: TokenStream, item: TokenStream) -> TokenStream {
             return TokenStream::from(e.write_errors());
         }
     };
+    let near_sdk_crate: syn::Path = args.krate.clone().unwrap_or_else(|| parse_quote!(::near_sdk));
+    let near_sdk_crate_str = crate_path_string(&near_sdk_crate);
+    let serde_crate_str = format!("{near_sdk_crate_str}::serde");
     if let Some(standard) = args.event_json.and_then(|event_json| event_json.standard) {
         if let Ok(mut input) = syn::parse::<ItemEnum>(item) {
             let name = &input.ident;
@@ -43,11 +54,14 @@ pub(crate) fn near_events(attr: TokenStream, item: TokenStream) -> TokenStream {
             let standard_ident = syn::Ident::new(&standard_name, Span::call_site());
             // NearEvent Macro handles implementation
             input.attrs.push(
-                parse_quote! (#[derive(::near_sdk::serde::Serialize, ::near_sdk::EventMetadata)]),
+                parse_quote! (#[derive(#near_sdk_crate::serde::Serialize, #near_sdk_crate::EventMetadata)]),
             );
-            input.attrs.push(parse_quote! (#[serde(crate="::near_sdk::serde")]));
+            input.attrs.push(parse_quote! (#[serde(crate = #serde_crate_str)]));
             input.attrs.push(parse_quote! (#[serde(tag = "event", content = "data")]));
             input.attrs.push(parse_quote! (#[serde(rename_all = "snake_case")]));
+            // Forwarded so the `EventMetadata` derive (which can't otherwise see how it was
+            // invoked) knows the resolved crate path too.
+            input.attrs.push(parse_quote! (#[event_metadata(crate = #near_sdk_crate_str)]));
 
             TokenStream::from(quote! {
                 const #standard_ident: &'static str = #standard;

--- a/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/attr_sig_info.rs
@@ -6,7 +6,7 @@ use crate::core_impl::{Returns, utils};
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::ToTokens;
 use syn::spanned::Spanned;
-use syn::{Attribute, Error, FnArg, GenericParam, Ident, ReturnType, Signature, Type};
+use syn::{Attribute, Error, FnArg, GenericParam, Ident, ReturnType, Signature, Type, parse_quote};
 
 /// Information extracted from method attributes and signature.
 pub struct AttrSigInfo {
@@ -24,6 +24,9 @@ pub struct AttrSigInfo {
     pub input_serializer: SerializerType,
     /// The original method signature.
     pub original_sig: Signature,
+    /// Path to the `near-sdk` crate to use in generated code. Defaults to `::near_sdk`;
+    /// overridden by `#[near(crate = "...")]` via [`crate::ItemImplInfo::set_krate`].
+    pub krate: syn::Path,
 }
 
 use darling::FromAttributes;
@@ -184,6 +187,7 @@ impl AttrSigInfo {
             returns,
             input_serializer: SerializerType::JSON,
             original_sig: original_sig.clone(),
+            krate: parse_quote!(::near_sdk),
         };
 
         let input_serializer =

--- a/near-sdk-macros/src/core_impl/info_extractor/item_impl_info.rs
+++ b/near-sdk-macros/src/core_impl/info_extractor/item_impl_info.rs
@@ -1,6 +1,6 @@
 use crate::ImplItemMethodInfo;
 use syn::spanned::Spanned;
-use syn::{Error, ImplItem, ItemImpl, Type};
+use syn::{Error, ImplItem, ItemImpl, Type, parse_quote};
 
 /// Information extracted from `impl` section.
 pub struct ItemImplInfo {
@@ -8,6 +8,10 @@ pub struct ItemImplInfo {
     pub ty: Type,
     /// Info extracted for each public method.
     pub methods: Vec<ImplItemMethodInfo>,
+    /// Path to the `near-sdk` crate to use in generated code. Defaults to `::near_sdk`;
+    /// overridden via [`ItemImplInfo::set_krate`] when `#[near(crate = "...")]` /
+    /// `#[near_bindgen(crate = "...")]` is used.
+    pub krate: syn::Path,
 }
 
 impl ItemImplInfo {
@@ -42,6 +46,14 @@ impl ItemImplInfo {
             return Err(combined_error.unwrap());
         }
 
-        Ok(Self { ty, methods })
+        Ok(Self { ty, methods, krate: parse_quote!(::near_sdk) })
+    }
+
+    /// Overrides the `near-sdk` crate path used by this `impl` block and all of its methods.
+    pub fn set_krate(&mut self, krate: &syn::Path) {
+        for method in &mut self.methods {
+            method.attr_signature_info.krate = krate.clone();
+        }
+        self.krate = krate.clone();
     }
 }

--- a/near-sdk-macros/src/core_impl/utils/mod.rs
+++ b/near-sdk-macros/src/core_impl/utils/mod.rs
@@ -7,6 +7,17 @@ use syn::{GenericArgument, Path, PathArguments, Signature, Type};
 #[cfg(test)]
 pub mod test_helpers;
 
+/// Renders a crate path (e.g. the one passed to `#[near(crate = "...")]`) as a string suitable
+/// for embedding in a nested `crate = "..."` argument, such as `#[serde(crate = "...")]` or
+/// `#[borsh(crate = "...")]`.
+///
+/// `quote! { #path }.to_string()` inserts spaces between tokens (e.g. `:: near_sdk`), which is
+/// still valid when re-parsed as a path but is not byte-identical to a hand-written literal, so
+/// this strips those spaces out.
+pub(crate) fn crate_path_string(path: &Path) -> String {
+    quote! {#path}.to_string().replace(' ', "")
+}
+
 /// Checks whether the given path is literally "Result".
 /// Note that it won't match a fully qualified name `core::result::Result` or a type alias like
 /// `type StringResult = Result<String, String>`.

--- a/near-sdk-macros/src/lib.rs
+++ b/near-sdk-macros/src/lib.rs
@@ -748,9 +748,25 @@ pub fn function_error(item: TokenStream) -> TokenStream {
     })
 }
 
-#[proc_macro_derive(EventMetadata, attributes(event_version))]
+#[derive(Default, darling::FromAttributes)]
+#[darling(attributes(event_metadata))]
+struct EventMetadataArgs {
+    /// Path to the `near-sdk` crate to use in the generated code. Populated by `near_events`
+    /// forwarding the resolved crate path from `#[near(event_json(...), crate = "...")]`.
+    #[darling(rename = "crate")]
+    krate: Option<syn::Path>,
+}
+
+#[proc_macro_derive(EventMetadata, attributes(event_version, event_metadata))]
 pub fn derive_event_attributes(item: TokenStream) -> TokenStream {
     if let Ok(input) = syn::parse::<ItemEnum>(item) {
+        use darling::FromAttributes;
+        let args = match EventMetadataArgs::from_attributes(&input.attrs) {
+            Ok(v) => v,
+            Err(e) => return TokenStream::from(e.write_errors()),
+        };
+        let near_sdk_crate = args.krate.unwrap_or_else(|| parse_quote!(::near_sdk));
+
         let name = &input.ident;
         // get `standard` const injected from `near_events`
         let standard_name = format!("{name}_event_standard");
@@ -797,12 +813,12 @@ pub fn derive_event_attributes(item: TokenStream) -> TokenStream {
         TokenStream::from(quote! {
             impl #impl_generics #name #type_generics #where_clause {
                 pub fn emit(&self) {
-                    use ::near_sdk::AsNep297Event;
-                    ::near_sdk::env::log_str(&self.to_nep297_event().to_event_log());
+                    use #near_sdk_crate::AsNep297Event;
+                    #near_sdk_crate::env::log_str(&self.to_nep297_event().to_event_log());
                 }
 
-                pub fn to_json(&self) -> ::near_sdk::serde_json::Value {
-                    use ::near_sdk::AsNep297Event;
+                pub fn to_json(&self) -> #near_sdk_crate::serde_json::Value {
+                    use #near_sdk_crate::AsNep297Event;
                     self.to_nep297_event().to_json()
                 }
 
@@ -823,9 +839,9 @@ pub fn derive_event_attributes(item: TokenStream) -> TokenStream {
                 }
             }
 
-            impl #impl_generics ::near_sdk::events::AsNep297Event for #name #type_generics #where_clause{
-                fn to_nep297_event(&self) -> ::near_sdk::events::Nep297Event<'_, Self> {
-                    ::near_sdk::events::Nep297Event::new(
+            impl #impl_generics #near_sdk_crate::events::AsNep297Event for #name #type_generics #where_clause{
+                fn to_nep297_event(&self) -> #near_sdk_crate::events::Nep297Event<'_, Self> {
+                    #near_sdk_crate::events::Nep297Event::new(
                         ::std::borrow::Cow::Borrowed(#standard_ident),
                         match self {
                             #(#version_arms),*

--- a/near-sdk-macros/src/lib.rs
+++ b/near-sdk-macros/src/lib.rs
@@ -44,6 +44,31 @@ struct NearMacroArgs {
     #[darling(default, flatten)]
     near_bindgen_args: NearBindgenMacroArgs,
     inside_nearsdk: Option<bool>,
+    /// Path to the `near-sdk` crate to use in the generated code, e.g.
+    /// `#[near(crate = "::my_wrapper::near_sdk")]`. Lets downstream crates that re-export or
+    /// rename `near-sdk` point macro expansions at the re-export instead of a direct dependency.
+    /// Mutually exclusive with `inside_nearsdk`, which remains as sugar for `crate = "crate"`
+    /// (used internally by `near-sdk` itself).
+    #[darling(rename = "crate")]
+    krate: Option<syn::Path>,
+}
+
+/// Resolves the `near-sdk` crate path to use in generated code from the `crate` / `inside_nearsdk`
+/// arguments of `#[near(...)]` or `#[derive(NearSchema)]`. Errors if both are set, since they're
+/// mutually exclusive.
+fn resolve_near_sdk_crate(
+    krate: Option<syn::Path>,
+    inside_nearsdk: Option<bool>,
+) -> Result<syn::Path, syn::Error> {
+    match (krate, inside_nearsdk.unwrap_or(false)) {
+        (Some(_), true) => Err(syn::Error::new(
+            Span::call_site(),
+            "cannot specify both `crate` and `inside_nearsdk`",
+        )),
+        (Some(path), false) => Ok(path),
+        (None, true) => Ok(parse_quote!(crate)),
+        (None, false) => Ok(parse_quote!(::near_sdk)),
+    }
 }
 
 fn has_nested_near_macros(item: TokenStream) -> bool {
@@ -85,11 +110,13 @@ pub fn near(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
 
-    let near_sdk_crate = if near_macro_args.inside_nearsdk.unwrap_or(false) {
-        quote! {crate}
-    } else {
-        quote! {::near_sdk}
-    };
+    let near_sdk_crate: syn::Path =
+        match resolve_near_sdk_crate(near_macro_args.krate.clone(), near_macro_args.inside_nearsdk)
+        {
+            Ok(krate) => krate,
+            Err(e) => return TokenStream::from(e.to_compile_error()),
+        };
+    let near_sdk_crate_str = quote! {#near_sdk_crate}.to_string();
 
     // Check for nested near macros by parsing the input and examining actual attributes
     if has_nested_near_macros(item.clone()) {
@@ -109,7 +136,7 @@ pub fn near(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     if near_macro_args.near_bindgen_args.contract_state.is_some() {
         let near_bindgen_args = near_macro_args.near_bindgen_args;
-        expanded = quote! {#[#near_sdk_crate::near_bindgen(#near_bindgen_args)]};
+        expanded = quote! {#[#near_sdk_crate::near_bindgen(#near_bindgen_args crate = #near_sdk_crate_str)]};
     };
 
     let mut has_borsh = false;
@@ -179,7 +206,7 @@ pub fn near(attr: TokenStream, item: TokenStream) -> TokenStream {
     #[cfg(feature = "abi")]
     {
         let schema_derive: proc_macro2::TokenStream =
-            get_schema_derive(has_json, has_borsh, near_sdk_crate.clone(), false);
+            get_schema_derive(has_json, has_borsh, quote! {#near_sdk_crate}, false);
         expanded = quote! {
             #expanded
             #schema_derive
@@ -206,7 +233,7 @@ pub fn near(attr: TokenStream, item: TokenStream) -> TokenStream {
         };
     } else if let Ok(input) = syn::parse::<ItemImpl>(item) {
         expanded = quote! {
-            #[#near_sdk_crate::near_bindgen]
+            #[#near_sdk_crate::near_bindgen(crate = #near_sdk_crate_str)]
             #input
         };
     } else {
@@ -227,6 +254,11 @@ struct NearBindgenMacroArgs {
     contract_state: Option<core_impl::state::ContractStateArgs>,
     #[darling(default)]
     contract_metadata: core_impl::ContractMetadata,
+    /// Path to the `near-sdk` crate to use in the generated code. Populated either directly, when
+    /// a user writes `#[near_bindgen(crate = "...")]`, or by `#[near(crate = "...")]` forwarding
+    /// its own resolved crate path into the `#[near_bindgen(...)]` attribute it emits.
+    #[darling(rename = "crate")]
+    krate: Option<syn::Path>,
 }
 
 impl quote::ToTokens for NearBindgenMacroArgs {
@@ -245,6 +277,22 @@ pub fn near_bindgen(attr: TokenStream, item: TokenStream) -> TokenStream {
     if attr.to_string().contains("event_json") {
         return core_impl::near_events(attr, item);
     }
+
+    let attr_args = match NestedMeta::parse_meta_list(attr.into()) {
+        Ok(v) => v,
+        Err(e) => {
+            return Error::from(e).write_errors().into();
+        }
+    };
+
+    let args = match NearBindgenMacroArgs::from_list(&attr_args) {
+        Ok(v) => v,
+        Err(e) => {
+            return e.write_errors().into();
+        }
+    };
+
+    let near_sdk_crate: syn::Path = args.krate.clone().unwrap_or_else(|| parse_quote!(::near_sdk));
 
     let (ident, generics) = if let Ok(input) = syn::parse::<ItemStruct>(item.clone()) {
         (input.ident, input.generics)
@@ -265,7 +313,7 @@ pub fn near_bindgen(attr: TokenStream, item: TokenStream) -> TokenStream {
                 }
             }
         }
-        return match process_impl_block(input) {
+        return match process_impl_block(input, &near_sdk_crate) {
             Ok(output) => output,
             Err(output) => output,
         }
@@ -280,29 +328,17 @@ pub fn near_bindgen(attr: TokenStream, item: TokenStream) -> TokenStream {
         );
     };
 
-    let attr_args = match NestedMeta::parse_meta_list(attr.into()) {
-        Ok(v) => v,
-        Err(e) => {
-            return Error::from(e).write_errors().into();
-        }
-    };
-
-    let args = match NearBindgenMacroArgs::from_list(&attr_args) {
-        Ok(v) => v,
-        Err(e) => {
-            return e.write_errors().into();
-        }
-    };
-
-    let impl_contract_state = args.contract_state.map(|s| s.impl_contract_state(&ident, &generics));
+    let impl_contract_state =
+        args.contract_state.map(|s| s.impl_contract_state(&ident, &generics, &near_sdk_crate));
     let metadata = args.contract_metadata.contract_source_metadata_const();
 
     let metadata_impl_gen = {
-        let metadata_impl_gen = generate_contract_metadata_method(&ident, &generics).into();
+        let metadata_impl_gen =
+            generate_contract_metadata_method(&ident, &generics, &near_sdk_crate).into();
 
         let metadata_impl_gen = syn::parse::<ItemImpl>(metadata_impl_gen)
             .expect("failed to generate contract metadata");
-        process_impl_block(metadata_impl_gen)
+        process_impl_block(metadata_impl_gen, &near_sdk_crate)
     };
 
     let metadata_impl_gen = match metadata_impl_gen {
@@ -310,9 +346,9 @@ pub fn near_bindgen(attr: TokenStream, item: TokenStream) -> TokenStream {
         Err(err) => return err.into(),
     };
 
-    let ext_gen = generate_ext_structs(&ident, Some(&generics));
+    let ext_gen = generate_ext_structs(&ident, Some(&generics), &near_sdk_crate);
     #[cfg(feature = "__abi-embed-checked")]
-    let abi_embedded = abi::embed();
+    let abi_embedded = abi::embed(&near_sdk_crate);
     #[cfg(not(feature = "__abi-embed-checked"))]
     let abi_embedded = quote! {};
     let item = proc_macro2::TokenStream::from(item);
@@ -330,15 +366,18 @@ pub fn near_bindgen(attr: TokenStream, item: TokenStream) -> TokenStream {
 //
 // # Arguments
 // * input - impl block to process.
+// * krate - path to the `near-sdk` crate to use in the generated code.
 //
 // The Result has a TokenStream error type, because those need to be propagated to the compiler.
 fn process_impl_block(
     mut input: ItemImpl,
+    krate: &syn::Path,
 ) -> Result<proc_macro2::TokenStream, proc_macro2::TokenStream> {
-    let item_impl_info = match ItemImplInfo::new(&mut input) {
+    let mut item_impl_info = match ItemImplInfo::new(&mut input) {
         Ok(x) => x,
         Err(err) => return Err(err.to_compile_error()),
     };
+    item_impl_info.set_krate(krate);
 
     #[cfg(not(feature = "__abi-generate"))]
     let abi_generated = quote! {};
@@ -403,6 +442,11 @@ struct DeriveNearSchema {
     attrs: Vec<syn::Attribute>,
     json: Option<bool>,
     borsh: Option<bool>,
+    /// Path to the `near-sdk` crate to use in the generated code, e.g.
+    /// `#[abi(json, crate = "::my_wrapper::near_sdk")]`. Mutually exclusive with the bare
+    /// `#[inside_nearsdk]` marker attribute, which remains as sugar for `crate = "crate"`.
+    #[darling(rename = "crate")]
+    krate: Option<syn::Path>,
 }
 
 #[proc_macro_derive(NearSchema, attributes(abi, serde, borsh, schemars, validate, inside_nearsdk))]
@@ -476,12 +520,13 @@ pub fn derive_near_schema(#[allow(unused)] input: TokenStream) -> TokenStream {
             }
         }
 
-        let near_sdk_crate =
-            if derive_input.attrs.iter().any(|attr| attr.path().is_ident("inside_nearsdk")) {
-                quote! {crate}
-            } else {
-                quote! {::near_sdk}
-            };
+        let inside_nearsdk =
+            derive_input.attrs.iter().any(|attr| attr.path().is_ident("inside_nearsdk"));
+        let near_sdk_crate = match resolve_near_sdk_crate(args.krate.clone(), Some(inside_nearsdk))
+        {
+            Ok(krate) => quote! {#krate},
+            Err(e) => return TokenStream::from(e.to_compile_error()),
+        };
 
         // <unspecified> or #[abi(json)]
         let json_schema = json_schema || !borsh_schema;
@@ -610,16 +655,32 @@ fn get_where_clause(
     where_clause
 }
 
-#[proc_macro_derive(PanicOnDefault)]
+#[derive(Default, darling::FromAttributes)]
+#[darling(attributes(panic_on_default))]
+struct PanicOnDefaultArgs {
+    /// Path to the `near-sdk` crate to use in the generated code, e.g.
+    /// `#[panic_on_default(crate = "::my_wrapper::near_sdk")]`.
+    #[darling(rename = "crate")]
+    krate: Option<syn::Path>,
+}
+
+#[proc_macro_derive(PanicOnDefault, attributes(panic_on_default))]
 pub fn derive_no_default(item: TokenStream) -> TokenStream {
     match syn::parse::<Item>(item) {
-        Ok(Item::Enum(ItemEnum { ident, .. })) | Ok(Item::Struct(ItemStruct { ident, .. })) => {
+        Ok(Item::Enum(ItemEnum { ident, attrs, .. }))
+        | Ok(Item::Struct(ItemStruct { ident, attrs, .. })) => {
+            use darling::FromAttributes;
+            let args = match PanicOnDefaultArgs::from_attributes(&attrs) {
+                Ok(v) => v,
+                Err(e) => return TokenStream::from(e.write_errors()),
+            };
+            let near_sdk_crate = args.krate.unwrap_or_else(|| parse_quote!(::near_sdk));
             TokenStream::from(quote! {
                 const _: () = {
                     #[automatically_derived]
                     impl ::std::default::Default for #ident {
                         fn default() -> Self {
-                            ::near_sdk::env::panic_str("The contract is not initialized");
+                            #near_sdk_crate::env::panic_str("The contract is not initialized");
                         }
                     }
                 };


### PR DESCRIPTION
Downstream crates that re-export `near-sdk` under a different name (e.g. `defuse_wallet` in [`near/intents`](https://github.com/near/intents/blob/f815a43f9c36cbb470cdb794fff70a09f4bf9151/contracts/wallet/ed25519/src/lib.rs#L57-L65), which wraps `#[near]` in its own `wallet!` macro) can't use it today: every macro expansion hardcodes `::near_sdk::...`, so any consumer of the wrapper needs `near-sdk` as a direct dependency with a matching version just to satisfy the hardcoded path. That defeats the point of the wrapper and forces version lock-step across the whole dependency chain. Tracked as #1059 (original report #519).

This adds a `crate` argument, following the `serde`/`borsh` convention:

```rust
#[near(contract_state, crate = "::my_wrapper::near_sdk")]
pub struct Contract { ... }

#[near(crate = "::my_wrapper::near_sdk")]
impl Contract { ... }
```

`#[near_bindgen(crate = "...")]` works the same way directly, and `#[near]` forwards its resolved path when it expands into `#[near_bindgen(...)]` internally. `#[derive(NearSchema)]` takes it via `#[abi(crate = "...")]`, and `#[derive(PanicOnDefault)]` via a new `#[panic_on_default(crate = "...")]` helper attribute. The existing `inside_nearsdk` flag (used internally by `near-sdk` itself) stays as sugar for `crate = "crate"` and is mutually exclusive with `crate`.

Covered: `#[near]`, `#[near_bindgen]`, `NearSchema`, `PanicOnDefault`. Left out: `ext_contract` and the `event_json`/`EventMetadata` path — both would need their own crate-passing plumbing and are separable follow-ups.

Default expansion output is unchanged (verified against the existing insta snapshots), with one intentional side effect worth flagging: 15 snapshots changed because a handful of codegen spots were hardcoding a *relative* `near_sdk::...` path instead of an absolute `::near_sdk::...` one (return-value JSON/Borsh serialization, and the ABI `ResultTypeExt` bound). Those would have silently stayed broken under a crate rename even with this fix, so they're corrected as part of it — this is not a behavior change for the default (unrenamed) case, just a more hygienic path form.

Added a `crate-rename-tests` workspace crate that depends on `near-sdk` under a renamed package name, re-exports it through a nested module, and builds a small contract against that path (checked both natively and for `wasm32-unknown-unknown`) to prove the end-to-end scenario actually works, not just the unit-level codegen.

Part of #1059.