### PR TITLE
fix: disable near-vm-runner default features for unit-testing

### DIFF
--- a/near-sdk/Cargo.toml
+++ b/near-sdk/Cargo.toml
@@ -67,7 +67,7 @@ p256 = { version = "0.13.2", default-features = false, features = [
 near-abi = { version = "0.4.0", features = [
     "__chunked-entries",
 ], optional = true }
-near-vm-runner = { version = "0.37.0", optional = true }
+near-vm-runner = { version = "0.37.0", default-features = false, optional = true }
 near-primitives-core = { version = "0.37.0", optional = true }
 near-primitives = { version = "0.37.0", optional = true }
 near-crypto = { version = "0.37.0", default-features = false, optional = true }


### PR DESCRIPTION
### Why

`unit-testing` depends on `near-vm-runner` without `default-features = false`, so it inherits the default `wasmtime_vm` feature — dragging in the wasmtime/cranelift backend and, via `prepare → metrics → near-o11y`, the full OpenTelemetry OTLP stack. None of it is used at test time: the mock env only touches near-vm-runner's always-compiled `logic` layer, never real wasm.

### Fix

Disable default features on `near-vm-runner`. Drops **339 → 202 crates (−137)**: wasmtime/cranelift/winch, opentelemetry + tonic/prost/hyper/tokio, finite-wasm, prometheus. All lib unit tests still pass.
