### PR TITLE
ci: install cargo-audit as a prebuilt binary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -256,14 +256,10 @@ jobs:
           rustup toolchain install 1.93 --profile minimal
           rustup override set 1.93
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-provider: warpbuild
-          shared-key: "linux-audit"
-          cache-all-crates: true
-
       - name: Install Audit
-        run: cargo install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
 
       - name: Run Audit
         run: cargo audit


### PR DESCRIPTION
The Audit job broke repo-wide on fresh runs: `cargo install cargo-audit` now pulls `kstring@2.0.4`, which requires rustc 1.96.0 (runner has 1.93.1).

**Repro:** any Audit run since ~2026-07-21, e.g. [this one](https://github.com/near/near-sdk-rs/actions/runs/29856683810/job/88722649621).

**Fix:** install the prebuilt binary via `taiki-e/install-action` instead of compiling from source. Unlike `--locked` (which fixes this instance), skipping the source build removes the whole class of failure — no dependency resolution against the pinned toolchain at all — and makes the job faster.

Also drops the `rust-cache` step, which existed to cache the cargo-audit build. The 1.93 toolchain stays since `cargo audit` still invokes cargo to generate the lockfile.