### PR TITLE
docs: enable all features on docs.rs for near-sdk and near-sys

### DIFF
--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -162,10 +162,5 @@ __macro-docs = []
 min_protocol_version = 84
 
 [package.metadata.docs.rs]
-features = [
-    "unstable",
-    "legacy",
-    "unit-testing",
-    "__macro-docs",
-    "__abi-generate",
-]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/near-sys/Cargo.toml
+++ b/near-sys/Cargo.toml
@@ -17,3 +17,6 @@ Syscall definitions for builtin functions of the NEAR runtime.
 [features]
 global-contracts = []
 deterministic-account-ids = []
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
**Problem**

The docs.rs feature list for `near-sdk` was hand-maintained and dropped several experimental features (`arbitrary`, `deterministic-account-ids`, `digest`, `global-contracts`, `non-contract-usage`). `near-sys` had no docs.rs metadata at all, so its gated syscalls never appeared.

**Fix**

- `near-sdk` + `near-sys`: `all-features = true`
- `near-sdk`: `rustdoc-args = ["--cfg", "docsrs"]` to turn on the `doc_cfg` badges already scaffolded in `lib.rs`, so each item shows which feature gates it

**Verification** — mirrors the docs.rs build:

```
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features -p near-sys -p near-sdk
```