### PR TITLE
docs: document GlobalContractId and StateInit types

### DIFF
--- a/near-global-contracts/src/global_contract_identifier.rs
+++ b/near-global-contracts/src/global_contract_identifier.rs
@@ -2,13 +2,6 @@ use near_account_id::AccountId;
 
 use near_crypto_hash::CryptoHash;
 
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum AccountContract {
-    None,
-    Local(CryptoHash),
-    Global(CryptoHash),
-    GlobalByAccount(AccountId),
 /// What contract code an account currently runs.
 ///
 /// An account either has its own copy of the code (`Local`) or points to shared

--- a/near-global-contracts/src/global_contract_identifier.rs
+++ b/near-global-contracts/src/global_contract_identifier.rs
@@ -15,7 +15,7 @@ pub enum AccountContract {
 ///
 /// Global contracts let contract code be deployed once and shared across the whole
 /// network, so many accounts can run the same code without each storing its own copy.
-/// A global contract is referenced in one of two ways, one per variant below.
+/// A global contract is referenced in one of two ways: by hash of its code or by `AccountId` that deployed it.
 ///
 /// [global contract]: https://github.com/near/NEPs/pull/591
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]

--- a/near-global-contracts/src/global_contract_identifier.rs
+++ b/near-global-contracts/src/global_contract_identifier.rs
@@ -11,6 +11,13 @@ pub enum AccountContract {
     GlobalByAccount(AccountId),
 }
 
+/// Identifies which [global contract] an account should run.
+///
+/// Global contracts let contract code be deployed once and shared across the whole
+/// network, so many accounts can run the same code without each storing its own copy.
+/// A global contract is referenced in one of two ways, one per variant below.
+///
+/// [global contract]: https://github.com/near/NEPs/pull/591
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(
     feature = "serde",
@@ -32,10 +39,20 @@ pub enum AccountContract {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(u8)]
 pub enum GlobalContractId {
+    /// Reference the contract by the hash of its code.
+    ///
+    /// This pins that exact bytecode: the reference never changes, even if the account
+    /// that originally deployed the code later deploys something else. Use it when you
+    /// want an immutable dependency.
     #[cfg_attr(feature = "serde", serde(rename = "hash"))]
     CodeHash(
         #[cfg_attr(feature = "serde", serde_as(as = "::serde_with::base58::Base58"))] CryptoHash,
     ) = 0,
+    /// Reference the contract by the account that deployed it globally.
+    ///
+    /// This follows whatever code that account currently has deployed as a global
+    /// contract, so the referenced code changes if the deployer upgrades it. Use it when
+    /// you want to track the deployer's latest version.
     #[cfg_attr(feature = "serde", serde(rename = "account_id"))]
     AccountId(AccountId) = 1,
 }

--- a/near-global-contracts/src/global_contract_identifier.rs
+++ b/near-global-contracts/src/global_contract_identifier.rs
@@ -9,6 +9,26 @@ pub enum AccountContract {
     Local(CryptoHash),
     Global(CryptoHash),
     GlobalByAccount(AccountId),
+/// What contract code an account currently runs.
+///
+/// An account either has its own copy of the code (`Local`) or points to shared
+/// [`GlobalContractId`] (`Global` / `GlobalByAccount`), letting many accounts run the
+/// same code without each storing it.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum AccountContract {
+    /// The account has no contract deployed and cannot be called.
+    None,
+    /// The code deployed directly to this account and stored in its own state, identified
+    /// by the code hash.
+    Local(CryptoHash),
+    /// A global contract referenced by code hash - pins exact bytecode.
+    /// Corresponds to [`GlobalContractId::CodeHash`]
+    Global(CryptoHash),
+    /// A global contract referenced by deployer account - follows that account's latest
+    /// globally deployed code.
+    /// Corresponds to [`GlobalContractId::AccountId`]
+    GlobalByAccount(AccountId),
 }
 
 /// Identifies which [global contract] an account should run.

--- a/near-global-contracts/src/lib.rs
+++ b/near-global-contracts/src/lib.rs
@@ -15,7 +15,7 @@
 //! ## Feature flags
 //!
 //! By default this crate exposes only the type definitions. To use
-//! [`StateInit::derive_account_id`] you must enable the `borsh` feature. The hashing
+//! `StateInit::derive_account_id` you must enable the `borsh` feature. The hashing
 //! backend is then selected automatically:
 //!
 //! - On-chain contract builds: set `--cfg near` (the `cargo-near` toolchain does this

--- a/near-global-contracts/src/state_init.rs
+++ b/near-global-contracts/src/state_init.rs
@@ -8,8 +8,8 @@ use serde_with::base64::Base64;
 ///
 /// A deterministic account ([NEP-616]) lives at an address computed from its own initial
 /// state instead of one chosen up front, so anyone who knows the state can work out the
-/// address ahead of time. This type is that state; pass it to
-/// [`StateInit::derive_account_id`] to get the resulting [`AccountId`].
+/// address ahead of time. This type is that state; enable the `borsh` feature and call
+/// `StateInit::derive_account_id` to get the resulting [`AccountId`].
 ///
 /// It is versioned so the layout can change later without breaking existing data.
 /// [`V1`](StateInit::V1) is the only version today.

--- a/near-global-contracts/src/state_init.rs
+++ b/near-global-contracts/src/state_init.rs
@@ -4,6 +4,19 @@ use std::collections::BTreeMap;
 #[cfg(feature = "serde")]
 use serde_with::base64::Base64;
 
+/// Initial on-chain state used to derive a [deterministic account].
+///
+/// A deterministic account ([NEP-616]) lives at an address computed from its own initial
+/// state instead of one chosen up front, so anyone who knows the state can work out the
+/// address ahead of time. This type is that state; pass it to
+/// [`StateInit::derive_account_id`] to get the resulting [`AccountId`].
+///
+/// It is versioned so the layout can change later without breaking existing data.
+/// [`V1`](StateInit::V1) is the only version today.
+///
+/// [deterministic account]: https://github.com/near/NEPs/pull/616
+/// [NEP-616]: https://github.com/near/NEPs/pull/616
+/// [`AccountId`]: near_account_id::AccountId
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -20,6 +33,7 @@ use serde_with::base64::Base64;
 #[cfg_attr(feature = "abi", derive(borsh::BorshSchema))]
 #[repr(u8)]
 pub enum StateInit {
+    /// Version 1: see [`StateInitV1`].
     V1(StateInitV1) = 0,
 }
 
@@ -74,6 +88,9 @@ impl StateInit {
     }
 }
 
+/// Version 1 of the [`StateInit`] payload.
+///
+/// Holds the global contract to run and the account's initial storage entries.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(
@@ -90,17 +107,24 @@ impl StateInit {
 )]
 #[cfg_attr(feature = "abi", derive(borsh::BorshSchema))]
 pub struct StateInitV1 {
+    /// The global contract whose code the derived account will run.
     pub code: GlobalContractId,
+    /// Key/value entries written to the account's trie storage at creation.
     #[cfg_attr(feature = "serde", serde_as(as = "BTreeMap<Base64, Base64>"))]
     pub data: BTreeMap<Vec<u8>, Vec<u8>>,
 }
 
 impl StateInitV1 {
+    /// Creates a payload that runs `code` with no initial storage.
+    ///
+    /// Chain [`with_data_entry`](Self::with_data_entry) to add storage entries.
     #[inline]
     pub fn code(code: impl Into<GlobalContractId>) -> Self {
         Self { code: code.into(), data: BTreeMap::new() }
     }
 
+    /// Adds one key/value entry to the initial storage, returning `self` so calls can be
+    /// chained.
     #[inline]
     pub fn with_data_entry(mut self, key: impl Into<Vec<u8>>, value: impl Into<Vec<u8>>) -> Self {
         self.data.insert(key.into(), value.into());

--- a/near-global-contracts/src/state_init.rs
+++ b/near-global-contracts/src/state_init.rs
@@ -4,15 +4,13 @@ use std::collections::BTreeMap;
 #[cfg(feature = "serde")]
 use serde_with::base64::Base64;
 
-/// Initial on-chain state used to derive a [deterministic account].
+/// Initial on-chain state used to derive a [deterministic account] ([NEP-616]).
 ///
-/// A deterministic account ([NEP-616]) lives at an address computed from its own initial
-/// state instead of one chosen up front, so anyone who knows the state can work out the
-/// address ahead of time. This type is that state; enable the `borsh` feature and call
-/// `StateInit::derive_account_id` to get the resulting [`AccountId`].
+/// A deterministic account lives at an address computed from its own initial state, so
+/// anyone who knows the state can work out the address ahead of time. Enable the `borsh`
+/// feature and call `StateInit::derive_account_id` to get the resulting [`AccountId`].
 ///
-/// It is versioned so the layout can change later without breaking existing data.
-/// [`V1`](StateInit::V1) is the only version today.
+/// Version so the layout can evolve; [`V1`](StateInit::V1) is the only version today.
 ///
 /// [deterministic account]: https://github.com/near/NEPs/pull/616
 /// [NEP-616]: https://github.com/near/NEPs/pull/616

--- a/near-global-contracts/src/state_init.rs
+++ b/near-global-contracts/src/state_init.rs
@@ -40,16 +40,14 @@ impl StateInit {
     ///
     /// # Availability
     ///
-    /// This method is only compiled when:
-    /// - the `borsh` feature is enabled (needed to serialize the input for hashing), AND
-    /// - one of the following is true:
-    ///   - `--cfg near` is set (on-chain contract build; `cargo-near` sets this automatically) —
-    ///     routes through the `keccak256` host function via the `near-sdk-env` crate.
-    ///   - the `digest` feature is enabled (off-chain or non-NEAR wasm build) — uses pure-Rust
-    ///     `sha3::Keccak256`.
+    /// This method requires the `borsh` feature (needed to serialize the input for hashing).
+    /// If you see "no method named `derive_account_id`" on a `StateInit`, enable `borsh` on
+    /// your `near-global-contracts` dependency.
     ///
-    /// If you see "no method named `derive_account_id`" on a `StateInit`, add the `digest`
-    /// feature to your `near-global-contracts` dependency.
+    /// The keccak256 backend is selected automatically: on-chain contract builds (`--cfg near`,
+    /// set automatically by `cargo-near`) route through the `keccak256` host function via the
+    /// `near-sdk-env` crate, while all other builds use pure-Rust `sha3::Keccak256`. Both
+    /// produce identical output.
     #[inline]
     #[cfg(feature = "borsh")]
     pub fn derive_account_id(&self) -> near_account_id::AccountId {


### PR DESCRIPTION
Adds rustdoc for the two public types that were missing it in `near-global-contracts`:

- `GlobalContractId` + both variants (`CodeHash` vs `AccountId`, i.e. reference by immutable code hash vs by deployer account).
- `StateInit` / `StateInitV1` (variant, `code`/`data` fields, and the `code`/`with_data_entry` constructors).

Docs-only, no behavior change. `cargo doc` builds clean with `-D warnings` (docs.rs feature set).