### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.29.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.29.0...near-sdk-v5.29.1) - 2026-07-22
+
+### Fixed
+
+- confirm `p256_verify` on sdk to recommended in NEP-635 ([#1619](https://github.com/near/near-sdk-rs/pull/1619))
+
+### Other
+
+- enable all features on docs.rs for near-sdk and near-sys
+
 ## [5.29.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.29.0-rc.1...near-sdk-v5.29.0) - 2026-07-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.29.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.29.0...near-sdk-v5.29.1) - 2026-08-27
+
+### Fixed
+
+- disable near-vm-runner default features for unit-testing ([#1611](https://github.com/near/near-sdk-rs/pull/1611))
+- confirm `p256_verify` on sdk to recommended in NEP-635 ([#1619](https://github.com/near/near-sdk-rs/pull/1619))
+
+### Other
+
+- enable all features on docs.rs for near-sdk and near-sys
+
 ## [5.29.0](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.29.0-rc.1...near-sdk-v5.29.0) - 2026-07-13
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["examples/"]
 
 [workspace.package]
-version = "5.29.0"
+version = "5.29.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 categories = ["wasm"]

--- a/near-contract-standards/Cargo.toml
+++ b/near-contract-standards/Cargo.toml
@@ -14,7 +14,7 @@ NEAR smart contracts standard library.
 """
 
 [dependencies]
-near-sdk = { path = "../near-sdk", version = "~5.29.0", default-features = false, features = [
+near-sdk = { path = "../near-sdk", version = "~5.29.1", default-features = false, features = [
     "legacy",
 ] }
 

--- a/near-digest/Cargo.toml
+++ b/near-digest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-digest"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 categories.workspace = true
@@ -22,7 +22,7 @@ sha2 = { version = "0.11.0", optional = true }
 sha3 = { version = "0.11.0", optional = true }
 
 [target.'cfg(near)'.dependencies]
-near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.5" }
+near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.6" }
 impl-tools = "0.12.0"
 # for `unstable` Sha3-256/512
 sha3 = { version = "0.11.0", optional = true }

--- a/near-global-contracts/Cargo.toml
+++ b/near-global-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-global-contracts"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 license.workspace = true
 categories.workspace = true
@@ -31,13 +31,13 @@ borsh = { version = "1.0.0", features = ["derive"], optional = true }
 
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 
-near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.5", optional = true }
+near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.6", optional = true }
 near-primitives-core = { version = "0.37.0", optional = true }
 
 schemars-v0_8 = { version = "0.8.22", optional = true, package = "schemars" }
 
 [target.'cfg(near)'.dependencies]
-near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.5" }
+near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.6" }
 
 [target.'cfg(not(near))'.dependencies]
 digest-io = { version = "0.1" }

--- a/near-sdk-core/Cargo.toml
+++ b/near-sdk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sdk-core"
-version = "4.2.2"
+version = "4.2.3"
 authors = ["Near Inc <hello@near.org>"]
 edition.workspace = true
 license.workspace = true
@@ -33,7 +33,7 @@ near-account-id = { version = "2.3.0" }
 near-gas = { version = "0.3" }
 near-token = { version = "0.3" }
 near-crypto-hash = { path = "../near-crypto-hash/", version = "~0.2.0" }
-near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.5", optional = true }
+near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.6", optional = true }
 
 schemars-v0_8 = { version = "0.8.22", optional = true, package = "schemars" }
 near-primitives-core = { version = "0.37.0", optional = true }
@@ -48,7 +48,7 @@ near-parameters = { version = "0.37.0", optional = true }
 near-crypto = { version = "0.37.0", default-features = false, optional = true }
 
 [target.'cfg(near)'.dependencies]
-near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.5" }
+near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.6" }
 
 [dev-dependencies]
 # XXX: `near-sdk` was added in order to enable tests and doctests compiling with mockchain

--- a/near-sdk-env/Cargo.toml
+++ b/near-sdk-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sdk-env"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Near Inc <hello@near.org>"]
 edition.workspace = true
 license.workspace = true
@@ -16,10 +16,10 @@ non-wasm32 (via pure-Rust crates).
 """
 
 [dependencies]
-near-sys = { path = "../near-sys/", version = "~0.2.13", optional = true }
+near-sys = { path = "../near-sys/", version = "~0.2.14", optional = true }
 
 [target.'cfg(near)'.dependencies]
-near-sys = { path = "../near-sys/", version = "~0.2.13" }
+near-sys = { path = "../near-sys/", version = "~0.2.14" }
 
 [target.'cfg(not(near))'.dependencies]
 ripemd = { version = "0.1.1" }

--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -23,14 +23,14 @@ required-features = ["abi", "unstable"]
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_with = { version = "3", features = ["base64", "hex", "json"] }
-near-sdk-macros = { path = "../near-sdk-macros", version = "~5.29.0" }
-near-sys = { path = "../near-sys", version = "0.2.13" }
-near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.5" }
-near-sdk-core = { path = "../near-sdk-core/", version = "~4.2.2", features = [
+near-sdk-macros = { path = "../near-sdk-macros", version = "~5.29.1" }
+near-sys = { path = "../near-sys", version = "0.2.14" }
+near-sdk-env = { path = "../near-sdk-env/", version = "~0.1.6" }
+near-sdk-core = { path = "../near-sdk-core/", version = "~4.2.3", features = [
     "serde",
     "borsh",
 ] }
-near-global-contracts = { path = "../near-global-contracts/", version = "~0.2.5", features = [
+near-global-contracts = { path = "../near-global-contracts/", version = "~0.2.6", features = [
     "serde",
     "borsh",
 ] }
@@ -48,7 +48,7 @@ near-token = { version = "0.3", features = ["serde", "borsh"] }
 
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 
-near-digest = { path = "../near-digest/", version = "0.1.1", features = [
+near-digest = { path = "../near-digest/", version = "0.1.2", features = [
     "sha2",
     "sha3",
     "ripemd",

--- a/near-sys/CHANGELOG.md
+++ b/near-sys/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.14](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.13...near-sys-v0.2.14) - 2026-07-22
+
+### Other
+
+- enable all features on docs.rs for near-sdk and near-sys
+
 ## [0.2.13](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.12...near-sys-v0.2.13) - 2026-07-13
 
 ### Added

--- a/near-sys/CHANGELOG.md
+++ b/near-sys/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.14](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.13...near-sys-v0.2.14) - 2026-08-27
+
+### Other
+
+- enable all features on docs.rs for near-sdk and near-sys
+
 ## [0.2.13](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.12...near-sys-v0.2.13) - 2026-07-13
 
 ### Added

--- a/near-sys/Cargo.toml
+++ b/near-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sys"
-version = "0.2.13"
+version = "0.2.14"
 authors = ["Near Inc <hello@near.org>"]
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `near-sys`: 0.2.13 -> 0.2.14 (✓ API compatible changes)
* `near-global-contracts`: 0.2.5 -> 0.2.6 (✓ API compatible changes)
* `near-sdk-core`: 4.2.2 -> 4.2.3 (✓ API compatible changes)
* `near-sdk-macros`: 5.29.0 -> 5.29.1
* `near-sdk`: 5.29.0 -> 5.29.1 (✓ API compatible changes)
* `near-contract-standards`: 5.29.0 -> 5.29.1
* `near-sdk-env`: 0.1.5 -> 0.1.6
* `near-digest`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-sys`

<blockquote>


## [0.2.14](https://github.com/near/near-sdk-rs/compare/near-sys-v0.2.13...near-sys-v0.2.14) - 2026-08-27

### Other

- enable all features on docs.rs for near-sdk and near-sys
</blockquote>




## `near-sdk`

<blockquote>

## [5.29.1](https://github.com/near/near-sdk-rs/compare/near-sdk-v5.29.0...near-sdk-v5.29.1) - 2026-08-27

### Fixed

- disable near-vm-runner default features for unit-testing ([#1611](https://github.com/near/near-sdk-rs/pull/1611))
- confirm `p256_verify` on sdk to recommended in NEP-635 ([#1619](https://github.com/near/near-sdk-rs/pull/1619))

### Other

- enable all features on docs.rs for near-sdk and near-sys
</blockquote>

## `near-contract-standards`

<blockquote>

## [5.29.0](https://github.com/near/near-sdk-rs/releases/tag/near-contract-standards-v5.29.0) - 2026-07-13

### Other

- pin to nearcore 2.13.0 stable ([#1586](https://github.com/near/near-sdk-rs/pull/1586))
- fix outdated docs.near.org links in doc comments ([#1591](https://github.com/near/near-sdk-rs/pull/1591))
</blockquote>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).