### PR TITLE
fix(examples): use persistent storage in factory-contract-global

### DIFF
--- a/examples/factory-contract-global/src/lib.rs
+++ b/examples/factory-contract-global/src/lib.rs
@@ -1,13 +1,24 @@
 use near_sdk::json_types::{Base58CryptoHash, Base64VecU8};
-use near_sdk::{AccountId, CryptoHash, Promise, PromiseError, env, ext_contract, near};
+use near_sdk::store::IterableMap;
+use near_sdk::{AccountId, CryptoHash, Promise, PromiseError, env, ext_contract, near, require};
 
-#[derive(Default)]
 #[near(contract_state)]
 pub struct GlobalFactoryContract {
     /// Store the hash of deployed global contracts for reference
-    pub global_contracts_registered_by_code_hash: std::collections::HashMap<String, CryptoHash>,
+    pub global_contracts_registered_by_code_hash: IterableMap<String, CryptoHash>,
     /// Store account IDs that have deployed global contracts
-    pub global_contracts_registered_by_account_id: std::collections::HashMap<String, AccountId>,
+    pub global_contracts_registered_by_account_id: IterableMap<String, AccountId>,
+}
+
+impl Default for GlobalFactoryContract {
+    fn default() -> Self {
+        // Persistent SDK collections keep gas costs constant as the registry grows,
+        // unlike a `std::collections::HashMap` which is (de)serialized in full on every call.
+        Self {
+            global_contracts_registered_by_code_hash: IterableMap::new(b"h"),
+            global_contracts_registered_by_account_id: IterableMap::new(b"a"),
+        }
+    }
 }
 
 // Example contract interface that we'll deploy as a global contract
@@ -22,6 +33,12 @@ impl GlobalFactoryContract {
     /// Deploy a global contract with the given bytecode, identifiable by its code hash
     #[payable]
     pub fn deploy_global_contract(&mut self, name: String, code: Base64VecU8) -> Promise {
+        // Reject duplicate names so a registered entry can't be silently overwritten.
+        require!(
+            !self.global_contracts_registered_by_code_hash.contains_key(&name),
+            "Name is already registered"
+        );
+
         let code_hash = env::sha256_array(&code);
         self.global_contracts_registered_by_code_hash.insert(name.clone(), code_hash);
 
@@ -36,6 +53,12 @@ impl GlobalFactoryContract {
         code: Base64VecU8,
         account_id: AccountId,
     ) -> Promise {
+        // Reject duplicate names so a registered entry can't be silently overwritten.
+        require!(
+            !self.global_contracts_registered_by_account_id.contains_key(&name),
+            "Name is already registered"
+        );
+
         self.global_contracts_registered_by_account_id.insert(name, account_id.clone());
 
         Promise::new(account_id)


### PR DESCRIPTION
## Motivation

Reported in #1604 (an automated audit). The report targets an *example*, not the SDK, so it's not a real SDK vulnerability — but the example does model two anti-patterns that are worth not teaching in official example code.

## What this changes

`examples/factory-contract-global`:

1. **Persistent storage instead of `std::collections::HashMap`.** The name registry fields were plain `std::collections::HashMap` inside `#[near(contract_state)]`, which means the entire map is Borsh (de)serialized on every call (O(N) gas as the registry grows). Swapped for `near_sdk::store::IterableMap` (iteration is needed for the `get_global_contracts_registered_*` getters, so `LookupMap` won't do) so gas cost stays constant.
2. **Reject duplicate names.** `deploy_global_contract` and `deploy_global_contract_by_account_id` inserted into the `name`-keyed maps with no uniqueness check, silently overwriting an existing entry. Added a `require!` guard on both. (Note: the overwrite only affected this factory's own convenience registry — global contracts by hash are content-addressed and the by-account-id path uses `create_account`, so the audit's "High severity hijacking" framing was overstated — but modeling silent overwrites in an example is still not ideal.)

No SDK crate changes, so no CHANGELOG entry.

## Testing

- `cargo test` in the example (2 unit + 4 workspaces integration tests pass)
- `cargo fmt --check` and `cargo clippy --all-targets` clean

Closes #1604